### PR TITLE
Require --description in intake and planning prompts

### DIFF
--- a/internal/project/templates/prompts/stages/intake.md
+++ b/internal/project/templates/prompts/stages/intake.md
@@ -107,6 +107,7 @@ For each inbox item provided below:
 ## Rules
 
 - Always use `--json` flag with wolfcastle commands.
+- Every `project create` MUST include `--description`. The description is the primary context for execution and auditing. Use the inbox item's text as the basis. A project without a description is useless to the agents that work on it.
 - Create projects at the root level unless there is a clear parent-child relationship.
 - Before creating a new root-level project, check if the work belongs under an existing project.
 - Do not create duplicate projects. Check the item descriptions carefully.


### PR DESCRIPTION
## Summary

The model was creating projects without `--description`, leaving placeholder text in node markdown files. Three prompt changes:

- **Intake prompt**: added hard rule that every `project create` MUST include `--description`, using the inbox item's text as the basis
- **Planning prompt** (PR #100): added `--description` to orchestrator and leaf examples, plus a guardrail forbidding the placeholder
- **Execute prompt** (PR #99): deletion safety and validation rigor (included in this branch)

## Test plan

- [ ] `go build ./...` passes
- [ ] Start daemon with inbox items, verify all created nodes have descriptions