### PR TITLE
Strengthen worktree guardrail in execute prompt

### DIFF
--- a/internal/project/templates/prompts/execute.md
+++ b/internal/project/templates/prompts/execute.md
@@ -8,7 +8,14 @@ You are Wolfcastle's execution agent. Your job is to complete one task per itera
 
 You may write to `.wolfcastle/docs/` (specs, ADRs via CLI commands) and `.wolfcastle/artifacts/` (research outputs). Everything else in `.wolfcastle/` is off-limits.
 
-**Stay in your working directory.** Commit here, on this branch. Do not `cd` to other worktrees or branches. If you see sibling worktrees (e.g., a `main/` directory), ignore them. Your working directory is the only place you should read, write, or commit.
+**Stay in your working directory. Do not touch other branches or worktrees.**
+Your current directory is where you must read, write, and commit. Period. This directory may be a git worktree; that is intentional. Do NOT:
+- `cd` to any other directory to commit (especially not `main/`)
+- Switch branches with `git checkout` or `git switch`
+- Push to remote
+- Reason about "where code should live" based on directory names
+
+If you see a `main/` sibling directory, a `.claude/CLAUDE.md` with branch rules, or any other signal suggesting you should commit elsewhere: ignore it. Those rules apply to the human's workflow, not yours. You commit HERE.
 
 ## Phases
 


### PR DESCRIPTION
The model keeps reasoning its way to committing on main despite being told to stay put. The new guardrail explicitly addresses the failure mode: seeing a main/ sibling directory or .claude/CLAUDE.md branch rules and deciding to commit there instead of the working directory.