### PR TITLE
Fix duplicate remediation subtask IDs on re-audit

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -238,17 +238,31 @@ func (d *Daemon) selfHeal() error {
 				if hasSubtasks {
 					continue
 				}
+				// Find existing subtask numbers to avoid duplicates.
+				existingSubs := make(map[string]bool)
+				subPrefix := t.ID + "."
+				for _, other := range ns.Tasks {
+					if len(other.ID) > len(subPrefix) && other.ID[:len(subPrefix)] == subPrefix {
+						existingSubs[other.ID] = true
+					}
+				}
+				nextNum := len(existingSubs) + 1
 				subCount := 0
 				for _, g := range ns.Audit.Gaps {
 					if g.Status != state.GapOpen {
 						continue
 					}
-					childID := fmt.Sprintf("%s.%04d", t.ID, subCount+1)
+					childID := fmt.Sprintf("%s.%04d", t.ID, nextNum)
+					for existingSubs[childID] {
+						nextNum++
+						childID = fmt.Sprintf("%s.%04d", t.ID, nextNum)
+					}
 					ns.Tasks = append(ns.Tasks, state.Task{
 						ID:          childID,
 						Description: fmt.Sprintf("Fix: %s", g.Description),
 						State:       state.StatusNotStarted,
 					})
+					nextNum++
 					subCount++
 				}
 				if subCount > 0 {

--- a/internal/daemon/iteration.go
+++ b/internal/daemon/iteration.go
@@ -662,14 +662,29 @@ func (d *Daemon) createRemediationSubtasks(nodeAddr, taskID string) int {
 			return nil
 		}
 
-		// Create a subtask for each open gap
-		for i, g := range openGaps {
-			childID := fmt.Sprintf("%s.%04d", taskID, i+1)
+		// Find existing subtask IDs to avoid duplicates.
+		existingSubtasks := make(map[string]bool)
+		prefix := taskID + "."
+		for _, t := range ns.Tasks {
+			if len(t.ID) > len(prefix) && t.ID[:len(prefix)] == prefix {
+				existingSubtasks[t.ID] = true
+			}
+		}
+
+		// Create a subtask for each open gap that doesn't already have one.
+		nextNum := len(existingSubtasks) + 1
+		for _, g := range openGaps {
+			childID := fmt.Sprintf("%s.%04d", taskID, nextNum)
+			if existingSubtasks[childID] {
+				nextNum++
+				childID = fmt.Sprintf("%s.%04d", taskID, nextNum)
+			}
 			ns.Tasks = append(ns.Tasks, state.Task{
 				ID:          childID,
 				Description: fmt.Sprintf("Fix: %s", g.Description),
 				State:       state.StatusNotStarted,
 			})
+			nextNum++
 			created++
 		}
 


### PR DESCRIPTION
## Summary

`createRemediationSubtasks` and `selfHeal` both numbered new subtasks from 1, ignoring existing completed subtasks. When an audit re-ran and found the same gap still open, it created `audit.0001` again, producing a duplicate ID. Navigation found the completed one first and crashed trying to claim it, causing a restart loop that exhausted max restarts.

Fix: scan existing subtask IDs first, start numbering after the highest existing number, skip collisions.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/daemon/` passes
- [ ] Audit that blocks twice on the same gap creates `audit.0001` then `audit.0002`, not duplicate `audit.0001`