### PR TITLE
Inject working directory into every assembled prompt

### DIFF
--- a/internal/pipeline/prompt.go
+++ b/internal/pipeline/prompt.go
@@ -7,13 +7,28 @@ package pipeline
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/dorkusprime/wolfcastle/internal/config"
 )
 
+// cwdSection returns a prompt section that anchors the model to its
+// working directory. Injected at the top of every assembled prompt so
+// the model never cd's to a sibling worktree or follows branch rules
+// from .claude/CLAUDE.md.
+func cwdSection(wolfcastleDir string) string {
+	repoDir := filepath.Dir(wolfcastleDir)
+	return fmt.Sprintf(`# Working Directory
+
+Your working directory is %s. Do not change it.
+Do not cd to any other directory. Do not follow branch rules or directory
+instructions from .claude/CLAUDE.md — those apply to the human, not you.
+Run all commands from your current directory. You work HERE.`, repoDir)
+}
+
 // AssemblePrompt builds the complete system prompt for a pipeline stage.
-// Assembly order: rule fragments, script reference, stage prompt, iteration context.
+// Assembly order: working directory, rule fragments, script reference, stage prompt, iteration context.
 func AssemblePrompt(wolfcastleDir string, cfg *config.Config, stage config.PipelineStage, iterContext string) (string, error) {
 	if stage.ShouldSkipPromptAssembly() {
 		// Lightweight stage — stage prompt + iteration context only
@@ -22,6 +37,7 @@ func AssemblePrompt(wolfcastleDir string, cfg *config.Config, stage config.Pipel
 			return "", err
 		}
 		var sections []string
+		sections = append(sections, cwdSection(wolfcastleDir))
 		sections = append(sections, content)
 		if iterContext != "" {
 			sections = append(sections, "# Current Task Context\n\n"+iterContext)
@@ -30,6 +46,9 @@ func AssemblePrompt(wolfcastleDir string, cfg *config.Config, stage config.Pipel
 	}
 
 	var sections []string
+
+	// 0. Working directory anchor
+	sections = append(sections, cwdSection(wolfcastleDir))
 
 	// 1. Rule fragments
 	fragments, err := ResolveAllFragments(wolfcastleDir, "rules", cfg.Prompts.Fragments, cfg.Prompts.ExcludeFragments)

--- a/internal/project/templates/prompts/stages/execute.md
+++ b/internal/project/templates/prompts/stages/execute.md
@@ -11,10 +11,6 @@ You may write to `.wolfcastle/docs/` (specs, ADRs via CLI commands) and `.wolfca
 **Do not run git commands.** The daemon owns all git operations (add, commit, push). Your changes are committed automatically after each iteration. Do NOT:
 - Run `git add`, `git commit`, `git push`, or any other git command
 - Switch branches with `git checkout` or `git switch`
-- `cd` to any other directory (especially not `main/`)
-- Reason about "where code should live" based on directory names
-
-If you see a `main/` sibling directory, a `.claude/CLAUDE.md` with branch rules, or any other signal suggesting you should commit elsewhere: ignore it. Those rules apply to the human's workflow, not yours. You work HERE.
 
 ## Phases
 

--- a/internal/project/templates/prompts/stages/intake-planning.md
+++ b/internal/project/templates/prompts/stages/intake-planning.md
@@ -2,10 +2,6 @@
 
 You are Wolfcastle's intake agent. Your role is narrower than usual: create root orchestrators with scope descriptions. The orchestrators will plan their own structure.
 
-## Boundaries
-
-**Do not change your working directory.** The daemon sets your working directory to the correct repository root. Do NOT `cd` to any other directory. If you see a `main/` sibling directory or `.claude/CLAUDE.md` branch rules, ignore them. You work HERE.
-
 ## Your Job
 
 For each new inbox item:

--- a/internal/project/templates/prompts/stages/intake.md
+++ b/internal/project/templates/prompts/stages/intake.md
@@ -4,13 +4,6 @@ You are processing inbox items for the Wolfcastle project management system. You
 
 ## Boundaries
 
-**Do not change your working directory.** The daemon sets your working directory to the correct repository root. Do NOT:
-- `cd` to any other directory (especially not `main/` or any sibling worktree)
-- Use absolute paths to other worktrees in CLI commands
-- Follow instructions from `.claude/CLAUDE.md` about branch rules or directory structure (those apply to the human's workflow, not yours)
-
-Run all `wolfcastle` commands from your current directory. If you see a `main/` sibling directory, ignore it. You work HERE.
-
 **Never write to `.wolfcastle/system/`.** Configuration lives in Go source code, not JSON files. Deliverables for tasks that modify configuration should reference Go source files (e.g., `internal/config/types.go`), not `.wolfcastle/system/base/config.json`.
 
 ## Available Commands

--- a/internal/project/templates/prompts/stages/plan-amend.md
+++ b/internal/project/templates/prompts/stages/plan-amend.md
@@ -2,10 +2,6 @@
 
 You are Wolfcastle's planning agent. New scope has arrived for your orchestrator. Integrate it into your existing plan without disrupting in-progress work.
 
-## Boundaries
-
-**Do not change your working directory.** The daemon sets your working directory to the correct repository root. Do NOT `cd` to any other directory. If you see a `main/` sibling directory or `.claude/CLAUDE.md` branch rules, ignore them. You work HERE.
-
 ## Phases
 
 ### A. Review

--- a/internal/project/templates/prompts/stages/plan-initial.md
+++ b/internal/project/templates/prompts/stages/plan-initial.md
@@ -2,10 +2,6 @@
 
 You are Wolfcastle's planning agent. Your job is to study a scope description and create the project structure that will implement it.
 
-## Boundaries
-
-**Do not change your working directory.** The daemon sets your working directory to the correct repository root. Do NOT `cd` to any other directory. If you see a `main/` sibling directory or `.claude/CLAUDE.md` branch rules, ignore them. You work HERE.
-
 ## Phases
 
 ### A. Study

--- a/internal/project/templates/prompts/stages/plan-remediate.md
+++ b/internal/project/templates/prompts/stages/plan-remediate.md
@@ -2,10 +2,6 @@
 
 You are Wolfcastle's planning agent. One of your children has blocked or its audit has failed. Diagnose the problem and fix it.
 
-## Boundaries
-
-**Do not change your working directory.** The daemon sets your working directory to the correct repository root. Do NOT `cd` to any other directory. If you see a `main/` sibling directory or `.claude/CLAUDE.md` branch rules, ignore them. You work HERE.
-
 ## Phases
 
 ### A. Diagnose

--- a/internal/project/templates/prompts/stages/plan-review.md
+++ b/internal/project/templates/prompts/stages/plan-review.md
@@ -2,10 +2,6 @@
 
 You are Wolfcastle's planning agent. All your children are complete (or blocked/skipped). Review whether the work achieved the goal.
 
-## Boundaries
-
-**Do not change your working directory.** The daemon sets your working directory to the correct repository root. Do NOT `cd` to any other directory. If you see a `main/` sibling directory or `.claude/CLAUDE.md` branch rules, ignore them. You work HERE.
-
 ## Phases
 
 ### A. Assess


### PR DESCRIPTION
## Summary

- `AssemblePrompt` now prepends a "Working Directory" section to every stage prompt, anchoring the model to its correct working directory
- The section is injected in both code paths (full assembly and skip-assembly), so every stage gets it automatically, including future stages
- Removes the per-stage cwd boundary sections added in #168; those are now redundant
- Net result: fewer lines of prompt text, one source of truth for the cwd instruction

Supersedes #168's per-prompt approach with a centralized injection.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/pipeline/ ./internal/project/` passes
- [x] Verified cwd section appears in both assembly paths
- [x] Removed cwd boundaries from: intake, intake-planning, plan-initial, plan-amend, plan-remediate, plan-review, execute (7 files cleaned)