### PR TITLE
Groom backlog: 20 items completed, duplicates removed

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -6,57 +6,47 @@ Items accumulate here as they surface. Don't process unless directed.
 
 These shape how Wolfcastle plans, executes, and learns from its work.
 
-- **Planning pipeline doesn't populate task References.** Tasks created by the planner have bodies but no References linking back to the originating spec. The executor has to discover the spec by searching. The planner should set References on every task. When no spec exists, the planner should create a spec-writing discovery task first.
-
-- **Spec stubs pass through the pipeline.** During the domains eval, 5 of 7 spec files contained only `[Spec content goes here.]`. The audit model created placeholder files to satisfy its own "spec exists" check. The PromptRepository audit caught and fixed its own stub, but earlier audits didn't. The planning prompt should require populated specs as deliverables, not just file creation.
-
-- **Spec review pipeline.** Specs currently go from draft to implementation with no structured review. The domain repository spec needed 4 revision passes to reach quality (internal audit, external audit, existential review). Wolfcastle should have a review stage: after a spec is created, a separate model audits it for logical gaps, missing method signatures, contradictions, and under-specified behavior before it drives implementation.
-
-- **Structured audit reports with PASS/REMEDIATE verdicts.** Audit tasks should produce a markdown report with a clear verdict. PASS is the expected outcome. REMEDIATE requires concrete, verifiable findings with file:line evidence. The daemon parses the verdict: PASS completes, REMEDIATE spawns tasks plus a re-audit. The template must make "no issues found" a first-class outcome to prevent hallucinated remediation.
-
-- **Audit quality beyond structural checks.** The current audit prompt only verifies files exist and are in the right place. It should also check error wrapping, doc comments on exports, test coverage, Go idiom, naming conventions, and dead code. The task-classes spec defines a `discipline-audit` class whose behavioral prompt should carry these criteria. Implement as part of task-classes, not separately.
+- **Spec review pipeline.** Specs go from draft to implementation with no structured review. The domain repository spec needed 4 revision passes to reach quality. Wolfcastle should have a review stage: after a spec is created, a separate model audits it for logical gaps, missing method signatures, contradictions, and under-specified behavior before it drives implementation.
 
 - **After Action Reviews per task.** Every task should produce an AAR following the standard template: objective, what happened, what went well, what can be improved, action items. The next task reads prior AARs for full context. Replaces terse breadcrumbs with actionable narrative. AARs accumulate in the leaf directory and become the audit's primary input.
 
-- **Eval framework using task commits as regression tests.** The domain repository runs produced both failures and successes. Roll back to the commit before a known-bad decision, apply a fix, replay the task, verify the fix prevents the original mistake. Regression testing for the AI pipeline itself.
+- **Eval framework using task commits as regression tests.** Roll back to the commit before a known-bad decision, apply a fix, replay the task, verify the fix prevents the original mistake. Regression testing for the AI pipeline itself. Multiple eval runs have produced ideal regression cases.
 
 ## Daemon Mechanics
 
 Operational improvements to the daemon's core loop and resilience.
 
-- **Stall detector for model invocations.** When the model produces no output for N seconds (e.g., 120s), kill the process and retry. The current 3600s invocation timeout is far too generous when the model has already committed its work and is hung on post-commit steps. Caught during eval when a claude process hung for 10+ minutes due to API instability.
+- **Stall detector for model invocations.** When the model produces no output for N seconds (e.g., 120s), kill the process and retry. The current 3600s invocation timeout is far too generous. Caught during eval when a claude process hung for 10+ minutes due to API instability.
 
