### PR TITLE
Status: timeline sort (complete above active above pending)

### DIFF
--- a/cmd/daemon/status.go
+++ b/cmd/daemon/status.go
@@ -291,9 +291,11 @@ func printNodeTree(app *cmdutil.App, idx *state.RootIndex, details map[string]*n
 		output.PrintHuman("%s  breadcrumb: %s", indent, text)
 	}
 
-	// For orchestrators, print children in creation order (which is execution order)
+	// For orchestrators, print children as a timeline: completed work
+	// at top (past), active work in middle (present), pending at bottom
+	// (future). Within each group, creation order is preserved.
 	if nd.entry.Type == state.NodeOrchestrator {
-		for _, childAddr := range nd.entry.Children {
+		for _, childAddr := range sortChildrenTimeline(nd.entry.Children, idx) {
 			printNodeTree(app, idx, details, childAddr, indent+"  ", expand, detail)
 		}
 		if nd.ns != nil {
@@ -643,6 +645,33 @@ func countDescendants(idx *state.RootIndex, addr string) int {
 		count += countDescendants(idx, child)
 	}
 	return count
+}
+
+// sortChildrenTimeline reorders children so completed nodes appear first
+// (they finished in the past), then in-progress/blocked (happening now),
+// then not-started (future). Creation order preserved within each group.
+func sortChildrenTimeline(children []string, idx *state.RootIndex) []string {
+	sorted := make([]string, len(children))
+	copy(sorted, children)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return timelinePriority(idx.Nodes[sorted[i]].State) < timelinePriority(idx.Nodes[sorted[j]].State)
+	})
+	return sorted
+}
+
+func timelinePriority(s state.NodeStatus) int {
+	switch s {
+	case state.StatusComplete:
+		return 0
+	case state.StatusInProgress:
+		return 1
+	case state.StatusBlocked:
+		return 2
+	case state.StatusNotStarted:
+		return 3
+	default:
+		return 4
+	}
 }
 
 // isInSubtree checks whether addr is the scope node or a descendant of it.


### PR DESCRIPTION
## Summary

The daemon doesn't execute siblings in creation order when some are orchestrators (needing planning) and others are leaves (ready to execute). Leaves run first while orchestrators wait for planning. Completed siblings were showing below in-progress ones because creation order didn't match completion order.

Timeline sort: complete(0), in_progress(1), blocked(2), not_started(3). Creation order preserved within each group. The display now reads chronologically: past at top, present in middle, future at bottom.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./cmd/daemon/` passes
- [ ] Completed siblings appear above in-progress siblings in status output