### PR TITLE
Fix audit remediation deadlock in navigation

### DIFF
--- a/internal/state/hierarchical_test.go
+++ b/internal/state/hierarchical_test.go
@@ -203,6 +203,38 @@ func TestDeriveParentStatus_NonAuditStillCompletes(t *testing.T) {
 	}
 }
 
+func TestNavigation_AuditRemediationChildrenRunnable(t *testing.T) {
+	// audit is not_started (reset for re-verification) with remediation
+	// children. Children must be runnable despite the parent being
+	// not_started, because the audit's not_started state means
+	// "waiting for children to finish."
+	ns := NewNodeState("test", "Test", NodeLeaf)
+	ns.State = StatusInProgress
+	ns.Tasks = []Task{
+		{ID: "task-0001", Description: "work", State: StatusComplete},
+		{ID: "audit", Description: "audit", State: StatusNotStarted, IsAudit: true},
+		{ID: "audit.0001", Description: "fix race condition", State: StatusNotStarted},
+	}
+
+	idx := NewRootIndex()
+	idx.Root = []string{"test"}
+	idx.Nodes["test"] = IndexEntry{
+		Name: "Test", Type: NodeLeaf, State: StatusInProgress, Address: "test",
+	}
+
+	loader := func(addr string) (*NodeState, error) { return ns, nil }
+	nav, err := FindNextTask(idx, "", loader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !nav.Found {
+		t.Fatal("expected to find audit.0001 but navigation found nothing")
+	}
+	if nav.TaskID != "audit.0001" {
+		t.Errorf("expected audit.0001, got %s", nav.TaskID)
+	}
+}
+
 func TestNavigation_HierarchicalDepthFirst(t *testing.T) {
 	// task-0001 has children, task-0002 is a sibling.
 	// Navigation should pick task-0001.0001 before task-0002.

--- a/internal/state/navigation.go
+++ b/internal/state/navigation.go
@@ -247,6 +247,8 @@ func parentInList(childID string, tasks []Task) bool {
 
 // hasNotStartedAncestor checks if any ancestor of the task is not_started.
 // An ancestor is a task whose ID is a prefix of this task's ID.
+// Audit ancestors are exempt: when an audit is reset to not_started for
+// re-verification, its remediation children must still be runnable.
 func hasNotStartedAncestor(taskID string, ns *NodeState) bool {
 	// Walk up the hierarchy: task-0001.0002.0001 → task-0001.0002 → task-0001
 	id := taskID
@@ -257,7 +259,7 @@ func hasNotStartedAncestor(taskID string, ns *NodeState) bool {
 		}
 		parentID := id[:dot]
 		for _, t := range ns.Tasks {
-			if t.ID == parentID && t.State == StatusNotStarted {
+			if t.ID == parentID && t.State == StatusNotStarted && !t.IsAudit {
 				return true
 			}
 		}


### PR DESCRIPTION
## Summary

`hasNotStartedAncestor` blocked audit remediation children (audit.0001) because their parent (audit) was not_started. But the audit was not_started because DeriveParentStatus reset it for re-verification, waiting for children to run first. Deadlock.

Audit ancestors are now exempt from the not_started ancestor check. A not_started audit task is waiting for its children, not blocking them.

## Test plan

- [x] TestNavigation_AuditRemediationChildrenRunnable: audit.0001 is found when audit parent is not_started
- [x] All state and daemon tests pass with race detector