### PR TITLE
Treat superseded blocks as skip, not blocked

### DIFF
--- a/internal/daemon/iteration.go
+++ b/internal/daemon/iteration.go
@@ -172,6 +172,20 @@ func (d *Daemon) runIteration(ctx context.Context, nav *state.NavigationResult, 
 		if marker == "WOLFCASTLE_BLOCKED" {
 			_ = d.Logger.Log(map[string]any{"type": "terminal_marker", "marker": "WOLFCASTLE_BLOCKED", "task": nav.TaskID})
 
+			// Check if the model blocked a task that's actually
+			// superseded. Superseded work should be SKIP, not BLOCKED.
+			// Treat it as complete so it doesn't poison node state.
+			if d.isSupersededBlock(nav.NodeAddress, nav.TaskID) {
+				_ = d.Logger.Log(map[string]any{"type": "superseded_to_skip", "task": nav.TaskID})
+				output.PrintHuman("  Superseded (treating as skip).")
+				if err := d.Store.MutateNode(nav.NodeAddress, func(ns *state.NodeState) error {
+					return state.TaskComplete(ns, nav.TaskID)
+				}); err != nil {
+					_ = d.Logger.Log(map[string]any{"type": "save_error", "error": err.Error()})
+				}
+				return nil
+			}
+
 			// For audit tasks with gaps, create remediation subtasks
 			// instead of blocking. The subtasks fix each gap, and when
 			// they all complete, DeriveParentStatus resets the audit to
@@ -573,4 +587,31 @@ func (d *Daemon) createRemediationSubtasks(nodeAddr, taskID string) int {
 		return nil
 	})
 	return created
+}
+
+// isSupersededBlock checks whether a blocked task was actually superseded
+// (work done via a different path). The model should use WOLFCASTLE_SKIP
+// for these, but sometimes uses BLOCKED instead. This catches the mistake.
+func (d *Daemon) isSupersededBlock(nodeAddr, taskID string) bool {
+	var superseded bool
+	_ = d.Store.MutateNode(nodeAddr, func(ns *state.NodeState) error {
+		for _, t := range ns.Tasks {
+			if t.ID != taskID {
+				continue
+			}
+			reason := strings.ToLower(t.BlockedReason)
+			if strings.Contains(reason, "supersed") ||
+				strings.Contains(reason, "already done") ||
+				strings.Contains(reason, "already completed") ||
+				strings.Contains(reason, "no longer needed") ||
+				strings.Contains(reason, "replaced by") ||
+				strings.Contains(reason, "done in") ||
+				strings.Contains(reason, "done directly") {
+				superseded = true
+			}
+			break
+		}
+		return nil
+	})
+	return superseded
 }

--- a/internal/project/templates/prompts/execute.md
+++ b/internal/project/templates/prompts/execute.md
@@ -148,9 +148,9 @@ wolfcastle audit summary --node <your-node> "one-paragraph summary of what was a
 Then emit one terminal marker on its own line, as plain text. No markdown formatting, no bold, no backticks, no emphasis.
 
 - **WOLFCASTLE_COMPLETE** — Task is done. You must have committed changes before emitting this.
-- **WOLFCASTLE_SKIP** *reason* — The task's work was already completed by a prior task, manual change, or codebase evolution. Do not redo work that already exists. Include a reason. Example: `WOLFCASTLE_SKIP tree.Resolver already removed in prior commit`
+- **WOLFCASTLE_SKIP** *reason* — The task's work was already completed by a prior task, manual change, or codebase evolution. Superseded tasks are SKIP, not BLOCKED. If someone else already did the work, or the task was replaced by a different approach, that's SKIP. Include a reason. Example: `WOLFCASTLE_SKIP tree.Resolver already removed in prior commit`
 - **WOLFCASTLE_YIELD** — You made progress but the task needs more work, or you created sub-tasks and need the daemon to work on them.
-- **WOLFCASTLE_BLOCKED** — The task cannot be completed. Call `wolfcastle task block` first with a reason.
+- **WOLFCASTLE_BLOCKED** — The task cannot proceed due to an external dependency, missing prerequisite, or unresolvable conflict. Use this only when the work genuinely cannot be done, not when it was done differently. Call `wolfcastle task block` first with a reason.
 
 ### J. Pre-block downstream tasks (when applicable)
 


### PR DESCRIPTION
## Summary

- **Prompt fix**: execute.md now explicitly says superseded tasks are WOLFCASTLE_SKIP, not WOLFCASTLE_BLOCKED. BLOCKED description clarified to "genuinely cannot proceed" only.
- **Daemon safety net**: `isSupersededBlock` checks the blocked reason for supersession language and treats the task as complete. Prevents superseded tasks from poisoning node state and hiding actionable work (like audit remediation subtasks that couldn't be found because the node was blocked).

## Test plan

- [x] All daemon tests pass with race detector
- [x] Build clean