### PR TITLE
Status watch: alternate screen buffer, no jitter

### DIFF
--- a/cmd/daemon/status.go
+++ b/cmd/daemon/status.go
@@ -407,18 +407,26 @@ func showAllStatus(app *cmdutil.App) error {
 	return nil
 }
 
-// watchStatus refreshes the status display on an interval, clearing the
-// screen between refreshes. Returns when context is cancelled.
+// watchStatus refreshes the status display on an interval. Uses the
+// alternate screen buffer and cursor repositioning for flicker-free
+// updates (no clear-then-redraw flash).
 func watchStatus(ctx context.Context, app *cmdutil.App, scope string, showAll bool, intervalSec float64, expand bool) error {
 	if intervalSec < 0.1 {
 		intervalSec = 0.1
 	}
 	d := time.Duration(intervalSec * float64(time.Second))
-	for {
-		// Clear screen and move cursor to top-left
-		_, _ = fmt.Fprint(os.Stdout, "\033[2J\033[H")
 
-		// Show interval like watch(1) does
+	// Enter alternate screen buffer
+	if output.IsTerminal() {
+		_, _ = fmt.Fprint(os.Stdout, "\033[?1049h")
+		defer func() { _, _ = fmt.Fprint(os.Stdout, "\033[?1049l") }()
+	}
+
+	for {
+		// Move cursor home (no clear). Overwrite previous output in place.
+		_, _ = fmt.Fprint(os.Stdout, "\033[H")
+
+		// Show interval header
 		if output.IsTerminal() {
 			output.PrintHuman("%sEvery %.1fs: wolfcastle status%s", colorDim, intervalSec, colorReset)
 			output.PrintHuman("")
@@ -438,6 +446,13 @@ func watchStatus(ctx context.Context, app *cmdutil.App, scope string, showAll bo
 				}
 			}
 		}
+
+		// Clear from cursor to end of screen. This erases any leftover
+		// lines from the previous frame (e.g., when the tree shrinks
+		// because nodes completed and collapsed).
+		// Clear from cursor to end of screen, erasing leftover lines
+		// from the previous frame.
+		_, _ = fmt.Fprint(os.Stdout, "\033[J")
 
 		select {
 		case <-ctx.Done():

--- a/cmd/daemon/status_test.go
+++ b/cmd/daemon/status_test.go
@@ -204,6 +204,35 @@ func TestShowAllStatus_WithMultipleNamespaces(t *testing.T) {
 	}
 }
 
+func TestCountDescendants(t *testing.T) {
+	idx := state.NewRootIndex()
+	idx.Nodes["root"] = state.IndexEntry{
+		Name: "Root", Type: state.NodeOrchestrator, Children: []string{"root/a", "root/b"},
+	}
+	idx.Nodes["root/a"] = state.IndexEntry{
+		Name: "A", Type: state.NodeOrchestrator, Parent: "root", Children: []string{"root/a/x"},
+	}
+	idx.Nodes["root/a/x"] = state.IndexEntry{
+		Name: "X", Type: state.NodeLeaf, Parent: "root/a",
+	}
+	idx.Nodes["root/b"] = state.IndexEntry{
+		Name: "B", Type: state.NodeLeaf, Parent: "root",
+	}
+
+	if got := countDescendants(idx, "root"); got != 3 {
+		t.Errorf("expected 3 descendants, got %d", got)
+	}
+	if got := countDescendants(idx, "root/a"); got != 1 {
+		t.Errorf("expected 1 descendant, got %d", got)
+	}
+	if got := countDescendants(idx, "root/b"); got != 0 {
+		t.Errorf("expected 0 descendants for leaf, got %d", got)
+	}
+	if got := countDescendants(idx, "nonexistent"); got != 0 {
+		t.Errorf("expected 0 for missing node, got %d", got)
+	}
+}
+
 func TestShowTreeStatus_SubtaskIndentation(t *testing.T) {
 	env := newStatusTestEnv(t)
 


### PR DESCRIPTION
Missed in PR #54 squash merge. Uses alternate screen buffer and cursor repositioning instead of clear-then-redraw. Also adds TestCountDescendants.