### PR TITLE
Fix Codecov: switch to official GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - uses: actions/setup-go@v6
         with:
@@ -41,18 +41,12 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.go-version == 'stable'
-        run: |
-          PARENT_SHA=$(git rev-parse HEAD~1)
-          curl -Os https://cli.codecov.io/latest/linux/codecov
-          chmod +x codecov
-          ./codecov --verbose upload-process \
-            --fail-on-error \
-            -t ${{ secrets.CODECOV_TOKEN }} \
-            -n "ci-${{ github.run_id }}" \
-            -F unittests \
-            -f coverage.out \
-            --git-service github \
-            --parent-sha "$PARENT_SHA"
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.out
+          flags: unittests
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Codecov shows 'commit message unavailable' and no patch coverage on every commit. The manual CLI upload with `--parent-sha HEAD~1` breaks on merge commits because `HEAD~1` resolves to the wrong parent.

## Fix
Switch to `codecov/codecov-action@v5` which handles merge commit resolution, PR head detection, and base comparison automatically. Set `fetch-depth: 0` for full history.

## Test plan
- [x] CI should upload coverage successfully
- [x] Codecov should show patch coverage on this PR