### PR TITLE
Fix orchestrator completion review and strengthen audit test mandate

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -660,14 +660,9 @@ execute:
 		return IterationError, nil
 	}
 
-	// After task completion, check if any orchestrator needs re-planning.
-	// Re-read the index since the iteration may have changed node states.
-	if d.Config.Pipeline.Planning.Enabled {
-		freshIdx, readErr := d.Store.ReadIndex()
-		if readErr == nil {
-			d.checkReplanningTriggers(navResult.NodeAddress, navResult.TaskID, freshIdx)
-		}
-	}
+	// Replanning triggers are now checked inside runIteration, before
+	// propagation marks parent orchestrators complete. This ensures
+	// findPlanningTarget can still find the orchestrator on the next pass.
 
 	// If a spec task just completed, queue a review task so the spec
 	// gets audited before it drives implementation.

--- a/internal/daemon/iteration.go
+++ b/internal/daemon/iteration.go
@@ -229,6 +229,8 @@ func (d *Daemon) runIteration(ctx context.Context, nav *state.NavigationResult, 
 			}); err != nil {
 				_ = d.Logger.Log(map[string]any{"type": "save_error", "error": err.Error()})
 			}
+			// Check replanning triggers before propagation (see COMPLETE path).
+			d.checkReplanningTriggers(nav.NodeAddress, nav.TaskID, idx)
 			// Propagate blocked state so parent orchestrators can detect
 			// the block and trigger remediation planning.
 			if err := d.propagateState(nav.NodeAddress, state.StatusBlocked, idx); err != nil {
@@ -246,6 +248,8 @@ func (d *Daemon) runIteration(ctx context.Context, nav *state.NavigationResult, 
 			if !d.Config.Pipeline.Planning.Enabled {
 				d.autoCompleteDecomposedParents(nav.NodeAddress)
 			}
+			// Check replanning triggers before propagation (see COMPLETE path).
+			d.checkReplanningTriggers(nav.NodeAddress, nav.TaskID, idx)
 			// Propagate completion up through parent orchestrators so their
 			// persisted state derives from children. MutateNode propagates
 			// internally, but re-propagating here updates the in-memory idx
@@ -371,6 +375,12 @@ func (d *Daemon) runIteration(ctx context.Context, nav *state.NavigationResult, 
 			if !d.Config.Pipeline.Planning.Enabled {
 				d.autoCompleteDecomposedParents(nav.NodeAddress)
 			}
+			// Check replanning triggers BEFORE propagation. Propagation may
+			// mark the parent orchestrator complete, after which the planning
+			// DFS skips it. The trigger must be set while the parent is still
+			// in_progress so findPlanningTarget can find it.
+			d.checkReplanningTriggers(nav.NodeAddress, nav.TaskID, idx)
+
 			// Propagate completion up through parent orchestrators so their
 			// persisted state derives from children. MutateNode propagates
 			// internally, but re-propagating here updates the in-memory idx

--- a/internal/project/templates/prompts/stages/execute.md
+++ b/internal/project/templates/prompts/stages/execute.md
@@ -35,7 +35,7 @@ Procedure:
 2. **Open each deliverable file.** Read it. If a deliverable file does not exist, record a gap. If a task has no deliverables listed, infer them from the task description and AARs: what files should this task have created or modified? Open those files and verify the work was done.
 3. **Verify each acceptance criterion against the actual file contents.** Do not trust breadcrumbs, AARs, or task completion status. The file is the source of truth. If a task has no acceptance criteria, derive them from the task description: what would "done" look like in the actual files?
 4. **For removal tasks** (tasks that say "remove X," "delete X," or "clean up X"), grep the codebase for the thing that should be gone. If it's still there, record a gap.
-5. **Run the project's build/test commands** (e.g., `go build ./...` and `go test ./...`, or `npm run build`). If either fails, record a gap.
+5. **Run both the build AND the test suite.** For example: `go build ./...` AND `go test ./...`, or `npm run build` AND `npm test`. You must run both commands. If you only ran the build, step 5 is incomplete. If any test fails, record a gap. Do not dismiss failures as "pre-existing" or "unrelated." You cannot verify that claim without checking out the parent branch, which you cannot do. Record every failure. The orchestrator review and remediation system will triage whether a failure is new.
 6. **Check enrichment criteria.** If the audit task has enrichment checks (shown in the audit context below), verify each one.
 
 Record a breadcrumb summarizing what you verified and what you found. Then emit WOLFCASTLE_COMPLETE. If you recorded any gaps, the daemon will create remediation tasks automatically.


### PR DESCRIPTION
## Summary

Two bugs found during a live daemon run on Go modernization tasks:

- **Orchestrator completion review never fired.** `propagateState` marked the parent `StatusComplete` before `checkReplanningTriggers` set `NeedsPlanning`. On the next pass, `findPlanningTarget` skipped complete nodes, so the review was stranded. Fix: move `checkReplanningTriggers` into `runIteration` before each `propagateState` call (COMPLETE, SKIP, BLOCKED paths). Remove the duplicate post-iteration call in `daemon.go`.

- **Audit skipped the test suite and dismissed failures.** The audit model ran `go build` but not `go test`, then declared test failures "pre-existing" without evidence. Fix: strengthen execute.md audit step 5 to require both build and test, prohibit dismissing failures as pre-existing.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race ./...` all pass
- [ ] CI green