### PR TITLE
Skip dirty-tree confirmation in background mode

### DIFF
--- a/cmd/daemon/start.go
+++ b/cmd/daemon/start.go
@@ -81,8 +81,10 @@ Examples:
 
 			// Check for uncommitted changes before the daemon touches anything.
 			// Direct commits will sweep in whatever is in the working tree,
-			// so the user needs to know before we start.
-			if cfg.Git.AutoCommit {
+			// so the user needs to know before we start. Skip in background
+			// mode: the foreground process already confirmed with the user,
+			// and the re-exec has no TTY to prompt on.
+			if cfg.Git.AutoCommit && !background {
 				if dirty, reason := checkDirtyTree(repoDir); dirty {
 					output.PrintHuman("The working tree has uncommitted changes:\n%s", reason)
 					output.PrintHuman("")


### PR DESCRIPTION
## Summary

- `wolfcastle start -d` re-execs the binary as a detached background process
- The re-exec runs through the full startup sequence again, including the dirty-tree check
- `confirmContinue()` returns false when there's no TTY, so the background daemon silently aborts even though the user already confirmed in the foreground
- Fix: skip the dirty-tree check when `--daemon` is set

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./cmd/daemon/` passes
- [x] Verified: foreground `wolfcastle start` still prompts on dirty tree
- [x] Verified: `wolfcastle start -d` no longer aborts on dirty tree after foreground confirmation