### PR TITLE
Make Codecov patch coverage informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -16,6 +16,7 @@ coverage:
     patch:
       default:
         target: 80%
+        informational: true
 
 parsers:
   go:


### PR DESCRIPTION
Patch coverage still reports but no longer blocks PRs. Project-level target (85%) remains required.