### PR TITLE
selfHeal: create remediation subtasks for blocked audits with open gaps

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -168,6 +168,31 @@ func (d *Daemon) selfHeal() error {
 				needsHeal = true
 				break
 			}
+			// Blocked audit with open gaps but no remediation subtasks:
+			// the daemon crashed or exited before creating them.
+			if t.IsAudit && t.State == state.StatusBlocked {
+				hasOpenGaps := false
+				for _, g := range ns.Audit.Gaps {
+					if g.Status == state.GapOpen {
+						hasOpenGaps = true
+						break
+					}
+				}
+				if hasOpenGaps {
+					hasSubtasks := false
+					prefix := t.ID + "."
+					for _, other := range ns.Tasks {
+						if len(other.ID) > len(prefix) && other.ID[:len(prefix)] == prefix {
+							hasSubtasks = true
+							break
+						}
+					}
+					if !hasSubtasks {
+						needsHeal = true
+						break
+					}
+				}
+			}
 		}
 		if !needsHeal {
 			continue
@@ -194,6 +219,48 @@ func (d *Daemon) selfHeal() error {
 					healed++
 				}
 			}
+			// Blocked audit with open gaps but no remediation subtasks:
+			// create the subtasks that should have been created when
+			// the audit first blocked.
+			for i := range ns.Tasks {
+				t := &ns.Tasks[i]
+				if !t.IsAudit || t.State != state.StatusBlocked {
+					continue
+				}
+				prefix := t.ID + "."
+				hasSubtasks := false
+				for _, other := range ns.Tasks {
+					if len(other.ID) > len(prefix) && other.ID[:len(prefix)] == prefix {
+						hasSubtasks = true
+						break
+					}
+				}
+				if hasSubtasks {
+					continue
+				}
+				subCount := 0
+				for _, g := range ns.Audit.Gaps {
+					if g.Status != state.GapOpen {
+						continue
+					}
+					childID := fmt.Sprintf("%s.%04d", t.ID, subCount+1)
+					ns.Tasks = append(ns.Tasks, state.Task{
+						ID:          childID,
+						Description: fmt.Sprintf("Fix: %s", g.Description),
+						State:       state.StatusNotStarted,
+					})
+					subCount++
+				}
+				if subCount > 0 {
+					// Re-index after append may have reallocated the slice.
+					ns.Tasks[i].State = state.StatusNotStarted
+					ns.Tasks[i].BlockedReason = ""
+					output.PrintHuman("  Created %d remediation subtask(s) for %s/%s", subCount, addr, ns.Tasks[i].ID)
+					changed = true
+					healed += subCount
+				}
+			}
+
 			if !changed {
 				return errNoChange
 			}

