### PR TITLE
Split daemon startup: _daemon-run for background re-exec

### DIFF
--- a/cmd/daemon/coverage_deep_test.go
+++ b/cmd/daemon/coverage_deep_test.go
@@ -429,25 +429,8 @@ func TestPrintNodeTree_OpenGapNonTerminal(t *testing.T) {
 // startBackground — PID write failure (read-only dir)
 // ═══════════════════════════════════════════════════════════════════════════
 
-func TestStartBackground_PIDWriteFailure(t *testing.T) {
-	if os.Getenv("CI") != "" {
-		t.Skip("skip in CI")
-	}
-	t.Parallel()
-	dir := t.TempDir()
-	wolfDir := filepath.Join(dir, ".wolfcastle")
-	sysDir := filepath.Join(wolfDir, "system")
-	_ = os.MkdirAll(sysDir, 0755)
-
-	// Create daemon.log writable, but make the PID write path fail
-	// by pre-creating wolfcastle.pid as a directory.
-	_ = os.MkdirAll(filepath.Join(sysDir, "wolfcastle.pid"), 0755)
-
-	err := startBackground(wolfDir, "", "", false, "sleep")
-	if err == nil {
-		t.Error("expected error when PID file cannot be written")
-	}
-}
+// TestStartBackground_PIDWriteFailure was removed: startBackground no
+// longer writes the PID file. The child _daemon-run process handles it.
 
 // ═══════════════════════════════════════════════════════════════════════════
 // recoverStaleDaemonState — read error on PID file (not ENOENT)

--- a/cmd/daemon/daemon_test.go
+++ b/cmd/daemon/daemon_test.go
@@ -746,18 +746,9 @@ func TestStartBackground_HappyPath(t *testing.T) {
 	_ = os.MkdirAll(filepath.Join(wolfDir, "system"), 0755)
 
 	// Use "sleep" as the child process; it starts and we release it.
-	err := startBackground(wolfDir, "", "", false, "sleep")
+	err := startBackground(wolfDir, "", false, false, "sleep")
 	if err != nil {
 		t.Fatalf("startBackground failed: %v", err)
-	}
-
-	// PID file should exist
-	pidData, err := os.ReadFile(filepath.Join(wolfDir, "system", "wolfcastle.pid"))
-	if err != nil {
-		t.Fatal("PID file should exist after startBackground")
-	}
-	if len(pidData) == 0 {
-		t.Error("PID file should not be empty")
 	}
 
 	// daemon.log should exist
@@ -773,22 +764,9 @@ func TestStartBackground_WithNodeScope(t *testing.T) {
 	_ = os.MkdirAll(wolfDir, 0755)
 	_ = os.MkdirAll(filepath.Join(wolfDir, "system"), 0755)
 
-	err := startBackground(wolfDir, "my-project", "", false, "sleep")
+	err := startBackground(wolfDir, "my-project", false, false, "sleep")
 	if err != nil {
 		t.Fatalf("startBackground with scope failed: %v", err)
-	}
-}
-
-func TestStartBackground_WithWorktree(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	wolfDir := filepath.Join(dir, ".wolfcastle")
-	_ = os.MkdirAll(wolfDir, 0755)
-	_ = os.MkdirAll(filepath.Join(wolfDir, "system"), 0755)
-
-	err := startBackground(wolfDir, "", "feature-branch", false, "sleep")
-	if err != nil {
-		t.Fatalf("startBackground with worktree failed: %v", err)
 	}
 }
 
@@ -799,7 +777,7 @@ func TestStartBackground_BadExecutable(t *testing.T) {
 	_ = os.MkdirAll(wolfDir, 0755)
 	_ = os.MkdirAll(filepath.Join(wolfDir, "system"), 0755)
 
-	err := startBackground(wolfDir, "", "", false, "/nonexistent/binary")
+	err := startBackground(wolfDir, "", false, false, "/nonexistent/binary")
 	if err == nil {
 		t.Error("expected error for nonexistent executable")
 	}
@@ -819,7 +797,7 @@ func TestStartBackground_LogDirNotWritable(t *testing.T) {
 	_ = os.Chmod(filepath.Join(wolfDir, "system"), 0555)
 	defer func() { _ = os.Chmod(filepath.Join(wolfDir, "system"), 0755) }()
 
-	err := startBackground(wolfDir, "", "", false, "sleep")
+	err := startBackground(wolfDir, "", false, false, "sleep")
 	if err == nil {
 		t.Error("expected error when log dir is not writable")
 	}

--- a/cmd/daemon/register.go
+++ b/cmd/daemon/register.go
@@ -40,8 +40,11 @@ func Register(app *cmdutil.App, rootCmd *cobra.Command) {
 	stopCmd.GroupID = "lifecycle"
 	logCmd.GroupID = "lifecycle"
 	statusCmd.GroupID = "lifecycle"
+	daemonRunCmd := newDaemonRunCmd(app)
+
 	rootCmd.AddCommand(startCmd)
 	rootCmd.AddCommand(stopCmd)
 	rootCmd.AddCommand(logCmd)
 	rootCmd.AddCommand(statusCmd)
+	rootCmd.AddCommand(daemonRunCmd)
 }

--- a/cmd/daemon/run.go
+++ b/cmd/daemon/run.go
@@ -1,0 +1,77 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+
+	"github.com/dorkusprime/wolfcastle/cmd/cmdutil"
+	dmn "github.com/dorkusprime/wolfcastle/internal/daemon"
+	"github.com/dorkusprime/wolfcastle/internal/output"
+	"github.com/dorkusprime/wolfcastle/internal/signals"
+	"github.com/spf13/cobra"
+)
+
+// newDaemonRunCmd creates the hidden _daemon-run command. This is the
+// background half of "wolfcastle start -d": no interactive checks, no
+// validation, no dirty-tree prompts. The foreground start command
+// handles all of that before re-execing into this command.
+func newDaemonRunCmd(app *cmdutil.App) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "_daemon-run",
+		Hidden: true,
+		Short:  "Internal: run the daemon loop (called by start -d)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			output.PrintHuman("wolfcastle %s", app.Version)
+			nodeScope, _ := cmd.Flags().GetString("node")
+			exitWhenDone, _ := cmd.Flags().GetBool("exit-when-done")
+			verbose, _ := cmd.Flags().GetBool("verbose")
+
+			cfg, err := app.Config.Load()
+			if err != nil {
+				return err
+			}
+
+			if verbose {
+				cfg.Daemon.LogLevel = "debug"
+			}
+
+			repoDir := filepath.Dir(app.Config.Root())
+
+			// Acquire global lock. The foreground start command does not
+			// hold the lock across the re-exec boundary, so we acquire
+			// it here.
+			if err := dmn.AcquireGlobalLock(repoDir, repoDir); err != nil {
+				return err
+			}
+			defer dmn.ReleaseGlobalLock()
+
+			d, err := dmn.New(cfg, app.Config.Root(), app.State, nodeScope, repoDir)
+			if err != nil {
+				return err
+			}
+			d.ExitWhenDone = exitWhenDone
+
+			// Write PID file. In background mode the foreground process
+			// used to write this, but now we own our own PID file.
+			if err := app.Daemon.WritePID(os.Getpid()); err != nil {
+				return fmt.Errorf("writing PID file: %w", err)
+			}
+			defer func() { _ = app.Daemon.RemovePID() }()
+
+			ctx, cancel := signal.NotifyContext(context.Background(), signals.Shutdown...)
+			defer cancel()
+
+			runErr := d.RunWithSupervisor(ctx)
+			return runErr
+		},
+	}
+
+	cmd.Flags().String("node", "", "Scope execution to a subtree")
+	cmd.Flags().Bool("exit-when-done", false, "Exit after all available work is complete")
+	cmd.Flags().BoolP("verbose", "v", false, "Set console log level to debug")
+
+	return cmd
+}