-- **NeedsPlanning inference for re-planning triggers.** The daemon infers initial planning from structure (childless orchestrator), but re-planning (new scope, child blocked, completion review) still depends on explicitly setting a flag. Could be made structural: check whether pending scope exists, whether any child is blocked, or whether all children are complete, rather than relying on a flag set at the right time.
-
-- **CWD resolution for wolfcastle commands.** Commands should require `.wolfcastle/` in CWD and refuse to operate if it isn't there. No walking up the directory tree. Caught when `wolfcastle start` was accidentally run from `~/` with a stray `.wolfcastle/` and silently operated on the wrong project.
+- **CWD resolution for wolfcastle commands.** Commands should require `.wolfcastle/` in CWD and refuse to operate if it isn't there. No walking up the directory tree. Caught when `wolfcastle start` was accidentally run from `~/` with a stray `.wolfcastle/`.
 
 ## User Experience
 
 How the tool feels to use.
 
-- **`wolfcastle log` design pass.** The log command needs a full spec. Current issues: intake log (10001-*) sorts after execute logs, follow mode doesn't know which iteration is active, no stage filtering, no human-readable formatting. Design goals: multiple verbosity levels (daemon output, info, debug, raw NDJSON), `--follow` at all levels, unified log stream with stage tags, iteration addressing (`--iteration 24`), stage filtering (`--stage execute`).
+- **`wolfcastle log` design pass.** Current issues: intake log (10001-*) sorts after execute logs, follow mode doesn't know which iteration is active, no stage filtering, no human-readable formatting. Design goals: multiple verbosity levels, `--follow` at all levels, unified log stream with stage tags, iteration addressing, stage filtering.
 
 - **`wolfcastle status` detail.** Show task descriptions (not just titles), failure reasons from the last attempt, deliverable declarations, and breadcrumbs. A user watching the daemon should understand what's happening without reading raw logs.
 
-- **README files in every `.wolfcastle/` directory.** `system/` should explain the three-tier system. `system/base/prompts/` should explain how to override prompts. `docs/` should explain what goes there. These are the discoverability layer for humans browsing the directory.
+- **README files in every `.wolfcastle/` directory.** `system/` should explain the three-tier system. `system/base/prompts/` should explain how to override prompts. `docs/` should explain what goes there.
 
-- **Prompt subdirectories for human navigation.** The flat `system/base/prompts/` mixes stage prompts, class prompts, audit prompts, and templates. Better: `prompts/stages/`, `prompts/classes/`, `prompts/audits/`, `prompts/templates/`. Users should browse and understand what's available without reading source code.
+- **Prompt subdirectories for human navigation.** The flat `system/base/prompts/` mixes stage prompts, class prompts, audit prompts, and templates. Better: `prompts/stages/`, `prompts/classes/`, `prompts/audits/`, `prompts/templates/`.
 
-- **Fully user-configurable prompts via the tier system.** Prompts are currently embedded in the binary via go:embed and extracted at scaffold time. Users can override in custom/local but can't easily see the defaults. Make base/ prompts the authoritative reference. `init` populates, `init --force` regenerates.
+- **Fully user-configurable prompts via the tier system.** Prompts are embedded via go:embed and extracted at scaffold time. Users can override in custom/local but can't easily see the defaults. Make base/ prompts the authoritative reference. `init` populates, `init --force` regenerates.
 
 ## Code Quality
 
 Things that should be better in the implementation.
 
-- **Domain refactor: migrate remaining backward-compat callers.** 17 files still use `app.WolfcastleDir`, 9 use `app.Cfg`, 15 use `app.Store`. These need migration to repository methods before `tree.Resolver` can be deleted. Old code paths (`AssemblePrompt`, `project.Scaffold`) exist alongside new ones and will drift.
+- **Domain refactor: migrate remaining backward-compat callers.** 17 files still use `app.WolfcastleDir`, 9 use `app.Cfg`, 15 use `app.Store`. These need migration to repository methods before `tree.Resolver` can be deleted.
 
-- **ContextBuilder null-safety.** Docstring claims nil repositories degrade gracefully, but `findTask()` returns nil silently causing context truncation. Should error. Template re-parsing on every `Build()` call with no caching.
+- **ContextBuilder null-safety.** `findTask()` returns nil silently causing context truncation. Should error. Template re-parsing on every `Build()` call with no caching.
 
