### PR TITLE
Restore truncation for breadcrumbs and task body

### DIFF
--- a/cmd/daemon/status.go
+++ b/cmd/daemon/status.go
@@ -323,7 +323,7 @@ func printNodeTree(app *cmdutil.App, idx *state.RootIndex, details map[string]*n
 	// Show most recent breadcrumb for in_progress nodes when --detail is set.
 	if detail && nd.ns != nil && nd.entry.State == state.StatusInProgress && len(nd.ns.Audit.Breadcrumbs) > 0 {
 		bc := nd.ns.Audit.Breadcrumbs[len(nd.ns.Audit.Breadcrumbs)-1]
-		text := bc.Text
+		text := truncate(bc.Text, 120)
 		output.PrintHuman("%s  breadcrumb: %s", indent, text)
 	}
 
@@ -445,7 +445,7 @@ func printNodeTree(app *cmdutil.App, idx *state.RootIndex, details map[string]*n
 		// Detail-only lines: task body
 		if detail {
 			if t.Body != "" {
-				output.PrintHuman("%s       %s", taskIndent, t.Body)
+				output.PrintHuman("%s       %s", taskIndent, truncate(t.Body, 120))
 			}
 		}
 	}
@@ -469,7 +469,17 @@ func printNodeTree(app *cmdutil.App, idx *state.RootIndex, details map[string]*n
 	}
 }
 
-// truncate shortens s to maxLen characters, appending "..." if truncated.
+func truncate(s string, maxLen int) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	if len(s) <= maxLen {
+		return s
+	}
+	if maxLen <= 3 {
+		return s[:maxLen]
+	}
+	return s[:maxLen-3] + "..."
+}
+
 // ANSI color codes matching the TUI spec (section 2.9).
 const (
 	colorGreen  = "\033[32m"

--- a/cmd/daemon/status_test.go
+++ b/cmd/daemon/status_test.go
@@ -1278,3 +1278,23 @@ func TestIsInSubtree_NestedHierarchy(t *testing.T) {
 		t.Error("nonexistent should not be in subtree of a")
 	}
 }
+
+func TestTruncate(t *testing.T) {
+	cases := []struct {
+		in     string
+		maxLen int
+		want   string
+	}{
+		{"short", 80, "short"},
+		{"exactly ten", 11, "exactly ten"},
+		{"this is a longer string that should be truncated", 20, "this is a longer ..."},
+		{"ab", 1, "a"},
+		{"line one\nline two", 80, "line one line two"},
+	}
+	for _, tc := range cases {
+		got := truncate(tc.in, tc.maxLen)
+		if got != tc.want {
+			t.Errorf("truncate(%q, %d) = %q, want %q", tc.in, tc.maxLen, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Restore `truncate` helper, bumped from 80 to 120 chars
- Breadcrumbs and task body in `--detail` mode are truncated again
- Restored `TestTruncate`

Reverts the truncation removal from #143 after seeing real-world output was too long.