### PR TITLE
Fix blocked state not propagating when model blocks then completes

### DIFF
--- a/internal/daemon/iteration.go
+++ b/internal/daemon/iteration.go
@@ -190,14 +190,15 @@ func (d *Daemon) runIteration(ctx context.Context, nav *state.NavigationResult, 
 				return state.TaskComplete(ns, nav.TaskID)
 			}); err != nil {
 				_ = d.Logger.Log(map[string]any{"type": "complete_error", "task": nav.TaskID, "error": err.Error()})
-			} else {
-				// Re-read for propagation
-				if updated, readErr := d.Store.ReadNode(nav.NodeAddress); readErr == nil {
-					ns = updated
-				}
-				if err := d.propagateState(nav.NodeAddress, ns.State, idx); err != nil {
-					_ = d.Logger.Log(map[string]any{"type": "propagate_error", "error": err.Error()})
-				}
+			}
+			// Always propagate after COMPLETE, even if TaskComplete failed.
+			// The model may have blocked the task via CLI during execution,
+			// leaving the node in a blocked state that needs propagation.
+			if updated, readErr := d.Store.ReadNode(nav.NodeAddress); readErr == nil {
+				ns = updated
+			}
+			if err := d.propagateState(nav.NodeAddress, ns.State, idx); err != nil {
+				_ = d.Logger.Log(map[string]any{"type": "propagate_error", "error": err.Error()})
 			}
 			return nil
 		}


### PR DESCRIPTION
## Summary
When the audit model blocks its own task via `wolfcastle task block` during
execution, then emits WOLFCASTLE_COMPLETE, the daemon's `TaskComplete` call
fails (task is blocked). Propagation was in the `else` branch, so it was
skipped. The node stayed `in_progress` in the root index despite being
`blocked` on disk.

## Fix
Move propagation outside the if/else to run unconditionally after any
WOLFCASTLE_COMPLETE marker, regardless of whether TaskComplete succeeded.

## Test plan
- [x] `go test -race ./...` passes (22/22)
- [x] Verified against /tmp/wolfcastle_test/run-015-wild scenario