--- a/internal/daemon/selfheal_audit_test.go
+++ b/internal/daemon/selfheal_audit_test.go
@@ -1,0 +1,162 @@
+package daemon
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dorkusprime/wolfcastle/internal/state"
+)
+
+func setupSelfHealEnv(t *testing.T) (*state.StateStore, string) {
+	t.Helper()
+	tmp := t.TempDir()
+	projDir := filepath.Join(tmp, "projects", "test-ns")
+	_ = os.MkdirAll(projDir, 0755)
+
+	// Create root index with one leaf node
+	idx := state.NewRootIndex()
+	idx.Nodes["proj"] = state.IndexEntry{
+		Name:    "proj",
+		Type:    state.NodeLeaf,
+		State:   state.StatusInProgress,
+		Address: "proj",
+	}
+	idx.Root = []string{"proj"}
+	idxData, _ := json.MarshalIndent(idx, "", "  ")
+	_ = os.WriteFile(filepath.Join(projDir, "state.json"), idxData, 0644)
+
+	// Create node state
+	nodeDir := filepath.Join(projDir, "proj")
+	_ = os.MkdirAll(nodeDir, 0755)
+	ns := state.NewNodeState("proj", "proj", state.NodeLeaf)
+	ns.State = state.StatusInProgress
+	ns.Tasks = []state.Task{
+		{ID: "task-0001", Title: "Do work", State: state.StatusNotStarted},
+		{ID: "audit", Title: "Audit", State: state.StatusNotStarted, IsAudit: true},
+	}
+	_ = state.SaveNodeState(filepath.Join(nodeDir, "state.json"), ns)
+
+	store := state.NewStateStore(projDir, 5)
+	return store, projDir
+}
+
+func TestSelfHeal_BlockedAuditWithOpenGaps_CreatesSubtasks(t *testing.T) {
+	store, _ := setupSelfHealEnv(t)
+
+	_ = store.MutateNode("proj", func(ns *state.NodeState) error {
+		for i := range ns.Tasks {
+			if ns.Tasks[i].ID == "task-0001" {
+				ns.Tasks[i].State = state.StatusComplete
+			}
+			if ns.Tasks[i].IsAudit {
+				ns.Tasks[i].State = state.StatusBlocked
+				ns.Tasks[i].BlockedReason = "open gaps"
+			}
+		}
+		ns.Audit.Gaps = []state.Gap{
+			{ID: "gap-1", Description: "something wrong", Status: state.GapOpen},
+		}
+		ns.Audit.Status = state.AuditFailed
+		return nil
+	})
+
+	d := &Daemon{Store: store}
+	if err := d.selfHeal(); err != nil {
+		t.Fatalf("selfHeal error: %v", err)
+	}
+
+	ns, err := store.ReadNode("proj")
+	if err != nil {
+		t.Fatalf("reading node: %v", err)
+	}
+
+	found := false
+	for _, task := range ns.Tasks {
+		if task.ID == "audit.0001" {
+			found = true
+			if task.State != state.StatusNotStarted {
+				t.Errorf("subtask state = %s, want not_started", task.State)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected remediation subtask audit.0001 to be created")
+	}
+
+	for _, task := range ns.Tasks {
+		if task.IsAudit && task.ID == "audit" {
+			if task.State != state.StatusNotStarted {
+				t.Errorf("audit state = %s, want not_started", task.State)
+			}
+			if task.BlockedReason != "" {
+				t.Errorf("audit blocked reason = %q, want empty", task.BlockedReason)
+			}
+		}
+	}
+}
+
+func TestSelfHeal_BlockedAuditWithExistingSubtasks_Skips(t *testing.T) {
+	store, _ := setupSelfHealEnv(t)
+
+	_ = store.MutateNode("proj", func(ns *state.NodeState) error {
+		for i := range ns.Tasks {
+			if ns.Tasks[i].IsAudit {
+				ns.Tasks[i].State = state.StatusBlocked
+			}
+		}
+		ns.Tasks = append(ns.Tasks, state.Task{
+			ID:    "audit.0001",
+			State: state.StatusNotStarted,
+		})
+		ns.Audit.Gaps = []state.Gap{
+			{ID: "gap-1", Description: "something", Status: state.GapOpen},
+		}
+		return nil
+	})
+
+	d := &Daemon{Store: store}
+	if err := d.selfHeal(); err != nil {
+		t.Fatalf("selfHeal error: %v", err)
+	}
+
+	ns, _ := store.ReadNode("proj")
+	subtaskCount := 0
+	for _, task := range ns.Tasks {
+		if len(task.ID) > 6 && task.ID[:6] == "audit." {
+			subtaskCount++
+		}
+	}
+	if subtaskCount != 1 {
+		t.Errorf("expected 1 existing subtask, got %d", subtaskCount)
+	}
+}
+
+func TestSelfHeal_BlockedAuditNoGaps_Skips(t *testing.T) {
+	store, _ := setupSelfHealEnv(t)
+
+	_ = store.MutateNode("proj", func(ns *state.NodeState) error {
+		for i := range ns.Tasks {
+			if ns.Tasks[i].IsAudit {
+				ns.Tasks[i].State = state.StatusBlocked
+				ns.Tasks[i].BlockedReason = "model said so"
+			}
+		}
+		return nil
+	})
+
+	d := &Daemon{Store: store}
+	if err := d.selfHeal(); err != nil {
+		t.Fatalf("selfHeal error: %v", err)
+	}
+
+	ns, _ := store.ReadNode("proj")
+	for _, task := range ns.Tasks {
+		if task.IsAudit {
+			if task.State != state.StatusBlocked {
+				t.Errorf("audit should remain blocked without gaps, got %s", task.State)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

When an audit task is blocked with open gaps but no remediation subtasks exist, `selfHeal` now creates them on startup. This handles the case where the daemon exited before `createRemediationSubtasks` could fire during the BLOCKED marker handler.

Also fixes a slice reallocation bug: appending subtasks to `ns.Tasks` invalidated a pointer obtained from `&ns.Tasks[i]`, so the state reset wrote to stale memory.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] Blocked audit + open gaps + no subtasks: creates subtasks and resets audit to not_started
- [ ] Blocked audit + existing subtasks: skips (no duplicates)
- [ ] Blocked audit + no gaps: remains blocked (no false healing)