### PR TITLE
Delta audit: stale docs, coverage tests, audit checklist

### DIFF
--- a/cmd/daemon/daemon_test.go
+++ b/cmd/daemon/daemon_test.go
@@ -779,3 +779,145 @@ func TestLogCmd_AliasFollow(t *testing.T) {
 	env.RootCmd.SetArgs([]string{"follow", "--lines", "5"})
 	_ = env.RootCmd.Execute()
 }
+
+// ---------------------------------------------------------------------------
+// nodeGlyph
+// ---------------------------------------------------------------------------
+
+func TestNodeGlyph(t *testing.T) {
+	// In tests, output.IsTerminal() is false (piped), so we get plain glyphs.
+	tests := []struct {
+		status state.NodeStatus
+		want   string
+	}{
+		{state.StatusComplete, "●"},
+		{state.StatusInProgress, "◐"},
+		{state.StatusBlocked, "☢"},
+		{state.StatusNotStarted, "◯"},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			got := nodeGlyph(tt.status)
+			if got != tt.want {
+				t.Errorf("nodeGlyph(%s) = %q, want %q", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// taskGlyph
+// ---------------------------------------------------------------------------
+
+func TestTaskGlyph(t *testing.T) {
+	tests := []struct {
+		status state.NodeStatus
+		want   string
+	}{
+		{state.StatusComplete, "✓"},
+		{state.StatusInProgress, "→"},
+		{state.StatusBlocked, "✖"},
+		{state.StatusNotStarted, "○"},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			got := taskGlyph(tt.status)
+			if got != tt.want {
+				t.Errorf("taskGlyph(%s) = %q, want %q", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// printNodeTree
+// ---------------------------------------------------------------------------
+
+func TestPrintNodeTree(t *testing.T) {
+	env := newStatusTestEnv(t)
+
+	// Build a tree: one orchestrator ("orch") with two leaf children ("leaf-a", "leaf-b").
+	// Each leaf has tasks in various states.
+	idx := state.NewRootIndex()
+	idx.Root = []string{"orch"}
+	idx.Nodes["orch"] = state.IndexEntry{
+		Name:     "Orchestrator",
+		Type:     state.NodeOrchestrator,
+		State:    state.StatusInProgress,
+		Address:  "orch",
+		Children: []string{"leaf-a", "leaf-b"},
+	}
+	idx.Nodes["leaf-a"] = state.IndexEntry{
+		Name:    "Leaf A",
+		Type:    state.NodeLeaf,
+		State:   state.StatusComplete,
+		Address: "leaf-a",
+		Parent:  "orch",
+	}
+	idx.Nodes["leaf-b"] = state.IndexEntry{
+		Name:    "Leaf B",
+		Type:    state.NodeLeaf,
+		State:   state.StatusBlocked,
+		Address: "leaf-b",
+		Parent:  "orch",
+	}
+
+	// Create node state files for the leaves
+	leafADir := filepath.Join(env.ProjectsDir, "leaf-a")
+	_ = os.MkdirAll(leafADir, 0755)
+	nsA := state.NewNodeState("leaf-a", "Leaf A", state.NodeLeaf)
+	nsA.Tasks = []state.Task{
+		{ID: "task-0001", Title: "First task", State: state.StatusComplete},
+		{ID: "task-0002", Title: "Second task", State: state.StatusInProgress},
+	}
+	nsAData, _ := json.MarshalIndent(nsA, "", "  ")
+	_ = os.WriteFile(filepath.Join(leafADir, "state.json"), nsAData, 0644)
+
+	leafBDir := filepath.Join(env.ProjectsDir, "leaf-b")
+	_ = os.MkdirAll(leafBDir, 0755)
+	nsB := state.NewNodeState("leaf-b", "Leaf B", state.NodeLeaf)
+	nsB.Tasks = []state.Task{
+		{ID: "task-0003", Title: "Blocked task", State: state.StatusBlocked, BlockedReason: "waiting on API"},
+		{ID: "task-0004", Description: "Not started yet", State: state.StatusNotStarted},
+		{ID: "task-0005", Title: "Failing task", State: state.StatusInProgress, FailureCount: 3},
+	}
+	nsBData, _ := json.MarshalIndent(nsB, "", "  ")
+	_ = os.WriteFile(filepath.Join(leafBDir, "state.json"), nsBData, 0644)
+
+	// Build details map the same way showTreeStatus does
+	details := map[string]*nodeDetail{
+		"orch":   {entry: idx.Nodes["orch"]},
+		"leaf-a": {entry: idx.Nodes["leaf-a"], ns: nsA},
+		"leaf-b": {entry: idx.Nodes["leaf-b"], ns: nsB},
+	}
+
+	// Should not panic; exercises orchestrator recursion, leaf task rendering,
+	// blocked reason display, failure count display, and title/description fallback.
+	printNodeTree(env.App, idx, details, "orch", "  ")
+}
+
+func TestPrintNodeTree_MissingAddr(t *testing.T) {
+	env := newStatusTestEnv(t)
+	idx := state.NewRootIndex()
+	details := map[string]*nodeDetail{}
+
+	// Calling with an address not in details should return silently.
+	printNodeTree(env.App, idx, details, "nonexistent", "  ")
+}
+
+func TestPrintNodeTree_LeafWithNilNodeState(t *testing.T) {
+	env := newStatusTestEnv(t)
+	idx := state.NewRootIndex()
+	idx.Nodes["leaf"] = state.IndexEntry{
+		Name:    "Leaf",
+		Type:    state.NodeLeaf,
+		State:   state.StatusNotStarted,
+		Address: "leaf",
+	}
+	details := map[string]*nodeDetail{
+		"leaf": {entry: idx.Nodes["leaf"], ns: nil},
+	}
+
+	// Should not panic when ns is nil (no tasks to print).
+	printNodeTree(env.App, idx, details, "leaf", "  ")
+}

--- a/docs/agents/AUDIT.md
+++ b/docs/agents/AUDIT.md
@@ -130,7 +130,7 @@ Does the build pipeline catch problems?
 - [ ] CodeQL security scanning runs on main pushes, PRs, and weekly.
 - [ ] GoReleaser config matches `cmd/version.go` LDFLAGS (Version, Commit, Date).
 - [ ] Makefile targets work: `make build`, `make test`, `make lint`.
-- [ ] Pre-commit hook (`.githooks/pre-commit`) runs fmt, vet, build, lint.
+- [ ] Pre-commit hook (`.githooks/pre-commit`) runs gofmt only. CI handles vet, build, and lint via branch protection.
 - [ ] Integration and smoke tests run in CI with correct build tags.
 - [ ] Dependencies are minimal and current. `go mod tidy` produces no changes.
 

--- a/docs/humans/cli/start.md
+++ b/docs/humans/cli/start.md
@@ -44,6 +44,6 @@ Then the loop begins: [navigate](navigate.md) to the next task, run the [pipelin
 ## See Also
 
 - [`wolfcastle stop`](stop.md) to shut it down.
-- [`wolfcastle follow`](follow.md) to watch it work.
+- [`wolfcastle log`](follow.md) to watch it work (`follow` still works as an alias).
 - [`wolfcastle status`](status.md) to check progress.
 - [The Daemon](../how-it-works.md#the-daemon) for the full execution model.

--- a/docs/humans/cli/status.md
+++ b/docs/humans/cli/status.md
@@ -29,5 +29,5 @@ None. This command is strictly read-only.
 
 ## See Also
 
-- [`wolfcastle follow`](follow.md) to watch daemon output in real time.
+- [`wolfcastle log`](follow.md) to watch daemon output in real time (`follow` still works as an alias).
 - [The Project Tree](../how-it-works.md#the-project-tree) for how the tree is structured.

--- a/docs/humans/collaboration.md
+++ b/docs/humans/collaboration.md
@@ -73,7 +73,7 @@ Logs are NDJSON, one self-contained JSON record per line. Each daemon iteration 
 .wolfcastle/logs/0002-20260312T18-47Z.jsonl
 ```
 
-`wolfcastle follow` finds the latest file and tails it, watching for new files as iterations advance.
+`wolfcastle log` finds the latest file and tails it, watching for new files as iterations advance. (`follow` still works as an alias.)
 
 ```json
 {


### PR DESCRIPTION
## Summary
Post-session delta audit found 3 issues from today's changes.

- Update stale `wolfcastle follow` references to `wolfcastle log` in 3 doc files
- Add tests for `printNodeTree`, `nodeGlyph`, `taskGlyph` (0% → 54-85%)
- Update audit checklist: pre-commit is gofmt-only now

## Test plan
- [x] `go test -race ./...` passes (22/22)
- [x] cmd/daemon coverage: 66.6% → 73.4%
- [x] Total: 90.1% → 90.8%