-- **git.CreateWorktree loses the first error.** When the primary `git worktree add -b` fails, the fallback runs without `-b`. If both fail, only the fallback error surfaces. The original (potentially more informative) error is discarded.
+- **git.CreateWorktree loses the first error.** When the primary `git worktree add -b` fails and the fallback also fails, only the fallback error surfaces.
 
-- **ScaffoldService.Reinit silently ignores migration errors.** Three `_ = migrator.Migrate...()` calls. If migration fails for a real reason (permissions, corruption), the operator never knows.
+- **ScaffoldService.Reinit silently ignores migration errors.** Three `_ = migrator.Migrate...()` calls. If migration fails for a real reason, the operator never knows.
 
-- **TTL-based caching in tierfs.** Short TTL (1-5s) for custom/local tiers (rapid-fire reads during a single iteration hit cache, human edits between iterations are fresh). Long/infinite TTL for base (only changes on rescaffold). All repositories benefit from the same caching layer.
+- **TTL-based caching in tierfs.** Short TTL for custom/local tiers, long/infinite for base. All repositories benefit from the same caching layer.
 
 ## Completed
 
@@ -72,27 +62,45 @@ Things that should be better in the implementation.
 - ~~Status detail for completed tasks~~ (summary shown)
 - ~~Stale ADR-070~~ (marked superseded)
 - ~~Stale daemon agent guide~~ (updated for new patterns)