--- a/cmd/daemon/start.go
+++ b/cmd/daemon/start.go
@@ -81,12 +81,8 @@ Examples:
 
 			// Check for uncommitted changes before the daemon touches anything.
 			// Direct commits will sweep in whatever is in the working tree,
-			// so the user needs to know before we start. Skip when there is
-			// no TTY: the background re-exec runs `wolfcastle start` (without
-			// --daemon), so checking !background doesn't help. No TTY means
-			// either a background re-exec or piped input, both cases where
-			// the user already approved in the parent process.
-			if cfg.Git.AutoCommit && output.IsTerminal() {
+			// so the user needs to know before we start.
+			if cfg.Git.AutoCommit {
 				if dirty, reason := checkDirtyTree(repoDir); dirty {
 					output.PrintHuman("The working tree has uncommitted changes:\n%s", reason)
 					output.PrintHuman("")
@@ -164,7 +160,10 @@ Examples:
 			}
 
 			if background {
-				return startBackground(app.Config.Root(), nodeScope, worktreeBranch, exitWhenDone, "")
+				if worktreeBranch != "" {
+					return fmt.Errorf("--worktree and --daemon cannot be combined: the background process cannot create worktrees")
+				}
+				return startBackground(app.Config.Root(), nodeScope, exitWhenDone, verbose, "")
 			}
 
 			d, err := dmn.New(cfg, app.Config.Root(), app.State, nodeScope, repoDir)
@@ -228,8 +227,11 @@ Examples:
 }
 
 // startBackground launches the daemon as a detached background process.
+// The child re-execs into the hidden _daemon-run command, which skips
+// all interactive checks (dirty tree, validation prompts). The foreground
+// start command has already validated everything.
 // executablePath is the binary to re-exec; pass "" to use os.Executable().
-func startBackground(wolfcastleDir, nodeScope, worktreeBranch string, exitWhenDone bool, executablePath string) error {
+func startBackground(wolfcastleDir, nodeScope string, exitWhenDone bool, verbose bool, executablePath string) error {
 	if executablePath == "" {
 		var err error
 		executablePath, err = os.Executable()
@@ -238,15 +240,15 @@ func startBackground(wolfcastleDir, nodeScope, worktreeBranch string, exitWhenDo
 		}
 	}
 
-	cmdArgs := []string{"start"}
+	cmdArgs := []string{"_daemon-run"}
 	if nodeScope != "" {
 		cmdArgs = append(cmdArgs, "--node", nodeScope)
 	}
-	if worktreeBranch != "" {
-		cmdArgs = append(cmdArgs, "--worktree", worktreeBranch)
-	}
 	if exitWhenDone {
 		cmdArgs = append(cmdArgs, "--exit-when-done")
+	}
+	if verbose {
+		cmdArgs = append(cmdArgs, "--verbose")
 	}
 
 	proc := exec.Command(executablePath, cmdArgs...)
@@ -268,17 +270,11 @@ func startBackground(wolfcastleDir, nodeScope, worktreeBranch string, exitWhenDo
 		return fmt.Errorf("starting background process: %w", err)
 	}
 
-	// Write PID file
-	repo := dmn.NewDaemonRepository(wolfcastleDir)
-	if err := repo.WritePID(proc.Process.Pid); err != nil {
-		return fmt.Errorf("writing PID file: %w", err)
-	}
-
 	output.PrintHuman("Daemon deployed (PID %d)", proc.Process.Pid)
 	output.PrintHuman("  wolfcastle log -f    Watch the operation")
 	output.PrintHuman("  wolfcastle stop      Stand down")
 
-	// Detach
+	// Detach. The child process writes its own PID file.
 	_ = proc.Process.Release()
 	return nil
 }


### PR DESCRIPTION
## Summary

- Background daemon startup (`-d`) re-execed into `wolfcastle start`, which re-ran all interactive checks with no TTY. This caused two bugs: dirty-tree confirmation always failing (#162/#163), and PID self-detection aborting startup (#164)
- New hidden `wolfcastle _daemon-run` command handles only daemon creation and `RunWithSupervisor`. No interactive checks, no dirty-tree prompt, no PID conflict detection. The foreground `start` command handles all validation before spawning the child
- `startBackground` no longer writes the PID file; the child process owns its own PID
- `--worktree` and `--daemon` now error instead of silently breaking (the child can't create worktrees from a detached context)
- Supersedes #164

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 31 packages)
- [x] Removed worktree+background test (combination now errors)
- [x] Removed PID-write-failure test (child writes PID now, not startBackground)
- [x] Updated all startBackground call sites to new signature