### PR TITLE
Add --body to spec create, reinforce ADRs, audit file locations

### DIFF
--- a/cmd/spec.go
+++ b/cmd/spec.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -44,6 +45,8 @@ Examples:
 			return fmt.Errorf("spec title cannot be empty. Name it")
 		}
 		nodeAddr, _ := cmd.Flags().GetString("node")
+		body, _ := cmd.Flags().GetString("body")
+		useStdin, _ := cmd.Flags().GetBool("stdin")
 
 		if nodeAddr != "" {
 			if err := app.RequireResolver(); err != nil {
@@ -62,7 +65,18 @@ Examples:
 		}
 		specPath := filepath.Join(docsDir, filename)
 
-		content := fmt.Sprintf("# %s\n\n[Spec content goes here.]\n", title)
+		var content string
+		if useStdin {
+			data, readErr := io.ReadAll(os.Stdin)
+			if readErr != nil {
+				return fmt.Errorf("reading stdin: %w", readErr)
+			}
+			content = fmt.Sprintf("# %s\n\n%s\n", title, strings.TrimSpace(string(data)))
+		} else if body != "" {
+			content = fmt.Sprintf("# %s\n\n%s\n", title, body)
+		} else {
+			content = fmt.Sprintf("# %s\n\n[Spec content goes here.]\n", title)
+		}
 		if err := os.WriteFile(specPath, []byte(content), 0644); err != nil {
 			return fmt.Errorf("writing spec file: %w", err)
 		}
@@ -243,6 +257,8 @@ Examples:
 
 func init() {
 	specCreateCmd.Flags().String("node", "", "Link spec to this node")
+	specCreateCmd.Flags().String("body", "", "Spec body content")
+	specCreateCmd.Flags().Bool("stdin", false, "Read spec body from stdin")
 	specLinkCmd.Flags().String("node", "", "Target node address (required)")
 	_ = specLinkCmd.MarkFlagRequired("node")
 	specListCmd.Flags().String("node", "", "Filter specs by linked node")

--- a/internal/invoke/terminal_unix.go
+++ b/internal/invoke/terminal_unix.go
@@ -3,20 +3,18 @@
 package invoke
 
 import (
-	"fmt"
 	"os"
 	"syscall"
 	"unsafe"
 )
 
 // RestoreTerminal forces the terminal back to cooked mode with signal
-// generation enabled. Claude Code leaves the terminal in raw mode
+// generation enabled. Child processes may leave the terminal in raw mode
 // (ISIG off) after exiting, which causes Ctrl+C to print ^C instead
 // of delivering SIGINT.
 func RestoreTerminal() {
 	fd := os.Stdin.Fd()
 
-	// Get current termios
 	var termios syscall.Termios
 	if _, _, errno := syscall.Syscall6(
 		syscall.SYS_IOCTL,
@@ -25,27 +23,16 @@ func RestoreTerminal() {
 		uintptr(unsafe.Pointer(&termios)),
 		0, 0, 0,
 	); errno != 0 {
-		fmt.Fprintf(os.Stderr, "  [terminal restore: not a terminal (errno=%d)]\n", errno)
 		return
 	}
 
-	hadISIG := termios.Lflag&syscall.ISIG != 0
-
-	// Ensure ISIG (Ctrl+C → SIGINT), ICANON (line buffering),
-	// and ECHO are enabled.
 	termios.Lflag |= syscall.ISIG | syscall.ICANON | syscall.ECHO
 
-	if _, _, errno := syscall.Syscall6(
+	_, _, _ = syscall.Syscall6(
 		syscall.SYS_IOCTL,
 		fd,
 		ioctlWriteTermios,
 		uintptr(unsafe.Pointer(&termios)),
 		0, 0, 0,
-	); errno != 0 {
-		fmt.Fprintf(os.Stderr, "  [terminal restore: write failed (errno=%d)]\n", errno)
-	} else if !hadISIG {
-		fmt.Fprintf(os.Stderr, "  [terminal restored: ISIG was off, now on]\n")
-	} else {
-		fmt.Fprintf(os.Stderr, "  [terminal restore: ISIG was already on]\n")
-	}
+	)
 }

--- a/internal/project/templates/audits/audit-task.md
+++ b/internal/project/templates/audits/audit-task.md
@@ -5,7 +5,11 @@ Verify all work in this node is complete and correct.
 ## Checklist
 
 - [ ] All tasks marked complete actually did what they claimed
+- [ ] Deliverables exist and contain meaningful content
 - [ ] No files were left in a broken state
 - [ ] Any validation commands pass
 - [ ] Breadcrumbs describe what was done and why
 - [ ] No gaps remain open
+- [ ] Specs are in `.wolfcastle/docs/specs/` (not `docs/` or other locations). If a spec is in the wrong place, move it: create it via `wolfcastle spec create --body "content" --node <node>` and delete the misplaced file.
+- [ ] Technology choices have ADRs in `.wolfcastle/docs/decisions/`. If a framework, library, or architecture was chosen without an ADR, create one via `wolfcastle adr create --stdin "Decision Title"`.
+- [ ] Research documents are in `.wolfcastle/artifacts/` (not `docs/`). If research is in the wrong place, move it to `.wolfcastle/artifacts/` and update the deliverable path.

--- a/internal/project/templates/prompts/execute.md
+++ b/internal/project/templates/prompts/execute.md
@@ -53,16 +53,45 @@ wolfcastle audit scope --node <your-node> --description "what this node audits"
 
 ### F. Document decisions and specs
 
-When you make an architectural decision (choosing a framework, designing a data model, selecting an approach over alternatives), record it as an ADR:
-```
-wolfcastle adr create "Decision Title"
-```
-This creates a properly named file in `.wolfcastle/docs/decisions/`. Write the ADR body explaining context, options considered, and the decision.
+**ADRs are mandatory when you make a technology choice.** If you choose a framework, language, library, architecture pattern, or reject an alternative, record it. No exceptions.
 
-When you produce a design document or specification, create it through the CLI:
 ```
-wolfcastle spec create "Spec Title" --node <your-node>
+wolfcastle adr create --stdin "Use Sinatra for the web backend" <<'EOF'
+## Status
+Accepted
+
+## Context
+The project needs a lightweight web framework for a small bookmark API.
+
+## Options Considered
+1. **Sinatra**: minimal, well-documented, fits the scope
+2. **Rails**: too heavy for two endpoints
+3. **Roda**: less community support
+
+## Decision
+Sinatra. The scope is small, the API surface is two endpoints, and Sinatra's routing DSL maps directly to the requirements.
+
+## Consequences
+No ORM included by default. Database access will use raw SQL or a lightweight gem.
+EOF
 ```
+
+Every ADR needs: Status, Context, Options Considered, Decision, Consequences. Fill in real content, not placeholders.
+
+**Specs go through the CLI**, not as files in `docs/`:
+
+```
+wolfcastle spec create "API Design" --node <your-node> --body "## Overview
+The API exposes two endpoints: GET /bookmarks (list all) and POST /bookmarks (create).
+
+## Data Model
+Bookmark: id, url, title, created_at
+
+## Endpoints
+GET /bookmarks → 200 JSON array
+POST /bookmarks → 201 JSON object"
+```
+
 This creates a properly named file in `.wolfcastle/docs/specs/` and links it to the node. Never write specs directly to `docs/` or other locations.
 
 Skip this phase if your task is pure implementation with no design choices.


### PR DESCRIPTION
## Summary
Models write specs to `docs/` instead of using `wolfcastle spec create`.
No ADRs created for technology choices. Audit doesn't catch either.

## Fixes
- `spec create --body "content"` for easy inline content
- `spec create --stdin` for piped content
- Execute prompt: ADRs mandatory for technology choices, concrete examples
- Audit checklist: verify file locations, record gaps for misplaced artifacts
- Remove debug terminal restore logging

## Test plan
- [x] `go test -race ./...` passes (22/22)