-- ~~Audit progress check~~ (skip for IsAudit tasks, PR #35)
-- ~~Markdown terminal markers~~ (strip formatting before matching, PR #35)
-- ~~Work-already-done concept~~ (WOLFCASTLE_SKIP marker, PR #35)
+- ~~Audit progress check~~ (skip for IsAudit, PR #35)
+- ~~Markdown terminal markers~~ (strip formatting, PR #35)
+- ~~Work-already-done concept~~ (WOLFCASTLE_SKIP, PR #35)
 - ~~YIELD + self-decomposition~~ (block parent, auto-complete, PR #35)
 - ~~Deliverable missing = failure loop~~ (downgraded to warning, PR #35)
-- ~~Deliverable path validation~~ (warns and suggests at declaration, PR #35)
-- ~~Failure context in retry prompt~~ (LastFailureType injected, PR #35)
+- ~~Deliverable path validation~~ (warns at declaration, PR #35)
+- ~~Failure context in retry prompt~~ (LastFailureType, PR #35)
 - ~~Decomposition trigger~~ ("list files, decompose if >8", PR #35)
 - ~~Scope creep across task boundaries~~ (auto-commit partial work, PR #35)
 - ~~ADR/spec audit enforcement~~ (reframed as descriptive, PR #35 + PR #36)
-- ~~Rich task definitions~~ (Body, TaskType, Constraints, AcceptanceCriteria, References, PR #36)
+- ~~Rich task definitions~~ (Body, TaskType, Constraints, References, PR #36)
 - ~~Hierarchical task IDs~~ (depth-first navigation, derived parent status, PR #36)
 - ~~Single daemon enforcement~~ (global lock, CWD-only resolution, PR #36)
-- ~~Orchestrator planning pipeline~~ (active planning agents, re-planning, completion review, PR #36)
+- ~~Orchestrator planning pipeline~~ (active planners, re-planning, completion review, PR #36)
 - ~~Task descriptions need more detail~~ (rich fields on Task struct, PR #36)
-- ~~Decomposition by concern~~ (orchestrator planning handles this, PR #36)
+- ~~Decomposition by concern~~ (orchestrator planning, PR #36)
 - ~~Auto-decompose on block~~ (orchestrator-as-unblocker, PR #36)
-- ~~Intake decomposition granularity~~ (orchestrator reads spec, plans at right granularity, PR #36)
-- ~~Planning enabled by default~~ (was dead code at false, fix/low-hanging)
-- ~~Execute prompt: --parent for hierarchical decomposition~~ (fix/low-hanging)
-- ~~Execute prompt: branch/worktree guardrail~~ (fix/low-hanging)
-- ~~Audit prompt: verify spec content not just existence~~ (fix/low-hanging)
-- ~~Execute prompt spec reference~~ (inline .md references in iteration context, fix/low-hanging)
-- ~~Planning prompts require --reference when scope has a spec~~ (fix/low-hanging)
+- ~~Intake decomposition granularity~~ (orchestrator plans at spec granularity, PR #36)
+- ~~Planning enabled by default~~ (PR #40)
+- ~~Execute prompt: --parent for hierarchical decomposition~~ (PR #40)
+- ~~Execute prompt: branch/worktree guardrail~~ (PR #40, strengthened PR #45)
+- ~~Audit prompt: verify spec content~~ (PR #40)
+- ~~Execute prompt spec reference~~ (inline .md references in context, PR #40)
+- ~~Planning prompts require --reference~~ (PR #40)
+- ~~Duplicate planning bug~~ (inference only, no flag from project create, PR #42)
+- ~~OVERLAP marker parsing~~ (daemon delivers scope to target orchestrator, PR #42)
+- ~~Audit quality: build, test, correctness, modularity~~ (language-agnostic checklist, PR #43 + PR #44)
+- ~~Orchestrator audits~~ (all nodes get audits, deferred until children complete, PR #44 + PR #46 + PR #47)
+- ~~Lazy planning~~ (execute first, plan when no tasks available, PR #44 + PR #49)
+- ~~PendingScope cleared prematurely~~ (only clear pre-pass scope items, PR #44)
+- ~~Default Clock on App~~ (prevent nil pointer, PR #44)
+- ~~Flat structure guidance~~ (planning prompt: sub-orchestrators >4 children, PR #44)
+- ~~Remediate prompt strategies~~ (spec-fix, code-fix, prerequisite, escalate, PR #44)
+- ~~Planning deadlock with audit tasks~~ (inference ignores audit tasks, PR #47)
+- ~~Planners only create direct children~~ (not grandchildren, PR #48)
+- ~~.gitignore not tracking state files~~ (unignore intermediate directories, PR #48)
+- ~~Daemon loop cleanup~~ (three clean steps: execute, plan, idle, PR #49)
+- ~~Blocked audit propagation~~ (BLOCKED propagates to index for remediation, PR #50)
+- ~~ADR/spec prompt rewrite~~ (WHY/WHAT/HOW framing, missing ADRs = REMEDIATE, PR #50)
+- ~~NeedsPlanning inference~~ (structural detection of childless orchestrators, PR #42 + PR #47)
+- ~~Spec stubs pass through pipeline~~ (audit checks content not existence, PR #40 + PR #43)
+- ~~Structured audit PASS/REMEDIATE~~ (verdicts, daemon handles BLOCKED, PR #43 + PR #44 + PR #50)


### PR DESCRIPTION
## Changes

**Moved to Completed (20 items from PRs #40-50):**
- Planning enabled by default, duplicate planning fix, OVERLAP parsing
- Audit quality overhaul (build/test/correctness/modularity)
- Orchestrator audits with deferral and deadlock fix
- Lazy planning (execute first, plan when idle)
- PendingScope preservation, default Clock, flat structure guidance
- Remediate prompt strategies, planners only create direct children
- .gitignore tracking fix, daemon loop cleanup
- Blocked audit propagation, ADR/spec prompt rewrite
- NeedsPlanning inference, spec stub detection, PASS/REMEDIATE verdicts

**Removed (completed or absorbed by other items):**
- "Planning pipeline doesn't populate References" (done in PR #40)
- "Spec stubs pass through pipeline" (done in PR #40 + #43)
- "Structured audit PASS/REMEDIATE" (done across PR #43, #44, #50)
- "Audit quality beyond structural checks" (done in PR #43)
- "NeedsPlanning inference" (done in PR #42 + #47)

**Remaining active: 12 items** across Pipeline Architecture (3), Daemon Mechanics (2), User Experience (5), Code Quality (5).