### PR TITLE
selfHeal: derive parent task status from children

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -142,6 +142,9 @@ func PreStartSelfHeal(resolver *tree.Resolver, wolfcastleDir string) {
 					ns.Tasks[i].State = state.StatusNotStarted
 				}
 				changed = true
+			} else if derived, hasChildren := state.DeriveParentStatus(ns, ns.Tasks[i].ID); hasChildren && derived != ns.Tasks[i].State {
+				ns.Tasks[i].State = derived
+				changed = true
 			}
 		}
 		if changed {
@@ -180,9 +183,8 @@ func (d *Daemon) selfHeal() error {
 		changed := false
 		for i := range ns.Tasks {
 			t := &ns.Tasks[i]
-			// Reset stale in_progress to not_started
 			if t.State == state.StatusInProgress {
-				// Check if this is a parent with all children complete
+				// Stale in_progress: derive from children or reset
 				if derived, hasChildren := state.DeriveParentStatus(ns, t.ID); hasChildren {
 					t.State = derived
 					output.PrintHuman("  Derived %s/%s → %s", addr, t.ID, derived)
@@ -190,6 +192,14 @@ func (d *Daemon) selfHeal() error {
 					t.State = state.StatusNotStarted
 					output.PrintHuman("  Reset %s/%s → not_started", addr, t.ID)
 				}
+				changed = true
+				healed++
+			} else if derived, hasChildren := state.DeriveParentStatus(ns, t.ID); hasChildren && derived != t.State {
+				// Parent task disagrees with its children. Write the
+				// derived status so the on-disk state matches what
+				// navigation computes on the fly.
+				output.PrintHuman("  Derived %s/%s → %s (was %s)", addr, t.ID, derived, t.State)
+				t.State = derived
 				changed = true
 				healed++
 			}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -358,6 +358,38 @@ func TestSelfHeal_HealsOrchestrators(t *testing.T) {
 	}
 }
 
+func TestSelfHeal_DerivesStaleParentStatus(t *testing.T) {
+	d := testDaemon(t)
+	projDir := d.Resolver.ProjectsDir()
+
+	// Parent task is not_started but all children are complete.
+	// selfHeal should derive the parent to complete.
+	setupLeafNode(t, d, "my-node", []state.Task{
+		{ID: "task-0001", State: state.StatusComplete},
+		{ID: "task-0002", State: state.StatusNotStarted},
+		{ID: "task-0002.0001", State: state.StatusComplete},
+		{ID: "task-0002.0002", State: state.StatusComplete},
+		{ID: "task-0002.0003", State: state.StatusComplete},
+		{ID: "audit", State: state.StatusNotStarted, IsAudit: true},
+	})
+
+	if err := d.selfHeal(); err != nil {
+		t.Fatalf("selfHeal error: %v", err)
+	}
+
+	ns, _ := state.LoadNodeState(filepath.Join(projDir, "my-node", "state.json"))
+	// task-0002 should be derived to complete from its children
+	for _, t2 := range ns.Tasks {
+		if t2.ID == "task-0002" {
+			if t2.State != state.StatusComplete {
+				t.Errorf("parent task-0002 should be complete, got %s", t2.State)
+			}
+			return
+		}
+	}
+	t.Fatal("task-0002 not found")
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // RunOnce
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- selfHeal now derives parent task status for ALL parents whose state disagrees with their children, not just in_progress parents
- Fixes stale not_started parent tasks (like task-0002, task-0004 in test/domains App Refactor) where all children completed before PR #55 added auto-derivation
- Same logic added to PreStartSelfHeal for consistency

## Test plan

- [x] New test: TestSelfHeal_DerivesStaleParentStatus (parent not_started, children all complete, derived to complete)
- [x] All existing selfHeal tests pass
- [x] Full daemon test suite passes with race detector