### PR TITLE
Fix eval blockers: PID cleanup, CHANGELOG, path traversal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ dist/
 coverage.out
 *.coverprofile
 *.test
-.claude
+.claude/
+.wolfcastle/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+## 0.1.0 (unreleased)
+
+Initial release.
+
+### Core
+- Model-agnostic autonomous coding orchestrator
+- Four-state lifecycle (not_started, in_progress, complete, blocked) with upward propagation
+- StateStore with lock-protected atomic mutations and auto-propagation
+- Two-goroutine daemon: execute loop + inbox watcher (fsnotify with polling fallback)
+- Supervisor with crash recovery and configurable restarts
+- Self-healing on startup (detects interrupted tasks)
+- Discovery-first intake pipeline with pre-blocking for infeasible work
+
+### CLI
+- 38 commands across lifecycle, work management, auditing, documentation, diagnostics
+- Tree view status with colored glyphs and --watch mode
+- Log command with --follow streaming and level filtering
+- Interactive unblock sessions with readline support
+- Doctor with 24 validation categories and multi-pass deterministic fixing
+- JSON output envelope on every command
+
+### Pipeline
+- Three-tier config (base, custom, local) with deep merge and null deletion
+- Prompt assembly: rule fragments, filtered script reference, stage prompt, iteration context
+- Deliverable verification with SHA-256 baseline change detection
+- Terminal markers (COMPLETE, YIELD, BLOCKED) with priority-ordered scanning
+
+### Safety
+- Atomic writes (temp file + fsync + rename) for all state files
+- File locking with stale lock detection
+- Terminal restoration after child process exit (ISIG/ICANON/ECHO)
+- Three-layer signal handling (NotifyContext + backup channel + spinner timeout)
+- Deliverable path traversal validation
+- Address validation prevents path traversal in node names
+
+### Documentation
+- 76 Architecture Decision Records
+- 17 implemented specs, 3 draft specs (TUI, worktree, task classes)
+- Human-facing docs for every command
+- Agent-facing guides for code modification
+- CONTRIBUTING.md, CODE_OF_CONDUCT.md, issue templates

--- a/cmd/cmdutil/app_test.go
+++ b/cmd/cmdutil/app_test.go
@@ -545,6 +545,12 @@ func TestCheckOverlap_FindsMatch(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestCompleteNodeAddresses_NilResolver(t *testing.T) {
+	// Run from a temp dir to avoid picking up .wolfcastle/ from the repo
+	tmp := t.TempDir()
+	origDir, _ := os.Getwd()
+	_ = os.Chdir(tmp)
+	defer func() { _ = os.Chdir(origDir) }()
+
 	a := &App{}
 	fn := CompleteNodeAddresses(a)
 	addrs, directive := fn(nil, nil, "")
@@ -557,6 +563,11 @@ func TestCompleteNodeAddresses_NilResolver(t *testing.T) {
 }
 
 func TestCompleteTaskAddresses_NilResolver(t *testing.T) {
+	tmp := t.TempDir()
+	origDir, _ := os.Getwd()
+	_ = os.Chdir(tmp)
+	defer func() { _ = os.Chdir(origDir) }()
+
 	a := &App{}
 	fn := CompleteTaskAddresses(a)
 	addrs, directive := fn(nil, nil, "")

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -209,14 +209,15 @@ func (d *Daemon) Run(ctx context.Context) error {
 				if !ok {
 					return
 				}
-				output.PrintHuman("\n=== Signal received. Standing down. ===")
+				output.PrintHuman("\n=== Wolfcastle standing down (signal) ===")
 				cancel()
 				d.shutdownOnce.Do(func() { close(d.shutdown) })
 				// Force exit after a grace period in case the main loop
-				// is stuck (e.g., spinner Stop() blocking).
+				// is stuck (e.g., spinner Stop() blocking). Clean up PID
+				// file before exiting to prevent stale PID on next start.
 				go func() {
 					time.Sleep(2 * time.Second)
-					output.PrintHuman("=== Forced shutdown ===")
+					_ = os.Remove(filepath.Join(d.WolfcastleDir, "wolfcastle.pid"))
 					os.Exit(0)
 				}()
 				return

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -196,7 +196,7 @@ func (s *StateStore) nodePath(addr string) (string, error) {
 	}
 	parts := strings.Split(addr, "/")
 	for _, p := range parts {
-		if p == "" || strings.ContainsAny(p, " \t\n") {
+		if p == "" || p == "." || p == ".." || strings.ContainsAny(p, " \t\n") {
 			return "", fmt.Errorf("invalid address segment %q in %q", p, addr)
 		}
 	}


### PR DESCRIPTION
## Summary
Addresses blockers and warnings from the second evaluation report.

- PID file removed before forced os.Exit(0) shutdown
- CHANGELOG.md for v0.1.0
- Reject . and .. in StateStore.nodePath (path traversal)
- Fix test isolation for completion tests
- Fix .gitignore concatenation

## Test plan
- [x] `go test -race ./...` passes (22/22)