### PR TITLE
Fix planning propagation: derive state from children

### DIFF
--- a/internal/daemon/planning.go
+++ b/internal/daemon/planning.go
@@ -267,8 +267,14 @@ func (d *Daemon) runPlanningPass(ctx context.Context, nodeAddr string, ns *state
 			}
 			return nil
 		})
-		// Propagate up the tree so parent orchestrators see the completion.
-		if err := d.propagateState(nodeAddr, state.StatusComplete, idx); err != nil {
+		// Propagate the actual derived state. If planning created children
+		// that haven't executed yet, the orchestrator won't be complete
+		// despite its own tasks being done.
+		derivedState := state.StatusNotStarted
+		if freshNS, readErr := d.Store.ReadNode(nodeAddr); readErr == nil {
+			derivedState = freshNS.State
+		}
+		if err := d.propagateState(nodeAddr, derivedState, idx); err != nil {
 			_ = d.Logger.Log(map[string]any{"type": "propagate_error", "error": err.Error()})
 		}
 


### PR DESCRIPTION
## Summary

After planning creates children via `project create`, the orchestrator's state should derive from those children. The `propagateState` call was hardcoded to `StatusComplete`, overriding the `MutateNode` callback's correct derivation. This made orchestrators appear complete in the index while their newly created children were `not_started`, blocking the daemon's navigation from ever reaching them.

One-line fix: read back the actual derived state after `MutateNode` and propagate that instead of hardcoding `StatusComplete`.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/daemon/` passes
- [ ] Start daemon with inbox items, verify orchestrators stay `not_started` until children complete
- [ ] Verify leaf nodes are navigable after planning creates them