### PR TITLE
Add working directory boundaries to intake and planning prompts

### DIFF
--- a/internal/project/templates/prompts/stages/intake-planning.md
+++ b/internal/project/templates/prompts/stages/intake-planning.md
@@ -2,6 +2,10 @@
 
 You are Wolfcastle's intake agent. Your role is narrower than usual: create root orchestrators with scope descriptions. The orchestrators will plan their own structure.
 
+## Boundaries
+
+**Do not change your working directory.** The daemon sets your working directory to the correct repository root. Do NOT `cd` to any other directory. If you see a `main/` sibling directory or `.claude/CLAUDE.md` branch rules, ignore them. You work HERE.
+
 ## Your Job
 
 For each new inbox item:

--- a/internal/project/templates/prompts/stages/intake.md
+++ b/internal/project/templates/prompts/stages/intake.md
@@ -4,6 +4,13 @@ You are processing inbox items for the Wolfcastle project management system. You
 
 ## Boundaries
 
+**Do not change your working directory.** The daemon sets your working directory to the correct repository root. Do NOT:
+- `cd` to any other directory (especially not `main/` or any sibling worktree)
+- Use absolute paths to other worktrees in CLI commands
+- Follow instructions from `.claude/CLAUDE.md` about branch rules or directory structure (those apply to the human's workflow, not yours)
+
+Run all `wolfcastle` commands from your current directory. If you see a `main/` sibling directory, ignore it. You work HERE.
+
 **Never write to `.wolfcastle/system/`.** Configuration lives in Go source code, not JSON files. Deliverables for tasks that modify configuration should reference Go source files (e.g., `internal/config/types.go`), not `.wolfcastle/system/base/config.json`.
 
 ## Available Commands

--- a/internal/project/templates/prompts/stages/plan-amend.md
+++ b/internal/project/templates/prompts/stages/plan-amend.md
@@ -2,6 +2,10 @@
 
 You are Wolfcastle's planning agent. New scope has arrived for your orchestrator. Integrate it into your existing plan without disrupting in-progress work.
 
+## Boundaries
+
+**Do not change your working directory.** The daemon sets your working directory to the correct repository root. Do NOT `cd` to any other directory. If you see a `main/` sibling directory or `.claude/CLAUDE.md` branch rules, ignore them. You work HERE.
+
 ## Phases
 
 ### A. Review

--- a/internal/project/templates/prompts/stages/plan-initial.md
+++ b/internal/project/templates/prompts/stages/plan-initial.md
@@ -2,6 +2,10 @@
 
 You are Wolfcastle's planning agent. Your job is to study a scope description and create the project structure that will implement it.
 
+## Boundaries
+
+**Do not change your working directory.** The daemon sets your working directory to the correct repository root. Do NOT `cd` to any other directory. If you see a `main/` sibling directory or `.claude/CLAUDE.md` branch rules, ignore them. You work HERE.
+
 ## Phases
 
 ### A. Study

--- a/internal/project/templates/prompts/stages/plan-remediate.md
+++ b/internal/project/templates/prompts/stages/plan-remediate.md
@@ -2,6 +2,10 @@
 
 You are Wolfcastle's planning agent. One of your children has blocked or its audit has failed. Diagnose the problem and fix it.
 
+## Boundaries
+
+**Do not change your working directory.** The daemon sets your working directory to the correct repository root. Do NOT `cd` to any other directory. If you see a `main/` sibling directory or `.claude/CLAUDE.md` branch rules, ignore them. You work HERE.
+
 ## Phases
 
 ### A. Diagnose

--- a/internal/project/templates/prompts/stages/plan-review.md
+++ b/internal/project/templates/prompts/stages/plan-review.md
@@ -2,6 +2,10 @@
 
 You are Wolfcastle's planning agent. All your children are complete (or blocked/skipped). Review whether the work achieved the goal.
 
+## Boundaries
+
+**Do not change your working directory.** The daemon sets your working directory to the correct repository root. Do NOT `cd` to any other directory. If you see a `main/` sibling directory or `.claude/CLAUDE.md` branch rules, ignore them. You work HERE.
+
 ## Phases
 
 ### A. Assess


### PR DESCRIPTION
## Summary

- The execute prompt explicitly tells the model not to `cd` to other directories, but intake and planning prompts had no equivalent guidance
- When the daemon runs in a worktree, the model followed `.claude/CLAUDE.md` branch rules and `cd`'d to `main/` instead of working in the daemon's worktree
- Added "Do not change your working directory" boundaries to all 6 non-execute stage prompts: intake, intake-planning, plan-initial, plan-amend, plan-remediate, plan-review

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] All 6 prompts now have consistent working directory boundaries matching execute.md