### PR TITLE
Remove CodeQL from PR checks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,6 @@ name: CodeQL
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   schedule:
     - cron: "0 6 * * 1"
 


### PR DESCRIPTION
## Summary

CodeQL still runs on every push to main and weekly, but no longer on PRs. Removes the X from PR checks when CodeQL is slow or queued.