### PR TITLE
Block path traversal in task reference file reads

### DIFF
--- a/internal/state/render.go
+++ b/internal/state/render.go
@@ -68,9 +68,11 @@ func (t *Task) RenderContext(nodeAddr string, nodeDir string) string {
 		for _, r := range t.References {
 			fmt.Fprintf(&b, "- `%s`\n", r)
 		}
-		// Inline spec content when references point to readable files
+		// Inline spec content when references point to readable .md files.
+		// Reject paths containing ".." to prevent traversal outside the
+		// project directory.
 		for _, r := range t.References {
-			if strings.HasSuffix(r, ".md") {
+			if strings.HasSuffix(r, ".md") && !strings.Contains(filepath.Clean(r), "..") {
 				if content, err := os.ReadFile(r); err == nil {
 					trimmed := strings.TrimSpace(string(content))
 					if len(trimmed) > 0 && len(trimmed) < 8000 {


### PR DESCRIPTION
## Summary

render.go reads task reference files with `os.ReadFile(r)` without validating the path. A reference like `../../etc/passwd` would be attempted. Now rejects paths containing `..` after cleaning.

The other two backlog code quality items (git.CreateWorktree error, MigrationService error swallowing) are on the test/domains branch, not main. CreateWorktree was already refactored and no longer has the fallback pattern.

## Test plan

- [x] state tests pass
- [x] Build clean