### PR TITLE
Fix Ctrl+C not working after task completion

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -228,6 +228,18 @@ func (d *Daemon) Run(ctx context.Context) error {
 
 	var idleSpinner *output.Spinner
 	for {
+		// Check for context cancellation before each iteration.
+		// This catches signals that arrived during the previous
+		// RunOnce call or while the spinner was animating.
+		select {
+		case <-ctx.Done():
+			if idleSpinner != nil {
+				idleSpinner.Stop()
+			}
+			return nil
+		default:
+		}
+
 		result, err := d.RunOnce(ctx)
 		if err != nil {
 			if idleSpinner != nil {
@@ -347,6 +359,11 @@ func (d *Daemon) RunOnce(ctx context.Context) (IterationResult, error) {
 	})
 	if err != nil {
 		return IterationStop, werrors.Navigation(fmt.Errorf("navigation failed: %w", err))
+	}
+
+	// Check for shutdown after navigation (which reads multiple files).
+	if ctx.Err() != nil {
+		return IterationStop, nil
 	}
 
 	if !navResult.Found {


### PR DESCRIPTION
## Summary
Ctrl+C stops working after a successful task run. The signal arrives during
RunOnce's navigation phase (reading state files), which doesn't check for
context cancellation. The daemon completes navigation, returns IterationNoWork,
enters the idle select (which DOES check ctx.Done()), but by then the signal
has already been consumed and the context is cancelled.

## Fix
- Add `ctx.Done()` check at the top of the main loop before calling RunOnce
- Add `ctx.Err()` check after navigation in RunOnce

Both are non-blocking checks that catch signals missed by other code paths.

## Test plan
- [x] `go test -race ./internal/daemon/` passes
- [x] Manual test: start daemon, let it complete a task, Ctrl+C works