### PR TITLE
Quiet remediation: subtask details to log, not stdout

### DIFF
--- a/internal/daemon/iteration.go
+++ b/internal/daemon/iteration.go
@@ -178,7 +178,7 @@ func (d *Daemon) runIteration(ctx context.Context, nav *state.NavigationResult, 
 			// not_started so it re-runs to verify the fixes.
 			if created := d.createRemediationSubtasks(nav.NodeAddress, nav.TaskID); created > 0 {
 				_ = d.Logger.Log(map[string]any{"type": "audit_remediation", "task": nav.TaskID, "subtasks": created})
-				output.PrintHuman("  Created %d remediation subtask(s) from audit gaps", created)
+				output.PrintHuman("  Audit: %d gap(s), remediating.", created)
 				return nil
 			}
 
@@ -561,7 +561,6 @@ func (d *Daemon) createRemediationSubtasks(nodeAddr, taskID string) int {
 				State:       state.StatusNotStarted,
 			})
 			created++
-			output.PrintHuman("  %s: %s", childID, g.Description)
 		}
 
 		// Reset the audit task to not_started so it doesn't stay blocked.


### PR DESCRIPTION
## Summary

- Removed per-gap `output.PrintHuman` that dumped full gap descriptions to stdout
- Summary line shortened to "Audit: N gap(s), remediating."
- Gap details already logged via `d.Logger.Log` with type `audit_remediation`

## Test plan

- [x] Daemon tests pass