### PR TITLE
Fix RunWithSupervisor race on shutdown channel

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -30,6 +30,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"time"
 
@@ -235,10 +236,12 @@ func (d *Daemon) RunWithSupervisor(ctx context.Context) error {
 		output.PrintHuman("Crash (attempt %d/%d): %v. Restarting in %v.", restart+1, maxRestarts, err, delay)
 		time.Sleep(delay)
 
-		// Reset daemon state for next Run() invocation.
-		// Resetting sync.Once is safe here because all goroutines from
-		// the previous Run() have exited — the signal-forwarding goroutine
-		// terminates when ctx.Done() closes, and Run() has returned.
+		// Ensure previous goroutines see shutdown before we reset.
+		// The signal goroutine and context-cancel goroutine both
+		// select on d.shutdown; closing it lets them exit cleanly.
+		d.shutdownOnce.Do(func() { close(d.shutdown) })
+		runtime.Gosched()
+
 		d.shutdown = make(chan struct{})
 		d.shutdownOnce = sync.Once{}
 		d.workAvailable = make(chan struct{}, 1)


### PR DESCRIPTION
Close d.shutdown before resetting so goroutines from the previous Run() see it and exit. Prevents race between signal goroutine reading d.shutdown and the reset writing it.