### PR TITLE
Fix blocked propagation, unblock raw JSON, empty input exit

### DIFF
--- a/cmd/daemon/follow.go
+++ b/cmd/daemon/follow.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/dorkusprime/wolfcastle/cmd/cmdutil"
+	"github.com/dorkusprime/wolfcastle/internal/invoke"
 	"github.com/dorkusprime/wolfcastle/internal/logging"
 	"github.com/dorkusprime/wolfcastle/internal/output"
 	"github.com/spf13/cobra"
@@ -206,7 +206,7 @@ func formatAndPrintLogLine(line string, minLevel logging.Level) {
 		fmt.Printf("%s[%s] Error: %s\n", prefix, stage, errMsg)
 	case "assistant":
 		if text, ok := record["text"].(string); ok {
-			formatted := formatAssistantText(text)
+			formatted := invoke.FormatAssistantText(text)
 			if formatted != "" {
 				fmt.Println(formatted)
 			}
@@ -253,73 +253,6 @@ func formatAndPrintLogLine(line string, minLevel logging.Level) {
 			fmt.Printf("%s[%s]\n", prefix, typ)
 		}
 	}
-}
-
-// formatAssistantText extracts human-readable content from Claude Code's
-// streaming JSON output.
-func formatAssistantText(raw string) string {
-	var envelope struct {
-		Type    string `json:"type"`
-		Subtype string `json:"subtype"`
-		Message struct {
-			Content []struct {
-				Type  string `json:"type"`
-				Text  string `json:"text"`
-				Name  string `json:"name"`
-				Input any    `json:"input"`
-			} `json:"content"`
-		} `json:"message"`
-		Result string `json:"result"`
-	}
-	if err := json.Unmarshal([]byte(raw), &envelope); err != nil {
-		if len(raw) > 200 {
-			return raw[:200] + "..."
-		}
-		return raw
-	}
-
-	switch envelope.Type {
-	case "assistant":
-		var parts []string
-		for _, c := range envelope.Message.Content {
-			switch c.Type {
-			case "text":
-				if c.Text != "" {
-					parts = append(parts, c.Text)
-				}
-			case "tool_use":
-				if c.Name != "" {
-					if inputMap, ok := c.Input.(map[string]any); ok {
-						if desc, ok := inputMap["description"].(string); ok {
-							parts = append(parts, fmt.Sprintf("  → %s: %s", c.Name, desc))
-						} else if cmd, ok := inputMap["command"].(string); ok {
-							if len(cmd) > 80 {
-								cmd = cmd[:80] + "..."
-							}
-							parts = append(parts, fmt.Sprintf("  → %s: %s", c.Name, cmd))
-						} else {
-							parts = append(parts, fmt.Sprintf("  → %s", c.Name))
-						}
-					} else {
-						parts = append(parts, fmt.Sprintf("  → %s", c.Name))
-					}
-				}
-			}
-		}
-		if len(parts) > 0 {
-			return strings.Join(parts, "\n")
-		}
-	case "result":
-		if envelope.Result != "" {
-			return "[result] " + envelope.Result
-		}
-	case "system":
-		if envelope.Subtype == "init" {
-			return "[session started]"
-		}
-	}
-
-	return ""
 }
 
 // Simple offset tracking for tail -f behavior

--- a/cmd/daemon/follow_test.go
+++ b/cmd/daemon/follow_test.go
@@ -4,17 +4,18 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dorkusprime/wolfcastle/internal/invoke"
 	"github.com/dorkusprime/wolfcastle/internal/logging"
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// formatAssistantText
+// invoke.FormatAssistantText
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestFormatAssistantText_AssistantWithTextContent(t *testing.T) {
 	t.Parallel()
 	raw := `{"type":"assistant","message":{"content":[{"type":"text","text":"Hello from the model"}]}}`
-	got := formatAssistantText(raw)
+	got := invoke.FormatAssistantText(raw)
 	if got != "Hello from the model" {
 		t.Errorf("expected 'Hello from the model', got %q", got)
 	}
@@ -23,7 +24,7 @@ func TestFormatAssistantText_AssistantWithTextContent(t *testing.T) {
 func TestFormatAssistantText_AssistantWithMultipleTextBlocks(t *testing.T) {
 	t.Parallel()
 	raw := `{"type":"assistant","message":{"content":[{"type":"text","text":"First"},{"type":"text","text":"Second"}]}}`
-	got := formatAssistantText(raw)
+	got := invoke.FormatAssistantText(raw)
 	if !strings.Contains(got, "First") || !strings.Contains(got, "Second") {
 		t.Errorf("expected both text blocks, got %q", got)
 	}
@@ -35,7 +36,7 @@ func TestFormatAssistantText_AssistantWithMultipleTextBlocks(t *testing.T) {
 func TestFormatAssistantText_AssistantWithToolUse_Description(t *testing.T) {
 	t.Parallel()
 	raw := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"description":"list files"}}]}}`
-	got := formatAssistantText(raw)
+	got := invoke.FormatAssistantText(raw)
 	if !strings.Contains(got, "Bash") || !strings.Contains(got, "list files") {
 		t.Errorf("expected tool name and description, got %q", got)
 	}
@@ -44,7 +45,7 @@ func TestFormatAssistantText_AssistantWithToolUse_Description(t *testing.T) {
 func TestFormatAssistantText_AssistantWithToolUse_Command(t *testing.T) {
 	t.Parallel()
 	raw := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"ls -la"}}]}}`
