### PR TITLE
Status UX: -n flag, watch interval header, subtask indentation

### DIFF
--- a/cmd/daemon/daemon_test.go
+++ b/cmd/daemon/daemon_test.go
@@ -776,6 +776,16 @@ func TestStatusCmd_IntervalAcceptsSubSecond(t *testing.T) {
 	}
 }
 
+func TestStatusCmd_ShortIntervalFlag(t *testing.T) {
+	env := newTestEnv(t)
+	// -n should work as shorthand for --interval
+	env.RootCmd.SetArgs([]string{"status", "-n", "2"})
+	err := env.RootCmd.Execute()
+	if err != nil && strings.Contains(err.Error(), "unknown shorthand flag") {
+		t.Errorf("-n should be accepted as shorthand for --interval: %v", err)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // log command has --follow flag
 // ---------------------------------------------------------------------------

--- a/cmd/daemon/register.go
+++ b/cmd/daemon/register.go
@@ -30,7 +30,7 @@ func Register(app *cmdutil.App, rootCmd *cobra.Command) {
 	statusCmd.Flags().Bool("all", false, "Show status across all engineers")
 	statusCmd.Flags().String("node", "", "Show status for a specific subtree")
 	statusCmd.Flags().BoolP("watch", "w", false, "Refresh status on an interval")
-	statusCmd.Flags().Float64("interval", 5, "Refresh interval in seconds (with --watch)")
+	statusCmd.Flags().Float64P("interval", "n", 5, "Refresh interval in seconds (with --watch)")
 	_ = statusCmd.RegisterFlagCompletionFunc("node", cmdutil.CompleteNodeAddresses(app))
 
 	startCmd.GroupID = "lifecycle"

--- a/cmd/daemon/status.go
+++ b/cmd/daemon/status.go
@@ -218,9 +218,17 @@ func printNodeTree(app *cmdutil.App, idx *state.RootIndex, details map[string]*n
 			label = t.Description
 		}
 
+		// Indent subtasks by depth. task-0001.0002 gets one extra
+		// level, task-0001.0002.0003 gets two, etc.
+		taskIndent := indent + "  "
+		depth := strings.Count(t.ID, ".")
+		for i := 0; i < depth; i++ {
+			taskIndent += "  "
+		}
+
 		extra := ""
 		if t.State == state.StatusBlocked && t.BlockedReason != "" {
-			extra = "\n" + indent + "         " + t.BlockedReason
+			extra = "\n" + taskIndent + "       " + t.BlockedReason
 		}
 		if t.FailureCount > 0 && t.State != state.StatusComplete {
 			extra += fmt.Sprintf("  (%d failures)", t.FailureCount)
@@ -228,10 +236,10 @@ func printNodeTree(app *cmdutil.App, idx *state.RootIndex, details map[string]*n
 		// Show description detail for completed tasks when a title is
 		// the primary label and the description adds information.
 		if t.State == state.StatusComplete && t.Title != "" && t.Description != "" && t.Description != t.Title {
-			extra += "\n" + indent + "         " + t.Description
+			extra += "\n" + taskIndent + "       " + t.Description
 		}
 
-		output.PrintHuman("%s  %s %s  %s%s", indent, tGlyph, t.ID, label, extra)
+		output.PrintHuman("%s%s %s  %s%s", taskIndent, tGlyph, t.ID, label, extra)
 	}
 
 	// Gaps
@@ -397,6 +405,12 @@ func watchStatus(ctx context.Context, app *cmdutil.App, scope string, showAll bo
 	for {
 		// Clear screen and move cursor to top-left
 		_, _ = fmt.Fprint(os.Stdout, "\033[2J\033[H")
+
+		// Show interval like watch(1) does
+		if output.IsTerminal() {
+			output.PrintHuman("%sEvery %.1fs: wolfcastle status%s", colorDim, intervalSec, colorReset)
+			output.PrintHuman("")
+		}
 
 		if showAll {
 			if err := showAllStatus(app); err != nil {

--- a/cmd/daemon/status_test.go
+++ b/cmd/daemon/status_test.go
@@ -203,3 +203,27 @@ func TestShowAllStatus_WithMultipleNamespaces(t *testing.T) {
 		t.Fatalf("showAllStatus JSON with multiple namespaces failed: %v", err)
 	}
 }
+
+func TestShowTreeStatus_SubtaskIndentation(t *testing.T) {
+	env := newStatusTestEnv(t)
+
+	// Add hierarchical tasks to the leaf node
+	nodeDir := filepath.Join(env.ProjectsDir, "my-project")
+	ns := state.NewNodeState("my-project", "My Project", state.NodeLeaf)
+	ns.State = state.StatusInProgress
+	ns.Tasks = []state.Task{
+		{ID: "task-0001", Description: "Parent task", State: state.StatusInProgress},
+		{ID: "task-0001.0001", Description: "First subtask", State: state.StatusComplete},
+		{ID: "task-0001.0002", Description: "Second subtask", State: state.StatusNotStarted},
+		{ID: "task-0002", Description: "Top-level task", State: state.StatusNotStarted},
+		{ID: "audit", Description: "Audit", State: state.StatusNotStarted, IsAudit: true},
+	}
+	nsData, _ := json.MarshalIndent(ns, "", "  ")
+	_ = os.WriteFile(filepath.Join(nodeDir, "state.json"), nsData, 0644)
+
+	idx, _ := state.LoadRootIndex(filepath.Join(env.ProjectsDir, "state.json"))
+	// Should not panic and should render hierarchical tasks
+	if err := showTreeStatus(env.App, idx, ""); err != nil {
+		t.Fatalf("showTreeStatus with subtasks failed: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
Three status command improvements from the backlog:

- `-n 2` as shorthand for `--interval 2` (matches `watch` convention)
- Watch mode shows "Every 5.0s: wolfcastle status" header like `watch` does
- Hierarchical task IDs (task-0001.0001) indent under their parent

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint` clean
- [x] New tests: TestStatusCmd_ShortIntervalFlag, TestShowTreeStatus_SubtaskIndentation