### PR TITLE
Add SpinnerWriter to coordinate renderer output with spinner

### DIFF
--- a/cmd/daemon/start.go
+++ b/cmd/daemon/start.go
@@ -189,17 +189,18 @@ Examples:
 			reader := logrender.NewFollowReader(logDir, 200*time.Millisecond)
 			records := reader.Records(ctx)
 			renderDone := make(chan struct{})
+			w := &output.SpinnerWriter{W: os.Stdout}
 			go func() {
 				defer close(renderDone)
 				switch mode {
 				case modeSummary:
-					sr := logrender.NewSummaryRenderer(os.Stdout)
+					sr := logrender.NewSummaryRenderer(w)
 					sr.Follow(ctx, records)
 				case modeThoughts:
-					tr := logrender.NewThoughtsRenderer(os.Stdout)
+					tr := logrender.NewThoughtsRenderer(w)
 					tr.Render(ctx, records)
 				case modeInterleaved:
-					ir := logrender.NewInterleavedRenderer(os.Stdout)
+					ir := logrender.NewInterleavedRenderer(w)
 					ir.Render(ctx, records)
 				case modeJSON:
 					for rec := range records {
@@ -207,8 +208,8 @@ Examples:
 						if err != nil {
 							continue
 						}
-						_, _ = os.Stdout.Write(raw)
-						_, _ = os.Stdout.Write([]byte{'\n'})
+						_, _ = w.Write(raw)
+						_, _ = w.Write([]byte{'\n'})
 					}
 				}
 			}()

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -68,7 +68,7 @@ Examples:
 		renderDone := make(chan struct{})
 		go func() {
 			defer close(renderDone)
-			ir := logrender.NewInterleavedRenderer(os.Stdout)
+			ir := logrender.NewInterleavedRenderer(&output.SpinnerWriter{W: os.Stdout})
 			ir.Render(ctx, records)
 		}()
 

--- a/cmd/intake.go
+++ b/cmd/intake.go
@@ -64,7 +64,7 @@ Examples:
 		renderDone := make(chan struct{})
 		go func() {
 			defer close(renderDone)
-			ir := logrender.NewInterleavedRenderer(os.Stdout)
+			ir := logrender.NewInterleavedRenderer(&output.SpinnerWriter{W: os.Stdout})
 			ir.Render(ctx, records)
 		}()
 

--- a/internal/output/envelope.go
+++ b/internal/output/envelope.go
@@ -7,6 +7,7 @@ package output
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 )
 
@@ -50,6 +51,21 @@ func PrintHuman(format string, args ...any) {
 // PrintError writes an error message to stderr.
 func PrintError(format string, args ...any) {
 	_, _ = fmt.Fprintf(os.Stderr, "Error: "+format+"\n", args...)
+}
+
+// SpinnerWriter wraps an io.Writer with spinner pause/resume so that
+// output through the writer doesn't collide with spinner animation.
+// Pass this to renderers in production; pass a plain buffer in tests.
+type SpinnerWriter struct {
+	W io.Writer
+}
+
+// Write pauses the spinner, writes to the underlying writer, then resumes.
+func (sw *SpinnerWriter) Write(p []byte) (int, error) {
+	PauseSpinner()
+	n, err := sw.W.Write(p)
+	ResumeSpinner()
+	return n, err
 }
 
 // Plural returns singular when n == 1, plural otherwise.

--- a/internal/output/envelope_test.go
+++ b/internal/output/envelope_test.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 )
@@ -99,6 +100,36 @@ func TestPlural_PluralWhenMany(t *testing.T) {
 	got := Plural(5, "task", "tasks")
 	if got != "5 tasks" {
 		t.Errorf("expected %q, got %q", "5 tasks", got)
+	}
+}
+
+func TestSpinnerWriter_DelegatesToUnderlying(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	sw := &SpinnerWriter{W: &buf}
+
+	n, err := sw.Write([]byte("hello"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 5 {
+		t.Errorf("expected n=5, got %d", n)
+	}
+	if buf.String() != "hello" {
+		t.Errorf("expected %q, got %q", "hello", buf.String())
+	}
+}
+
+func TestSpinnerWriter_MultipleWrites(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	sw := &SpinnerWriter{W: &buf}
+
+	_, _ = sw.Write([]byte("one"))
+	_, _ = sw.Write([]byte("two"))
+
+	if buf.String() != "onetwo" {
+		t.Errorf("expected %q, got %q", "onetwo", buf.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- Log renderers (`SummaryRenderer`, `ThoughtsRenderer`, `InterleavedRenderer`) write to `io.Writer` without spinner coordination, causing output to collide with the spinner animation (e.g., `[intake]` text rendered on the spinner line)
- New `output.SpinnerWriter` wraps an `io.Writer` with `PauseSpinner`/`ResumeSpinner` around each `Write` call
- Applied at all renderer construction sites in `start.go`, `execute.go`, and `intake.go`
- `follow.go` left unchanged (no spinner runs during `wolfcastle log`)
- Tests pass plain buffers to renderers as before; `SpinnerWriter` is a no-op when no spinner is active

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/output/ ./cmd/daemon/ ./cmd/` passes
- [x] New tests verify `SpinnerWriter` delegates writes correctly