### PR TITLE
Cover startBackground, add context to watchStatus/followLogs

### DIFF
--- a/cmd/daemon/daemon_test.go
+++ b/cmd/daemon/daemon_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -920,4 +921,216 @@ func TestPrintNodeTree_LeafWithNilNodeState(t *testing.T) {
 
 	// Should not panic when ns is nil (no tasks to print).
 	printNodeTree(env.App, idx, details, "leaf", "  ")
+}
+
+// ---------------------------------------------------------------------------
+// startBackground
+// ---------------------------------------------------------------------------
+
+func TestStartBackground_HappyPath(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	wolfDir := filepath.Join(dir, ".wolfcastle")
+	_ = os.MkdirAll(wolfDir, 0755)
+
+	// Use "sleep" as the child process; it starts and we release it.
+	err := startBackground(wolfDir, "", "", "sleep")
+	if err != nil {
+		t.Fatalf("startBackground failed: %v", err)
+	}
+
+	// PID file should exist
+	pidData, err := os.ReadFile(filepath.Join(wolfDir, "wolfcastle.pid"))
+	if err != nil {
+		t.Fatal("PID file should exist after startBackground")
+	}
+	if len(pidData) == 0 {
+		t.Error("PID file should not be empty")
+	}
+
+	// daemon.log should exist
+	if _, err := os.Stat(filepath.Join(wolfDir, "daemon.log")); err != nil {
+		t.Error("daemon.log should exist")
+	}
+}
+
+func TestStartBackground_WithNodeScope(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	wolfDir := filepath.Join(dir, ".wolfcastle")
+	_ = os.MkdirAll(wolfDir, 0755)
+
+	err := startBackground(wolfDir, "my-project", "", "sleep")
+	if err != nil {
+		t.Fatalf("startBackground with scope failed: %v", err)
+	}
+}
+
+func TestStartBackground_WithWorktree(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	wolfDir := filepath.Join(dir, ".wolfcastle")
+	_ = os.MkdirAll(wolfDir, 0755)
+
+	err := startBackground(wolfDir, "", "feature-branch", "sleep")
+	if err != nil {
+		t.Fatalf("startBackground with worktree failed: %v", err)
+	}
+}
+
+func TestStartBackground_BadExecutable(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	wolfDir := filepath.Join(dir, ".wolfcastle")
+	_ = os.MkdirAll(wolfDir, 0755)
+
+	err := startBackground(wolfDir, "", "", "/nonexistent/binary")
+	if err == nil {
+		t.Error("expected error for nonexistent executable")
+	}
+}
+
+func TestStartBackground_LogDirNotWritable(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skip in CI")
+	}
+	t.Parallel()
+	dir := t.TempDir()
+	wolfDir := filepath.Join(dir, ".wolfcastle")
+	_ = os.MkdirAll(wolfDir, 0755)
+
+	// Make wolfDir read-only so daemon.log creation fails
+	_ = os.Chmod(wolfDir, 0555)
+	defer func() { _ = os.Chmod(wolfDir, 0755) }()
+
+	err := startBackground(wolfDir, "", "", "sleep")
+	if err == nil {
+		t.Error("expected error when log dir is not writable")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// nodeGlyph and taskGlyph — all states
+// ---------------------------------------------------------------------------
+
+func TestNodeGlyph_AllStates(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		status state.NodeStatus
+		glyph  string
+	}{
+		{state.StatusComplete, "●"},
+		{state.StatusInProgress, "◐"},
+		{state.StatusBlocked, "☢"},
+		{state.StatusNotStarted, "◯"},
+		{"unknown_status", "◯"},
+	}
+	for _, tc := range cases {
+		result := nodeGlyph(tc.status)
+		if !strings.Contains(result, tc.glyph) {
+			t.Errorf("nodeGlyph(%s) = %q, expected to contain %q", tc.status, result, tc.glyph)
+		}
+	}
+}
+
+func TestTaskGlyph_AllStates(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		status state.NodeStatus
+		glyph  string
+	}{
+		{state.StatusComplete, "✓"},
+		{state.StatusInProgress, "→"},
+		{state.StatusBlocked, "✖"},
+		{state.StatusNotStarted, "○"},
+		{"unknown_status", "○"},
+	}
+	for _, tc := range cases {
+		result := taskGlyph(tc.status)
+		if !strings.Contains(result, tc.glyph) {
+			t.Errorf("taskGlyph(%s) = %q, expected to contain %q", tc.status, result, tc.glyph)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// watchStatus — runs one cycle then context cancels
+// ---------------------------------------------------------------------------
+
+func TestWatchStatus_SingleCycle(t *testing.T) {
+	t.Parallel()
+	env := newStatusTestEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- watchStatus(ctx, env.App, "", false, 0.1)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("watchStatus error: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("watchStatus did not exit after context cancellation")
+	}
+}
+
+func TestWatchStatus_WithScope(t *testing.T) {
+	t.Parallel()
+	env := newStatusTestEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- watchStatus(ctx, env.App, "my-project", false, 0.1)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("watchStatus with scope error: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("watchStatus did not exit")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// followLogs — context cancellation
+// ---------------------------------------------------------------------------
+
+func TestFollowLogs_NoLogs(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	err := followLogs(ctx, dir, 20, logging.LevelInfo)
+	if err != nil {
+		t.Fatalf("followLogs error: %v", err)
+	}
+}
+
+func TestFollowLogs_WithLogFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	// Create a log file
+	logLine := `{"level":"info","type":"stage_start","stage":"execute","timestamp":"2026-03-16T00:00:00Z"}` + "\n"
+	_ = os.WriteFile(filepath.Join(dir, "0001-20260316T00-00Z.jsonl"), []byte(logLine), 0644)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	err := followLogs(ctx, dir, 5, logging.LevelInfo)
+	if err != nil {
+		t.Fatalf("followLogs error: %v", err)
+	}
 }

--- a/cmd/daemon/follow.go
+++ b/cmd/daemon/follow.go
@@ -2,10 +2,13 @@ package daemon
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	"github.com/dorkusprime/wolfcastle/cmd/cmdutil"
@@ -46,7 +49,9 @@ Examples:
 			if !follow {
 				return showRecentLogs(logDir, lines, minLevel)
 			}
-			return followLogs(logDir, lines, minLevel)
+			ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+			defer stop()
+			return followLogs(ctx, logDir, lines, minLevel)
 		},
 	}
 }
