### PR TITLE
Collapse completed leaf nodes in status output

### DIFF
--- a/cmd/daemon/status.go
+++ b/cmd/daemon/status.go
@@ -206,6 +206,12 @@ func printNodeTree(app *cmdutil.App, idx *state.RootIndex, details map[string]*n
 			output.PrintHuman("%s%s %s  (%d nodes)", indent, glyph, nd.entry.Name, childCount+1)
 			return
 		}
+		// Completed leaf: show node name only, no task details.
+		if nd.ns != nil && len(nd.ns.Tasks) > 0 {
+			glyph := nodeGlyph(nd.entry.State)
+			output.PrintHuman("%s%s %s", indent, glyph, nd.entry.Name)
+			return
+		}
 	}
 
 	glyph := nodeGlyph(nd.entry.State)


### PR DESCRIPTION
## Summary

- Completed leaf nodes with tasks now collapse to just their name, matching how completed orchestrators already collapse
- Previously only orchestrators collapsed (checked `childCount > 0`); leaves with tasks fell through and printed all task details

## Test plan

- [x] Verified against test/domains: ClassRepository, Project Services, ContextBuilder, cmd Package Coverage all collapse
- [x] `--expand` still shows full task details
- [x] cmd/daemon tests pass