### PR TITLE
Respect commit prefix in state flush commits

### DIFF
--- a/internal/daemon/iteration.go
+++ b/internal/daemon/iteration.go
@@ -648,7 +648,11 @@ func commitStateFlush(repoDir string, logger *logging.Logger, gitCfg config.GitC
 		return
 	}
 
-	commitArgs := []string{"commit", "-m", "wolfcastle: update project state"}
+	msg := "update project state"
+	if gitCfg.CommitPrefix != "" {
+		msg = gitCfg.CommitPrefix + ": " + msg
+	}
+	commitArgs := []string{"commit", "-m", msg}
 	if gitCfg.SkipHooksOnAutoCommit {
 		commitArgs = append(commitArgs, "--no-verify")
 	}


### PR DESCRIPTION
## Summary

- `commitStateFlush` hardcoded `"wolfcastle: update project state"` instead of using the configured `CommitPrefix`
- When prefix is empty, state flush commits now omit the colon+space, producing just `"update project state"`

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/daemon/` passes
- [ ] CI green