### PR TITLE
Skip .archive/ in orphan definition scan

### DIFF
--- a/internal/validate/coverage_test.go
+++ b/internal/validate/coverage_test.go
@@ -127,6 +127,27 @@ func TestCheckOrphanedDefinitions_KnownNodeNotFlagged(t *testing.T) {
 	}
 }
 
+func TestCheckOrphanedDefinitions_ArchiveSkipped(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	idx := state.NewRootIndex()
+
+	archiveDir := filepath.Join(dir, ".archive", "old-project")
+	_ = os.MkdirAll(archiveDir, 0755)
+	_ = os.WriteFile(filepath.Join(archiveDir, "old-project.md"), []byte("archived"), 0644)
+	_ = os.WriteFile(filepath.Join(archiveDir, "audit.md"), []byte("archived audit"), 0644)
+
+	engine := NewEngine(dir, DefaultNodeLoader(dir))
+	report := &Report{}
+	engine.checkOrphanedDefinitions(idx, report)
+
+	for _, issue := range report.Issues {
+		if issue.Category == CatOrphanDefinition {
+			t.Errorf("archived .md files should not produce ORPHAN_DEFINITION, got: %s", issue.Node)
+		}
+	}
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // FixWithVerification — multi-pass convergence
 // ═══════════════════════════════════════════════════════════════════════════

--- a/internal/validate/engine.go
+++ b/internal/validate/engine.go
@@ -672,6 +672,9 @@ func (e *Engine) checkOrphanedDefinitions(idx *state.RootIndex, report *Report) 
 		if err != nil {
 			return nil
 		}
+		if info.IsDir() && info.Name() == ".archive" {
+			return filepath.SkipDir
+		}
 		if !strings.HasSuffix(info.Name(), ".md") || info.IsDir() {
 			return nil
 		}


### PR DESCRIPTION
## Summary

- `checkOrphanedDefinitions` now skips `.archive/` directories, matching the existing behavior of `checkOrphanedStateFiles`
- Eliminates 552 false-positive ORPHAN_DEFINITION warnings from archived project artifacts

## Context

The orphan definition scan walks the project tree looking for `.md` files without corresponding index entries. Archived nodes live under `.archive/` and are intentionally absent from the active index. The state file scanner already skipped `.archive/`; the definition scanner didn't.

## Test plan

- [x] New test: `TestCheckOrphanedDefinitions_ArchiveSkipped`
- [x] Existing orphan detection tests still pass
- [x] `make test` all green