### PR TITLE
Fix audit derivation after re-verification passes

### DIFF
--- a/internal/state/hierarchical_test.go
+++ b/internal/state/hierarchical_test.go
@@ -173,6 +173,24 @@ func TestDeriveParentStatus_AuditResetsWhenChildrenComplete(t *testing.T) {
 	}
 }
 
+func TestDeriveParentStatus_AuditCompletesAfterRerun(t *testing.T) {
+	// Audit re-ran and passed (state=complete). Children are also complete.
+	// DeriveParentStatus should return complete, not reset to not_started.
+	ns := NewNodeState("test", "Test", NodeLeaf)
+	ns.Tasks = []Task{
+		{ID: "audit", Description: "audit", State: StatusComplete, IsAudit: true},
+		{ID: "audit.0001", Description: "fix race condition", State: StatusComplete},
+	}
+
+	status, hasChildren := DeriveParentStatus(ns, "audit")
+	if !hasChildren {
+		t.Fatal("expected hasChildren=true")
+	}
+	if status != StatusComplete {
+		t.Errorf("audit should be complete after re-verification, got %s", status)
+	}
+}
+
 func TestDeriveParentStatus_AuditStaysInProgressWhenChildrenIncomplete(t *testing.T) {
 	ns := NewNodeState("test", "Test", NodeLeaf)
 	ns.Tasks = []Task{

--- a/internal/state/mutations.go
+++ b/internal/state/mutations.go
@@ -159,11 +159,12 @@ func DeriveParentStatus(ns *NodeState, taskID string) (NodeStatus, bool) {
 	}
 
 	if allComplete {
-		// Audit tasks reset to not_started when remediation children
-		// complete so the audit re-runs to verify the fixes. Regular
-		// parent tasks derive to complete normally.
+		// Audit tasks with remediation children: if the audit itself
+		// is complete (re-verification passed), derive complete. If
+		// the audit hasn't re-run yet (not_started/blocked), derive
+		// not_started so it gets picked up for re-verification.
 		for _, t := range ns.Tasks {
-			if t.ID == taskID && t.IsAudit {
+			if t.ID == taskID && t.IsAudit && t.State != StatusComplete {
 				return StatusNotStarted, true
 			}
 		}


### PR DESCRIPTION
## Summary

DeriveParentStatus returned not_started for completed audits with remediation children, preventing node completion. Now returns complete when the audit itself is complete (re-verification passed).

## Test plan

- [x] TestDeriveParentStatus_AuditCompletesAfterRerun (new)
- [x] TestDeriveParentStatus_AuditResetsWhenChildrenComplete (existing, still passes)
- [x] TestDeriveParentStatus_AuditStaysInProgressWhenChildrenIncomplete (existing, still passes)
- [x] All state and daemon tests pass with race detector