### PR TITLE
Fix stale doc counts, broken link, and missing ADR amendment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,8 +41,8 @@ Entries should be concrete, durable, and non-obvious. "The config loader silentl
 
 ## Design References
 
-- [Architecture Decision Records](docs/decisions/INDEX.md) (89 ADRs) document every major design choice. Consult these before making architectural decisions.
-- [Specifications](docs/specs/) (38 specs) describe the current system in detail. Consult these before modifying behavior.
+- [Architecture Decision Records](docs/decisions/INDEX.md) (94 ADRs) document every major design choice. Consult these before making architectural decisions.
+- [Specifications](docs/specs/) (43 specs) describe the current system in detail. Consult these before modifying behavior.
 - [Full documentation hub](docs/)
 
 ## Critical Rules

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Wolfcastle turns tokens into code. It uses a lot of them. Every planning pass, e
 
 ## More
 
-- [60 CLI commands](docs/humans/cli.md)
+- [59 CLI commands](docs/humans/cli.md)
 - [Architecture Decision Records](docs/decisions/INDEX.md) (94 and counting)
 - [Specifications](docs/specs/)
 - [Developer guides](docs/agents/)

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -38,7 +38,7 @@ wolfcastle/
 │   ├── tree/                # Tree addressing, slug generation, resolver
 │   └── validate/            # Structural validation engine and auto-fix
 ├── docs/
-│   ├── decisions/           # ADRs (001-089)
+│   ├── decisions/           # ADRs (001-094)
 │   ├── specs/               # Implementation specs (timestamped)
 │   └── agents/              # This directory (agent guidance)
 └── Makefile

--- a/docs/decisions/021-cli-command-surface.md
+++ b/docs/decisions/021-cli-command-surface.md
@@ -93,3 +93,7 @@ Wolfcastle needs a complete, consistent set of CLI commands that serve three aud
 - All state-mutating commands are deterministic and testable
 - The surface is intentionally minimal: new commands can be added as needs arise during implementation
 - Additional commands added in later ADRs: `wolfcastle doctor` (ADR-025), `wolfcastle install <target>` (ADR-026), `wolfcastle unblock` (ADR-028), `wolfcastle spec create/link/list` (ADR-031). See the CLI commands spec for the complete reference.
+
+## Amendment (2026-03-23)
+
+**ADR-073** renamed `wolfcastle follow` to `wolfcastle log`. The old name is preserved as a hidden alias. The lifecycle commands table above reflects the original design; the current command name is `wolfcastle log`.

--- a/docs/specs/2026-03-12T00-01Z-config-schema.md
+++ b/docs/specs/2026-03-12T00-01Z-config-schema.md
@@ -983,7 +983,7 @@ The following validation is performed when config is loaded:
 
 ## Related Specs
 
-- [Dict-Format Pipeline Stages](.wolfcastle/docs/specs/2026-03-21T03-11Z-dict-format-stages.md): defines the `pipeline.stages` map schema, `stage_order` semantics, merge behavior, validation rules, and migration contract. The config schema above implements that specification.
+- [Dict-Format Pipeline Stages](2026-03-21T03-11Z-dict-format-stages.md): defines the `pipeline.stages` map schema, `stage_order` semantics, merge behavior, validation rules, and migration contract. The config schema above implements that specification.
 
 ---
 


### PR DESCRIPTION
## Summary

Full 13-section audit of the codebase. Everything passed except five documentation drift issues, all fixed here:

- README claimed 60 CLI commands; actual count is 59
- AGENTS.md listed 89 ADRs and 38 specs; actual counts are 94 and 43
- architecture.md showed ADR range 001-089; corrected to 001-094
- config-schema spec had a broken cross-reference link to dict-format-stages
- ADR-021 was missing an amendment noting the `follow` → `log` rename from ADR-073

## Test plan

- [x] `go build ./...` passes
- [x] `go test -race ./...` passes (31 packages)
- [x] All changes are documentation-only; no behavioral impact