-	got := formatAssistantText(raw)
+	got := invoke.FormatAssistantText(raw)
 	if !strings.Contains(got, "Bash") || !strings.Contains(got, "ls -la") {
 		t.Errorf("expected tool name and command, got %q", got)
 	}
@@ -54,7 +55,7 @@ func TestFormatAssistantText_AssistantWithToolUse_LongCommand(t *testing.T) {
 	t.Parallel()
 	longCmd := strings.Repeat("x", 100)
 	raw := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"` + longCmd + `"}}]}}`
-	got := formatAssistantText(raw)
+	got := invoke.FormatAssistantText(raw)
 	if !strings.HasSuffix(got, "...") {
 		t.Errorf("long command should be truncated with ..., got %q", got)
 	}
@@ -63,7 +64,7 @@ func TestFormatAssistantText_AssistantWithToolUse_LongCommand(t *testing.T) {
 func TestFormatAssistantText_AssistantWithToolUse_NoInputDetails(t *testing.T) {
 	t.Parallel()
 	raw := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"path":"/foo"}}]}}`
-	got := formatAssistantText(raw)
+	got := invoke.FormatAssistantText(raw)
 	if got != "  → Read" {
 		t.Errorf("expected bare tool name, got %q", got)
 	}
@@ -72,7 +73,7 @@ func TestFormatAssistantText_AssistantWithToolUse_NoInputDetails(t *testing.T) {
 func TestFormatAssistantText_AssistantWithToolUse_NonMapInput(t *testing.T) {
 	t.Parallel()
 	raw := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":"just a string"}]}}`
-	got := formatAssistantText(raw)
+	got := invoke.FormatAssistantText(raw)
 	if got != "  → Read" {
 		t.Errorf("expected bare tool name for non-map input, got %q", got)
 	}
@@ -81,7 +82,7 @@ func TestFormatAssistantText_AssistantWithToolUse_NonMapInput(t *testing.T) {
 func TestFormatAssistantText_AssistantEmptyContent(t *testing.T) {
 	t.Parallel()
 	raw := `{"type":"assistant","message":{"content":[]}}`
-	got := formatAssistantText(raw)
+	got := invoke.FormatAssistantText(raw)
 	if got != "" {
 		t.Errorf("expected empty string for empty content, got %q", got)
 	}
@@ -90,7 +91,7 @@ func TestFormatAssistantText_AssistantEmptyContent(t *testing.T) {
 func TestFormatAssistantText_AssistantEmptyTextBlock(t *testing.T) {
 	t.Parallel()
 	raw := `{"type":"assistant","message":{"content":[{"type":"text","text":""}]}}`
-	got := formatAssistantText(raw)
+	got := invoke.FormatAssistantText(raw)
 	if got != "" {
 		t.Errorf("expected empty string when text is empty, got %q", got)
 	}
@@ -99,7 +100,7 @@ func TestFormatAssistantText_AssistantEmptyTextBlock(t *testing.T) {
 func TestFormatAssistantText_ResultType(t *testing.T) {
 	t.Parallel()
 	raw := `{"type":"result","result":"Task completed successfully"}`
-	got := formatAssistantText(raw)
+	got := invoke.FormatAssistantText(raw)
 	if got != "[result] Task completed successfully" {
 		t.Errorf("expected '[result] Task completed successfully', got %q", got)
 	}
@@ -108,7 +109,7 @@ func TestFormatAssistantText_ResultType(t *testing.T) {
 func TestFormatAssistantText_ResultTypeEmpty(t *testing.T) {
 	t.Parallel()
 	raw := `{"type":"result","result":""}`
-	got := formatAssistantText(raw)
+	got := invoke.FormatAssistantText(raw)
 	if got != "" {
 		t.Errorf("expected empty for empty result, got %q", got)
 	}
@@ -117,7 +118,7 @@ func TestFormatAssistantText_ResultTypeEmpty(t *testing.T) {
 func TestFormatAssistantText_SystemInit(t *testing.T) {
 	t.Parallel()
 	raw := `{"type":"system","subtype":"init"}`
-	got := formatAssistantText(raw)
+	got := invoke.FormatAssistantText(raw)
 	if got != "[session started]" {
 		t.Errorf("expected '[session started]', got %q", got)
 	}
@@ -126,7 +127,7 @@ func TestFormatAssistantText_SystemInit(t *testing.T) {
 func TestFormatAssistantText_SystemNonInit(t *testing.T) {
 	t.Parallel()
 	raw := `{"type":"system","subtype":"something_else"}`
-	got := formatAssistantText(raw)
+	got := invoke.FormatAssistantText(raw)
 	if got != "" {
 		t.Errorf("expected empty for non-init system, got %q", got)
 	}
@@ -135,7 +136,7 @@ func TestFormatAssistantText_SystemNonInit(t *testing.T) {
 func TestFormatAssistantText_UnknownType(t *testing.T) {
 	t.Parallel()
 	raw := `{"type":"delta","data":"stuff"}`
-	got := formatAssistantText(raw)
+	got := invoke.FormatAssistantText(raw)
 	if got != "" {
 		t.Errorf("expected empty for unknown type, got %q", got)
 	}
@@ -143,7 +144,7 @@ func TestFormatAssistantText_UnknownType(t *testing.T) {
 
 func TestFormatAssistantText_NonJSON(t *testing.T) {
 	t.Parallel()
-	got := formatAssistantText("plain text output")
+	got := invoke.FormatAssistantText("plain text output")
 	if got != "plain text output" {
 		t.Errorf("expected plain text passthrough, got %q", got)
 	}
@@ -152,7 +153,7 @@ func TestFormatAssistantText_NonJSON(t *testing.T) {
 func TestFormatAssistantText_NonJSON_LongTruncated(t *testing.T) {
 	t.Parallel()
 	long := strings.Repeat("a", 250)
-	got := formatAssistantText(long)
+	got := invoke.FormatAssistantText(long)
 	if len(got) != 203 { // 200 + "..."
 		t.Errorf("expected truncated to 203 chars, got %d", len(got))
 	}
@@ -164,7 +165,7 @@ func TestFormatAssistantText_NonJSON_LongTruncated(t *testing.T) {
 func TestFormatAssistantText_NonJSON_ExactlyAtLimit(t *testing.T) {
 	t.Parallel()
 	exact := strings.Repeat("b", 200)
-	got := formatAssistantText(exact)
+	got := invoke.FormatAssistantText(exact)
 	if got != exact {
 		t.Errorf("string at exactly 200 chars should not be truncated")
 	}

--- a/cmd/unblock.go
+++ b/cmd/unblock.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -187,8 +188,13 @@ func runInteractiveUnblock(ctx context.Context, taskAddr string, diagnostic stri
 			return fmt.Errorf("model invocation failed: %w", invokeErr)
 		}
 
-		// Display model response
-		output.PrintHuman("%s", result.Stdout)
+		// Display model response, formatting each streaming JSON line
+		scanner := bufio.NewScanner(strings.NewReader(result.Stdout))
+		for scanner.Scan() {
+			if formatted := invoke.FormatAssistantText(scanner.Text()); formatted != "" {
+				output.PrintHuman("%s", formatted)
+			}
+		}
 		if result.Stderr != "" {
 			output.PrintError("%s", result.Stderr)
 		}
@@ -207,10 +213,13 @@ func runInteractiveUnblock(ctx context.Context, taskAddr string, diagnostic stri
 		}
 		input = strings.TrimSpace(input)
 
-		if input == "quit" || input == "exit" || input == "" {
+		if input == "quit" || input == "exit" {
 			output.PrintHuman("Session closed.")
 			output.PrintHuman("\nWhen ready: wolfcastle task unblock --node %s", taskAddr)
 			break
+		}
+		if input == "" {
+			continue
 		}
 
 		conversation += "\n\nUser: " + input + "\n\nAssistant: "

--- a/internal/invoke/format.go
+++ b/internal/invoke/format.go
@@ -1,0 +1,76 @@
+package invoke
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// FormatAssistantText extracts human-readable content from Claude Code's
+// streaming JSON output. Each line of raw model stdout may be a JSON
+// envelope (assistant, result, system) or plain text; this function
+// normalises both into something a human would want to read.
+func FormatAssistantText(raw string) string {
+	var envelope struct {
+		Type    string `json:"type"`
+		Subtype string `json:"subtype"`
+		Message struct {
+			Content []struct {
+				Type  string `json:"type"`
+				Text  string `json:"text"`
+				Name  string `json:"name"`
+				Input any    `json:"input"`
+			} `json:"content"`
+		} `json:"message"`
+		Result string `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(raw), &envelope); err != nil {
+		if len(raw) > 200 {
+			return raw[:200] + "..."
+		}
+		return raw
+	}
+
+	switch envelope.Type {
+	case "assistant":
+		var parts []string
+		for _, c := range envelope.Message.Content {
+			switch c.Type {
+			case "text":
+				if c.Text != "" {
+					parts = append(parts, c.Text)
+				}
+			case "tool_use":
+				if c.Name != "" {
+					if inputMap, ok := c.Input.(map[string]any); ok {
+						if desc, ok := inputMap["description"].(string); ok {
+							parts = append(parts, fmt.Sprintf("  → %s: %s", c.Name, desc))
+						} else if cmd, ok := inputMap["command"].(string); ok {
+							if len(cmd) > 80 {
+								cmd = cmd[:80] + "..."
+							}
+							parts = append(parts, fmt.Sprintf("  → %s: %s", c.Name, cmd))
+						} else {
+							parts = append(parts, fmt.Sprintf("  → %s", c.Name))
+						}
+					} else {
+						parts = append(parts, fmt.Sprintf("  → %s", c.Name))
+					}
+				}
+			}
+		}
+		if len(parts) > 0 {
+			return strings.Join(parts, "\n")
+		}
+	case "result":
+		if envelope.Result != "" {
+			return "[result] " + envelope.Result
+		}
+	case "system":
+		if envelope.Subtype == "init" {
+			return "[session started]"
+		}
+	}
+
+	return ""
+}

--- a/internal/state/mutations.go
+++ b/internal/state/mutations.go
@@ -75,16 +75,21 @@ func TaskComplete(ns *NodeState, taskID string) error {
 	}
 	t.State = StatusComplete
 
-	// Check if all tasks are complete
+	// Recompute node state: all complete, all-non-complete blocked, or in_progress
 	allComplete := true
+	allBlockedOrComplete := true
 	for _, task := range ns.Tasks {
 		if task.State != StatusComplete {
 			allComplete = false
-			break
+		}
+		if task.State != StatusComplete && task.State != StatusBlocked {
+			allBlockedOrComplete = false
 		}
 	}
 	if allComplete {
 		ns.State = StatusComplete
+	} else if allBlockedOrComplete {
+		ns.State = StatusBlocked
 	}
 	SyncAuditLifecycle(ns)
 	return nil

--- a/internal/state/mutations_test.go
+++ b/internal/state/mutations_test.go
@@ -161,6 +161,40 @@ func TestTaskComplete_DoesNotMarkNodeCompleteWithRemainingTasks(t *testing.T) {
 	}
 }
 
+func TestTaskComplete_BlocksNodeWhenRemainingTasksBlocked(t *testing.T) {
+	t.Parallel()
+	ns := newLeafWithTasks(
+		Task{ID: "task-0001", Description: "work", State: StatusInProgress},
+		Task{ID: "task-0002", Description: "more work", State: StatusComplete},
+		Task{ID: "audit", Description: "audit", State: StatusBlocked, IsAudit: true, BlockedReason: "open gaps"},
+	)
+	ns.State = StatusInProgress
+
+	if err := TaskComplete(ns, "task-0001"); err != nil {
+		t.Fatal(err)
+	}
+	if ns.State != StatusBlocked {
+		t.Errorf("node should be blocked when all non-complete tasks are blocked, got %s", ns.State)
+	}
+}
+
+func TestTaskComplete_StaysInProgressWithNotStartedTasks(t *testing.T) {
+	t.Parallel()
+	ns := newLeafWithTasks(
+		Task{ID: "task-0001", Description: "work", State: StatusInProgress},
+		Task{ID: "task-0002", Description: "next", State: StatusNotStarted},
+		Task{ID: "audit", Description: "audit", State: StatusBlocked, IsAudit: true},
+	)
+	ns.State = StatusInProgress
+
+	if err := TaskComplete(ns, "task-0001"); err != nil {
+		t.Fatal(err)
+	}
+	if ns.State != StatusInProgress {
+		t.Errorf("node should stay in_progress with not_started tasks remaining, got %s", ns.State)
+	}
+}
+
 func TestTaskBlock_TransitionsInProgressToBlocked(t *testing.T) {
 	t.Parallel()
 	ns := newLeafWithTasks(


### PR DESCRIPTION
## Summary
Three bugs from the backlog:

1. **Blocked propagation**: `TaskComplete` only checked if all tasks were complete. When completing a task left only blocked tasks remaining, the node stayed `in_progress` instead of becoming `blocked`. Parents never saw the block.

2. **Unblock dumps raw JSON**: `runInteractiveUnblock` printed `result.Stdout` verbatim, which is Claude Code's JSON streaming output. Now parses each line through `FormatAssistantText` (moved to `internal/invoke/format.go` for sharing).

3. **Empty input exits session**: Pressing Enter in the unblock session closed it. Now only quit/exit/Ctrl+D close the session.

## Test plan
- [x] `go test -race ./...` passes (22/22)
- [x] New tests for `TaskComplete` with blocked remaining tasks
- [x] Existing `FormatAssistantText` tests updated for new location