### PR TITLE
Include fix-gap command in remediation subtask descriptions

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -259,7 +259,7 @@ func (d *Daemon) selfHeal() error {
 					}
 					ns.Tasks = append(ns.Tasks, state.Task{
 						ID:          childID,
-						Description: fmt.Sprintf("Fix: %s", g.Description),
+						Description: fmt.Sprintf("Fix: %s\n\nAfter fixing, close the gap:\n  wolfcastle audit fix-gap --node %s %s", g.Description, addr, g.ID),
 						State:       state.StatusNotStarted,
 					})
 					nextNum++

--- a/internal/daemon/iteration.go
+++ b/internal/daemon/iteration.go
@@ -681,7 +681,7 @@ func (d *Daemon) createRemediationSubtasks(nodeAddr, taskID string) int {
 			}
 			ns.Tasks = append(ns.Tasks, state.Task{
 				ID:          childID,
-				Description: fmt.Sprintf("Fix: %s", g.Description),
+				Description: fmt.Sprintf("Fix: %s\n\nAfter fixing, close the gap:\n  wolfcastle audit fix-gap --node %s %s", g.Description, nodeAddr, g.ID),
 				State:       state.StatusNotStarted,
 			})
 			nextNum++


### PR DESCRIPTION
## Summary

Remediation subtasks told the model what to fix but not to close the gap afterward. The audit re-ran, found the gap still open, created another subtask, infinite loop. Now the subtask description includes the exact `wolfcastle audit fix-gap --node <addr> <gap-id>` command.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/daemon/` passes
- [ ] Start daemon with a node that has an open gap, verify the remediation subtask description includes the fix-gap command