### PR TITLE
Strict sibling ordering: DFS stops at incomplete siblings

### DIFF
--- a/internal/state/navigation.go
+++ b/internal/state/navigation.go
@@ -84,10 +84,9 @@ func dfs(idx *RootIndex, addr string, loadNode func(addr string) (*NodeState, er
 	}
 
 	if entry.Type == NodeOrchestrator {
-		// Traverse children in order. If an earlier child needs planning
-		// (orchestrator with no children), stop: don't skip ahead to
-		// later siblings that might have executable tasks. This ensures
-		// creation order is respected as execution order.
+		// Traverse children strictly in creation order. If an earlier
+		// child is incomplete, do not skip to later siblings. This
+		// enforces the creation-order-equals-execution-order contract.
 		for _, childAddr := range entry.Children {
 			childEntry, childOk := idx.Nodes[childAddr]
 			if !childOk {
@@ -109,6 +108,11 @@ func dfs(idx *RootIndex, addr string, loadNode func(addr string) (*NodeState, er
 			if result != nil && result.Found {
 				return result, nil
 			}
+			// If DFS found nothing actionable in this incomplete child,
+			// stop. Don't skip to later siblings. The child has work
+			// that needs planning or unblocking before later siblings
+			// can proceed.
+			return nil, nil
 		}
 		// Children exhausted — check orchestrator's own tasks (e.g. audit)
 		return findActionableTask(addr, loadNode)


### PR DESCRIPTION
## Summary

DFS no longer skips to later sibling leaves when an earlier sibling is incomplete. If an earlier child has unfinished work (needs planning, has in-progress children, or returned no actionable tasks), later siblings wait. This enforces the creation-order-equals-execution-order contract.

Previously, only unplanned orchestrators (no children) blocked later siblings. Orchestrators with planned but incomplete children were skipped, allowing later leaf siblings to execute out of order.

## Test plan

- [x] `go test ./internal/state/... ./internal/daemon/...` passes
- [x] Binary installed for live testing