### PR TITLE
Post-release docs: status block position, abbreviation expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,34 @@
 
 You give Wolfcastle a goal. It breaks that goal into a tree of targets and sends AI coding agents to destroy them, depth-first, until the tree is conquered. While you do whatever it is you do.
 
+## Status
+
+[![CI](https://github.com/dorkusprime/wolfcastle/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/dorkusprime/wolfcastle/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/dorkusprime/wolfcastle/actions/workflows/codeql.yml/badge.svg)](https://github.com/dorkusprime/wolfcastle/actions/workflows/codeql.yml)
+[![codecov](https://codecov.io/gh/dorkusprime/wolfcastle/branch/main/graph/badge.svg)](https://codecov.io/gh/dorkusprime/wolfcastle)
+[![Go Report Card](https://goreportcard.com/badge/github.com/dorkusprime/wolfcastle)](https://goreportcard.com/report/github.com/dorkusprime/wolfcastle)
+[![Go Reference](https://pkg.go.dev/badge/github.com/dorkusprime/wolfcastle.svg)](https://pkg.go.dev/github.com/dorkusprime/wolfcastle)
+[![Go version](https://img.shields.io/github/go-mod/go-version/dorkusprime/wolfcastle)](https://go.dev/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Release](https://img.shields.io/github/v/release/dorkusprime/wolfcastle?include_prereleases)](https://github.com/dorkusprime/wolfcastle/releases)
+
+Pre-release. Probably broken. Then fixed. Then broken again. On repeat until release. Install if you're feeling brave:
+
+```bash
+brew install dorkusprime/tap/wolfcastle
+cd your-repo
+wolfcastle init                                            # scaffold .wolfcastle/
+wolfcastle inbox add "Build a website for my donut stand"  # queue up work
+wolfcastle start                                           # the daemon wakes up
+
+# in another terminal:
+wolfcastle status -w                                       # watch it work
+```
+
+`init` creates the `.wolfcastle/` directory with config, prompts, and state scaffolding. `inbox add` queues a feature request for the daemon to decompose into projects and tasks. `start` launches the daemon, which runs the full pipeline until there's nothing left to do. `status` shows you what's happening.
+
+Feed it work through the [CLI](docs/humans/cli.md) or let your coding agent inject work directly. The [daemon](docs/humans/how-it-works.md#the-daemon) takes it from there: triage, planning, execution, audit, commit. Serial, depth-first, until the [tree](docs/humans/how-it-works.md#the-project-tree) is conquered or something gets in the way.
+
 ## Why This Exists
 
 Coding agents are remarkably good at writing specs and following specs. Where they struggle is the middle: deciding what to build, building it, and maintaining quality across dozens of tasks without human intervention. Not because the models aren't capable, but because the scaffolding around them wasn't designed for sustained, unsupervised work.
@@ -58,34 +86,6 @@ The tree grows at runtime. Tasks that fail [decompose](docs/humans/failure-and-r
 
 Everything is deterministic except the model's output. State, specs, ADRs, AARs, breadcrumbs, and audit findings all live as [files on disk](docs/humans/how-it-works.md#distributed-state). Nothing important stays in memory. Every decision, every lesson, every result persists across invocations, restarts, and crashes. The model handles what models are good at: reading code, writing code, making judgment calls. [CLI scripts](docs/humans/cli.md) handle what's deterministic: state transitions, propagation, validation, navigation. Neither does the other's job.
 
-## Status
-
-[![CI](https://github.com/dorkusprime/wolfcastle/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/dorkusprime/wolfcastle/actions/workflows/ci.yml)
-[![CodeQL](https://github.com/dorkusprime/wolfcastle/actions/workflows/codeql.yml/badge.svg)](https://github.com/dorkusprime/wolfcastle/actions/workflows/codeql.yml)
-[![codecov](https://codecov.io/gh/dorkusprime/wolfcastle/branch/main/graph/badge.svg)](https://codecov.io/gh/dorkusprime/wolfcastle)
-[![Go Report Card](https://goreportcard.com/badge/github.com/dorkusprime/wolfcastle)](https://goreportcard.com/report/github.com/dorkusprime/wolfcastle)
-[![Go Reference](https://pkg.go.dev/badge/github.com/dorkusprime/wolfcastle.svg)](https://pkg.go.dev/github.com/dorkusprime/wolfcastle)
-[![Go version](https://img.shields.io/github/go-mod/go-version/dorkusprime/wolfcastle)](https://go.dev/)
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Release](https://img.shields.io/github/v/release/dorkusprime/wolfcastle?include_prereleases)](https://github.com/dorkusprime/wolfcastle/releases)
-
-Pre-release. Probably broken. Then fixed. Then broken again. On repeat until release. Install if you're feeling brave:
-
-```bash
-brew install dorkusprime/tap/wolfcastle
-cd your-repo
-wolfcastle init                                            # scaffold .wolfcastle/
-wolfcastle inbox add "Build a website for my donut stand"  # queue up work
-wolfcastle start                                           # the daemon wakes up
-
-# in another terminal:
-wolfcastle status -w                                       # watch it work
-```
-
-`init` creates the `.wolfcastle/` directory with config, prompts, and state scaffolding. `inbox add` queues a feature request for the daemon to decompose into projects and tasks. `start` launches the daemon, which runs the full pipeline until there's nothing left to do. `status` shows you what's happening.
-
-Feed it work through the [CLI](docs/humans/cli.md) or let your coding agent inject work directly. The [daemon](docs/humans/how-it-works.md#the-daemon) takes it from there: triage, planning, execution, audit, commit. Serial, depth-first, until the [tree](docs/humans/how-it-works.md#the-project-tree) is conquered or something gets in the way.
-
 ## Configuration
 
 Config [merges across three tiers](docs/humans/configuration.md#three-tiers): base (defaults, gitignored), custom (team-shared, committed), local (personal, gitignored). Manage it through [`wolfcastle config`](docs/humans/cli/config-show.md) commands or edit the JSON directly.
@@ -110,7 +110,7 @@ Wolfcastle turns tokens into code. It uses a lot of them. Every planning pass, e
 ## More
 
 - [53 CLI commands](docs/humans/cli.md)
-- [Architecture Decision Records](docs/decisions/INDEX.md) (79 and counting)
+- [Architecture Decision Records](docs/decisions/INDEX.md) (89 and counting)
 - [Specifications](docs/specs/)
 - [Developer guides](docs/agents/)
 - [AGENTS.md](AGENTS.md)

--- a/docs/humans/configuration.md
+++ b/docs/humans/configuration.md
@@ -67,7 +67,7 @@ The [daemon](how-it-works.md#the-daemon) runs a pipeline of stages. Stages are d
 
 The dict format lets you override a single stage's model or prompt file from a higher [tier](#three-tiers) without rewriting the entire stages array. `stage_order` controls which stages run and in what sequence; omit it to run all stages in map-iteration order. Each stage can be individually disabled by setting `"enabled": false`.
 
-The intake stage runs in a parallel goroutine, watching the inbox for new items and filing them into the tree. The execute stage runs in the main loop, claiming tasks and invoking models. Summaries are generated inline during execute via the `WOLFCASTLE_SUMMARY:` marker (ADR-036), not as a separate stage.
+The intake stage runs in a parallel goroutine, watching the inbox for new items and filing them into the tree. The execute stage runs in the main loop, claiming tasks and invoking models. Summaries are generated inline during execute via the `WOLFCASTLE_SUMMARY:` marker ([Architecture Decision Record](../decisions/INDEX.md) ADR-036), not as a separate stage.
 
 ## Identity
 

--- a/docs/humans/how-it-works.md
+++ b/docs/humans/how-it-works.md
@@ -91,7 +91,7 @@ At the start of each daemon iteration, the daemon reconciles every orchestrator'
 
 ## Auto-Archive
 
-When a root-level project completes, the daemon can automatically archive it. Auto-archive runs inline in the main daemon loop (ADR-064), after the execute and planning stages find nothing to do. The daemon polls for eligible nodes at a configurable interval, and each completed project must sit idle for a configurable delay (default 24 hours) before archival triggers. One node is archived per poll cycle, generating an archive rollup entry and moving the project tree to archived state. Archived nodes can be restored or permanently deleted via the CLI. The feature is disabled by default; enable it in [configuration](configuration.md):
+When a root-level project completes, the daemon can automatically archive it. Auto-archive runs inline in the main daemon loop ([Architecture Decision Record](../decisions/INDEX.md) ADR-064), after the execute and planning stages find nothing to do. The daemon polls for eligible nodes at a configurable interval, and each completed project must sit idle for a configurable delay (default 24 hours) before archival triggers. One node is archived per poll cycle, generating an archive rollup entry and moving the project tree to archived state. Archived nodes can be restored or permanently deleted via the CLI. The feature is disabled by default; enable it in [configuration](configuration.md):
 
 ```json
 {


### PR DESCRIPTION
## Summary

- Move Status section (badges, quickstart, install) above "Why This Exists" in README
- Expand first ADR occurrence in `configuration.md` and `how-it-works.md` with full name and link
- Update ADR count from 79 to 89 in "More" section

## Test plan

- [x] Doc-only change