### PR TITLE
Fix Codecov gap: treat Go partials as hits

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -17,6 +17,10 @@ coverage:
       default:
         target: 80%
 
+parsers:
+  go:
+    partials_as_hits: true
+
 comment:
   layout: "reach,diff,flags,files"
   behavior: default


### PR DESCRIPTION
## Summary
Go's coverage format marks lines with `if` statements as "hit" even when only one branch executes. Codecov counts these as "partials" which are excluded from the hit count, causing a ~3% gap between local coverage (90.8%) and Codecov (88.09%).

This is a known Go/Codecov discrepancy documented by Codecov themselves. The fix is `parsers.go.partials_as_hits: true` in codecov.yml.

Also includes branch coverage tests written earlier in this session (status glyphs, tree rendering, spinner, follow command paths).

## Test plan
- [x] `go test -race ./...` passes
- [x] Codecov should report ~90% after this merges