@@ -65,19 +70,30 @@ func showRecentLogs(logDir string, lines int, minLevel logging.Level) error {
 }
 
 // followLogs streams log output in real time, following new iterations.
-func followLogs(logDir string, lines int, minLevel logging.Level) error {
+// Returns when context is cancelled.
+func followLogs(ctx context.Context, logDir string, lines int, minLevel logging.Level) error {
 	var currentFile string
 	historicalShown := false
 	waitMessageShown := false
 
 	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
 		latestPath, err := logging.LatestLogFile(logDir)
 		if err != nil {
 			if !waitMessageShown {
 				output.PrintHuman("Waiting for the daemon to produce output...")
 				waitMessageShown = true
 			}
-			time.Sleep(2 * time.Second)
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(2 * time.Second):
+			}
 			continue
 		}
 
@@ -97,7 +113,12 @@ func followLogs(logDir string, lines int, minLevel logging.Level) error {
 		if err := tailFileStreaming(currentFile, minLevel); err != nil {
 			return err
 		}
-		time.Sleep(500 * time.Millisecond)
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(500 * time.Millisecond):
+		}
 	}
 }
 

--- a/cmd/daemon/start.go
+++ b/cmd/daemon/start.go
@@ -96,7 +96,7 @@ Examples:
 			}
 
 			if background {
-				return startBackground(app.WolfcastleDir, nodeScope, worktreeBranch)
+				return startBackground(app.WolfcastleDir, nodeScope, worktreeBranch, "")
 			}
 
 			d, err := daemon.New(app.Cfg, app.WolfcastleDir, app.Resolver, nodeScope, repoDir)
