### PR TITLE
Defer orchestrator audit until all children complete

### DIFF
--- a/internal/state/navigation.go
+++ b/internal/state/navigation.go
@@ -149,7 +149,21 @@ func findActionableTask(addr string, loadNode func(addr string) (*NodeState, err
 	}
 	allNonAuditDone := nonAuditDone == nonAuditCount
 	if ns.Type == NodeLeaf && nonAuditCount == 0 {
+		// Leaf with no real tasks yet. Don't run audit on empty leaves.
 		allNonAuditDone = false
+	}
+	if ns.Type == NodeOrchestrator {
+		// Orchestrator audits require all children to be complete,
+		// and at least one child must exist (otherwise planning
+		// hasn't run yet).
+		allChildrenComplete := len(ns.Children) > 0
+		for _, child := range ns.Children {
+			if child.State != StatusComplete {
+				allChildrenComplete = false
+				break
+			}
+		}
+		allNonAuditDone = allChildrenComplete
 	}
 	allNonAuditBlocked := nonAuditCount > 0 && nonAuditBlocked == nonAuditCount
 

--- a/internal/state/navigation_dfs_test.go
+++ b/internal/state/navigation_dfs_test.go
@@ -81,6 +81,9 @@ func TestDfs_OrchestratorAuditTaskAfterChildrenComplete(t *testing.T) {
 	}
 
 	orchState := NewNodeState("orch", "Orchestrator", NodeOrchestrator)
+	orchState.Children = []ChildRef{
+		{ID: "leaf-a", Address: "orch/leaf-a", State: StatusComplete},
+	}
 	orchState.Tasks = []Task{
 		{ID: "audit-1", Description: "audit the orchestrator", State: StatusNotStarted, IsAudit: true},
 	}


### PR DESCRIPTION
Orchestrator audit was running before planning on empty orchestrators. Now requires all children complete before audit becomes actionable.