### PR TITLE
Planning prompts: tasks on direct leaves only, not grandchildren

### DIFF
--- a/internal/project/templates/prompts/stages/plan-amend.md
+++ b/internal/project/templates/prompts/stages/plan-amend.md
@@ -15,7 +15,7 @@ Determine where the new work fits:
 
 ### C. Amend
 Make changes using wolfcastle CLI commands:
-- Create new children with `wolfcastle project create`. Do NOT use `wolfcastle task add`; the execution agent creates tasks.
+- Create new children with `wolfcastle project create`. Add tasks to direct leaf children with `wolfcastle task add`. Do NOT add tasks to child orchestrators or grandchildren.
 - Amend unstarted tasks with `wolfcastle task amend`.
 - Do not modify in-progress or complete tasks.
 - Do not modify children of child orchestrators. If a child orchestrator needs to absorb this scope, note it in the breadcrumb; the daemon will route it.

--- a/internal/project/templates/prompts/stages/plan-initial.md
+++ b/internal/project/templates/prompts/stages/plan-initial.md
@@ -27,13 +27,20 @@ wolfcastle project create "<name>" --node <your-node> --type orchestrator \
   --description "What this orchestrator covers and why it exists as a group"
 ```
 
-**Leaf node** (for concrete, implementable work):
+**Leaf with tasks** (for concrete, implementable work):
 ```
 wolfcastle project create "<name>" --node <your-node> --type leaf \
-  --description "What this leaf delivers. Include enough detail that the execution agent can create its own tasks without guessing."
+  --description "What this leaf delivers and how it fits into the parent's scope"
+wolfcastle task add --node <your-node>/<leaf-name> "task title" \
+  --body "detailed description" \
+  --type implementation \
+  --deliverable "path/to/file" \
+  --acceptance "tests pass" \
+  --constraint "do not modify X" \
+  --reference "docs/specs/some-spec.md"
 ```
 
-Do NOT call `wolfcastle task add` on child nodes. You create structure. The execution agent creates tasks when it runs on each leaf. Your job is to write a description detailed enough that the executor knows what to build, what files to touch, and what constraints to follow.
+You MUST add tasks to your direct leaf children. Leaves without tasks are dead ends. However, do NOT add tasks to child orchestrators or to any node deeper than your direct children. Each orchestrator plans its own subtree.
 
 Set success criteria for this orchestrator:
 ```
@@ -61,14 +68,17 @@ Emit WOLFCASTLE_BLOCKED if the scope cannot be planned (missing information not 
 - If you have more than 4 direct children, group related work under sub-orchestrators. Each sub-orchestrator gets its own audit pass, which makes verification more targeted than one audit covering everything. Prefer 2-4 children per orchestrator with sub-orchestrators over 5-10 flat children.
 - Maximum 8 tasks per leaf. If a leaf needs more, split into multiple leaves.
 - **Create children in execution order.** The daemon executes depth-first in creation order. The first child you create runs first. Spec leaves before implementation leaves. Discovery before specs.
-- **Specs before implementation.** If the work defines new types, interfaces, or contracts, create a spec-writing leaf BEFORE the implementation leaves. The spec leaf's description should say what contract to define. The implementation leaf's description should reference the spec. Without a spec, the audit will flag a missing contract and trigger remediation.
-- Every `project create` must have a `--description` explaining what the node covers. The description is the primary context for execution and auditing. Write enough detail that the execution agent can create its own tasks without guessing. "Project description goes here" is never acceptable.
-- If you found relevant specs in `.wolfcastle/docs/specs/` during the Study phase, mention them in the child's `--description` so the executor knows to read them.
+- **Specs before implementation.** If the work defines new types, interfaces, or contracts, create a spec-writing leaf BEFORE the implementation leaves. The spec leaf should have a task that writes the spec via `wolfcastle spec create`. Implementation leaves should reference the spec with `--reference`.
+- Every `project create` must have a `--description` explaining what the node covers. "Project description goes here" is never acceptable.
+- Every task must have a `--body` with concrete details. One-line descriptions are not acceptable.
+- Every implementation task must have at least one `--deliverable`.
+- If you found relevant specs in `.wolfcastle/docs/specs/` during the Study phase, add `--reference "path/to/spec.md"` to tasks that depend on them.
+- Maximum 8 tasks per leaf. If a leaf needs more, split into multiple leaves.
 
 ## Rules
 
-- You create structure, not tasks. Use `wolfcastle project create` to make children. Do NOT use `wolfcastle task add`. The execution agent creates tasks when it runs on each leaf.
-- **Only create YOUR direct children.** If you create a child orchestrator, set its `--description` and stop. Do not create that orchestrator's children. Each orchestrator plans its own level when its turn comes.
+- You create structure and define tasks for your direct leaf children. Use `wolfcastle project create` for children, `wolfcastle task add` for tasks on YOUR leaves only.
+- **Only create YOUR direct children.** If you create a child orchestrator, set its `--description` and stop. Do not create that orchestrator's children or add tasks to its leaves. Each orchestrator plans its own level when its turn comes. If you reach into grandchildren, you're taking decisions that belong to a lower-level planner with better context.
 - You may read any file in the codebase to inform your planning.
-- Do not call wolfcastle task add, task claim, task complete, or task block.
+- Do not call wolfcastle task claim, task complete, or task block.
 - Always emit exactly one terminal marker: WOLFCASTLE_COMPLETE or WOLFCASTLE_BLOCKED.

--- a/internal/project/templates/prompts/stages/plan-remediate.md
+++ b/internal/project/templates/prompts/stages/plan-remediate.md
@@ -19,7 +19,7 @@ Determine the remediation strategy:
 
 ### C. Execute
 Apply the strategy using wolfcastle CLI commands:
-- Create new leaves: `wolfcastle project create` (do NOT use `wolfcastle task add`; the execution agent creates tasks)
+- Create new leaves with `wolfcastle project create` and add tasks with `wolfcastle task add`. Do NOT add tasks to child orchestrators or grandchildren.
 - Amend unstarted tasks: `wolfcastle task amend`
 - Block yourself: `wolfcastle task block --node <your-node> "reason"` (only if escalating)
 

--- a/internal/project/templates/prompts/stages/plan-review.md
+++ b/internal/project/templates/prompts/stages/plan-review.md
@@ -19,7 +19,7 @@ Check the codebase:
 If all success criteria are met and no gaps exist, this orchestrator's work is done.
 
 If gaps exist:
-- Create new leaves to address them using `wolfcastle project create`. Do NOT use `wolfcastle task add`; the execution agent creates tasks.
+- Create new leaves with `wolfcastle project create` and add tasks with `wolfcastle task add`. Do NOT add tasks to child orchestrators or grandchildren.
 - Update success criteria if the scope has evolved: `wolfcastle orchestrator criteria --node <your-node> "updated criterion"`.
 
 ### D. Record


### PR DESCRIPTION
## Summary

PR #106 banned all task creation by planners, which caused leaves with no tasks (dead ends the daemon can't execute).

The correct rule: planners MUST create tasks on direct leaf children, but MUST NOT add tasks to child orchestrators or anything deeper. Each orchestrator plans its own subtree.

Restored `task add` in examples and guardrails across all four planning prompts.

## Test plan

- [ ] `go build ./...` passes
- [ ] Start daemon with inbox items, verify planner creates leaves WITH tasks
- [ ] Verify planner does NOT add tasks to child orchestrators