@@ -115,11 +115,15 @@ Examples:
 	}
 }
 
-func startBackground(wolfcastleDir, nodeScope, worktreeBranch string) error {
-	// Re-exec ourselves with the same flags but without -d
-	execPath, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("finding executable: %w", err)
+// startBackground launches the daemon as a detached background process.
+// executablePath is the binary to re-exec; pass "" to use os.Executable().
+func startBackground(wolfcastleDir, nodeScope, worktreeBranch, executablePath string) error {
+	if executablePath == "" {
+		var err error
+		executablePath, err = os.Executable()
+		if err != nil {
+			return fmt.Errorf("finding executable: %w", err)
+		}
 	}
 
 	cmdArgs := []string{"start"}
@@ -130,7 +134,7 @@ func startBackground(wolfcastleDir, nodeScope, worktreeBranch string) error {
 		cmdArgs = append(cmdArgs, "--worktree", worktreeBranch)
 	}
 
-	proc := exec.Command(execPath, cmdArgs...)
+	proc := exec.Command(executablePath, cmdArgs...)
 	proc.Stdin = nil
 	proc.Dir = filepath.Dir(wolfcastleDir)
 
@@ -145,6 +149,7 @@ func startBackground(wolfcastleDir, nodeScope, worktreeBranch string) error {
 	proc.Stderr = logFile
 
 	if err := proc.Start(); err != nil {
+		_ = logFile.Close()
 		return fmt.Errorf("starting background process: %w", err)
 	}
 
@@ -155,7 +160,7 @@ func startBackground(wolfcastleDir, nodeScope, worktreeBranch string) error {
 	}
 
 	output.PrintHuman("Daemon deployed (PID %d)", proc.Process.Pid)
-	output.PrintHuman("  wolfcastle follow    Watch the operation")
+	output.PrintHuman("  wolfcastle log -f    Watch the operation")
 	output.PrintHuman("  wolfcastle stop      Stand down")
 
 	// Detach

--- a/cmd/daemon/status.go
+++ b/cmd/daemon/status.go
@@ -1,8 +1,10 @@
 package daemon
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -44,7 +46,9 @@ Examples:
 			}
 
 			if watch {
-				return watchStatus(app, scopeNode, showAll, interval)
+				ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+				defer stop()
+				return watchStatus(ctx, app, scopeNode, showAll, interval)
 			}
 
 			if showAll {
@@ -379,15 +383,15 @@ func showAllStatus(app *cmdutil.App) error {
 }
 
 // watchStatus refreshes the status display on an interval, clearing the
-// screen between refreshes. Ctrl+C to stop.
-func watchStatus(app *cmdutil.App, scope string, showAll bool, intervalSec float64) error {
+// screen between refreshes. Returns when context is cancelled.
+func watchStatus(ctx context.Context, app *cmdutil.App, scope string, showAll bool, intervalSec float64) error {
 	if intervalSec < 0.1 {
 		intervalSec = 0.1
 	}
 	d := time.Duration(intervalSec * float64(time.Second))
 	for {
 		// Clear screen and move cursor to top-left
-		fmt.Print("\033[2J\033[H")
+		_, _ = fmt.Fprint(os.Stdout, "\033[2J\033[H")
 
 		if showAll {
 			if err := showAllStatus(app); err != nil {
@@ -404,7 +408,11 @@ func watchStatus(app *cmdutil.App, scope string, showAll bool, intervalSec float
 			}
 		}
 
-		time.Sleep(d)
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(d):
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
Three previously-untestable functions made testable and tested.

**Bug fixes:**
- `watchStatus` and `followLogs` looped forever with no cancellation. Now accept context, exit cleanly on Ctrl+C.
- `startBackground` output said "wolfcastle follow" (stale), now says "wolfcastle log -f"

**Coverage:**
- `startBackground`: 0% → 83.3%
- `followLogs`: 0% → 84.6%
- `watchStatus`: 0% → 66.7%
- cmd/daemon package: 66.6% → 81.7%
- Total: 91.0%

## Test plan
- [x] `go test -race ./...` passes (22/22)