### PR TITLE
Documentation pass for v0.3.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Entries should be concrete, durable, and non-obvious. "The config loader silentl
 ## Design References
 
 - [Architecture Decision Records](docs/decisions/INDEX.md) (95 ADRs) document every major design choice. Consult these before making architectural decisions.
-- [Specifications](docs/specs/) (43 specs) describe the current system in detail. Consult these before modifying behavior.
+- [Specifications](docs/specs/) (44 specs) describe the current system in detail. Consult these before modifying behavior.
 - [Full documentation hub](docs/)
 
 ## Critical Rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,49 @@
 # Changelog
 
-## 0.2.0 (unreleased)
+## 0.3.0
+
+### Core
+- Parallel sibling execution: when `daemon.parallel.enabled` is true, sibling tasks under the same orchestrator run concurrently with file-level scope locks preventing collisions (ADR-095)
+- Parallel dispatcher with worker pool, buffered result channel, and scoped git commits serialized through `gitMu`
+- Scope conflict handling: workers that overlap yield with `ErrYieldScopeConflict`, tracked in a blocked map with stale-entry cleanup
+- `parallel-status.json` snapshot for `wolfcastle status` to display worker pool state without IPC
+- Codebase knowledge files: per-namespace markdown files injected into iteration context for accumulated informal observations
+- Positional task address arguments for lifecycle commands (claim, complete, block, unblock)
+- Removed deprecated `LoadConfig`, `Invoke`, and `InvokeStreaming` wrappers
+
+### CLI
+- 74 commands (up from 53)
+- `task scope add`, `task scope list`, `task scope release` for file-level scope locks
+- `knowledge add`, `knowledge show`, `knowledge edit`, `knowledge prune` for codebase knowledge management
+- `config validate` for configuration validation
+- `execute` and `intake` as standalone commands with live interleaved output
+- `install skill` for Claude Code skill deployment
+
+### Pipeline
+- Knowledge injection in `ContextBuilder`: reads per-namespace knowledge file fresh each iteration
+- Scope lock table (`scope-locks.json`) with `ScopeLockTable` and `ScopeLock` types
+- `FindParallelTasks` navigation: returns up to `maxCount` actionable sibling tasks under the same orchestrator
+
+### Safety
+- Scope path validation: rejects empty, absolute, and `..`/`.` segment paths
+- Bidirectional prefix matching for file/directory scope conflicts
+- Git commit serialization in parallel mode: only the worker's declared files are staged
+
+### Validation
+- 28 validation categories (up from 27)
+
+### Quality
+- `internal/knowledge` package for knowledge file management
+- `internal/logrender` package for log record rendering (summaries, thoughts, session views)
+- 20 internal packages (up from 18)
+
+### Documentation
+- 95 Architecture Decision Records (up from 89)
+- 44 specs (up from 38)
+- 74 CLI commands documented
+- Agent guides updated for parallel dispatch flow and scope lock types
+
+## 0.2.0
 
 ### Core
 - Orchestrator planning pipeline: lazy planning, completion review, AAR action item triage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Package Structure
 
-Wolfcastle is a Go CLI with 18 internal packages. Here's the map:
+Wolfcastle is a Go CLI with 20 internal packages. Here's the map:
 
 | Package | What it does |
 |---------|-------------|
@@ -11,7 +11,7 @@ Wolfcastle is a Go CLI with 18 internal packages. Here's the map:
 | `internal/pipeline` | Prompt assembly, fragment resolution, script reference filtering |
 | `internal/invoke` | Model CLI subprocess execution, marker detection, terminal restoration |
 | `internal/config` | Three-tier config loading, deep merge, validation |
-| `internal/validate` | Structural validation engine: 25 validation categories, multi-pass deterministic repair, JSON recovery |
+| `internal/validate` | Structural validation engine: 28 validation categories, multi-pass deterministic repair, JSON recovery |
 | `internal/tree` | Address parsing, slug validation, filesystem path resolution |
 | `internal/logging` | Per-iteration NDJSON log files, rotation, retention |
 | `internal/output` | JSON envelope formatting, PrintHuman, spinner animation |
@@ -21,11 +21,13 @@ Wolfcastle is a Go CLI with 18 internal packages. Here's the map:
 | `internal/clock` | Time abstraction for deterministic testing |
 | `internal/selfupdate` | Binary self-update mechanism |
 | `internal/git` | Git operations behind a Provider interface for real repositories or test stubs |
+| `internal/knowledge` | Per-namespace codebase knowledge files (add, show, edit, prune, token budget) |
+| `internal/logrender` | Log record rendering (summaries, thoughts, session views) |
 | `internal/signals` | Canonical OS signal set (SIGINT, SIGTERM, SIGTSTP) for graceful shutdown |
 | `internal/tierfs` | Three-tier file resolution (base < custom < local) and tier name registry |
 | `internal/testutil` | Shared test helpers |
 
-The `cmd/` directory mirrors the CLI surface: `cmd/daemon/` (start, stop, log, status), `cmd/task/` (add, claim, complete, block, unblock, deliverable), `cmd/audit/` (breadcrumb, gap, scope, summary, etc.), `cmd/config/` (show, set, unset, append, remove), `cmd/orchestrator/`, `cmd/inbox/`, `cmd/project/`. Shared command utilities live in `cmd/cmdutil/`.
+The `cmd/` directory mirrors the CLI surface: `cmd/daemon/` (start, stop, log, status), `cmd/task/` (add, claim, complete, block, unblock, deliverable, scope), `cmd/audit/` (breadcrumb, gap, scope, summary, etc.), `cmd/config/` (show, set, unset, append, remove, validate), `cmd/orchestrator/`, `cmd/inbox/`, `cmd/project/`, `cmd/knowledge/` (add, show, edit, prune). Shared command utilities live in `cmd/cmdutil/`.
 
 ## Adding a CLI Command
 
@@ -83,6 +85,7 @@ graph TD
         cmdinbox[cmd/inbox]
         cmdproject[cmd/project]
         cmdorch[cmd/orchestrator]
+        cmdknow[cmd/knowledge]
     end
 
     subgraph Domain["Domain packages"]
@@ -91,6 +94,7 @@ graph TD
         validate[validate]
         archive[archive]
         project[project]
+        knowledge[knowledge]
     end
 
     subgraph Core["Core packages"]
@@ -107,6 +111,7 @@ graph TD
         git[git]
         output[output]
         logging[logging]
+        logrender[logrender]
         signals[signals]
     end
 
@@ -118,6 +123,7 @@ graph TD
     cmdinbox --> cmdutil
     cmdproject --> cmdutil
     cmdorch --> cmdutil
+    cmdknow --> cmdutil
 
     cmdutil --> daemon
     cmdutil --> state
@@ -160,4 +166,4 @@ graph TD
 
 Dependencies flow strictly downward. Domain packages orchestrate core packages. Core packages depend only on each other and on leaf packages. Leaf packages have no internal dependencies.
 
-79 ADRs document every major design decision. Read `docs/decisions/INDEX.md` before making architectural changes. If your change introduces a new pattern or reverses an existing decision, write an ADR.
+95 ADRs document every major design decision. Read `docs/decisions/INDEX.md` before making architectural changes. If your change introduces a new pattern or reverses an existing decision, write an ADR.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ wolfcastle init                                            # scaffold .wolfcastl
 wolfcastle inbox add "Build a website for my donut stand"  # queue up work
 wolfcastle start                                           # the daemon wakes up
 
-# in another terminal, same directory::
+# in another terminal, same directory:
 wolfcastle status -w                                       # watch it work
 ```
 
@@ -51,7 +51,7 @@ wolfcastle inbox add "Build a website for my donut stand"  # queue up work
 wolfcastle status -w                                       # watch it work
 ```
 
-Feed it work through the [CLI](docs/humans/cli.md) or chat with your coding agent to hammer out the details and have it inject the work directly with a markdown file path. A detailed spec or PRD gets the most predictable results, but Wolfcastle takes vague directions too without getting lost in the wrong state like a second lieutenant. "Make the API faster" becomes specs, task trees, and acceptance criteria before any code gets written. The [daemon](docs/humans/how-it-works.md#the-daemon) takes it from there: triage, planning, execution, audit, commit. Serial, depth-first, until the [tree](docs/humans/how-it-works.md#the-project-tree) is conquered or something insurmountable gets in the way.
+Feed it work through the [CLI](docs/humans/cli.md) or chat with your coding agent to hammer out the details and have it inject the work directly with a markdown file path. A detailed spec or PRD gets the most predictable results, but Wolfcastle takes vague directions too without getting lost in the wrong state like a second lieutenant. "Make the API faster" becomes specs, task trees, and acceptance criteria before any code gets written. The [daemon](docs/humans/how-it-works.md#the-daemon) takes it from there: triage, planning, execution, audit, commit. Serial by default, depth-first, until the [tree](docs/humans/how-it-works.md#the-project-tree) is conquered or something insurmountable gets in the way. With [parallel execution](docs/decisions/095-parallel-sibling-execution.md) enabled, sibling tasks under the same orchestrator run concurrently with file-level scope locks preventing collisions.
 
 ## Why This Exists
 
@@ -125,7 +125,7 @@ Wolfcastle turns tokens into code. It uses a lot of them. Every planning pass, e
 
 ## More
 
-- [65 CLI commands](docs/humans/cli.md)
+- [74 CLI commands](docs/humans/cli.md)
 - [Architecture Decision Records](docs/decisions/INDEX.md) (95 and counting)
 - [Specifications](docs/specs/)
 - [Developer guides](docs/agents/)

--- a/docs/agents/commands.md
+++ b/docs/agents/commands.md
@@ -56,6 +56,8 @@ These commands skip config loading in `PersistentPreRunE`: `init`, `version`, `h
 | `update` | Update the CLI |
 | `navigate` | Navigate to a node directory |
 | `doctor` | Diagnose and repair broken state |
+| `execute` | Run the execution loop with live interleaved output |
+| `intake` | Process inbox items with live interleaved output |
 | `unblock` | Unblock a blocked task interactively |
 | `install skill` | Install the Claude Code skill for Wolfcastle interaction |
 
@@ -115,6 +117,7 @@ Registered at root level (not grouped under a parent):
 | `unset` | Remove a configuration value from the local tier |
 | `append` | Append to a configuration list value |
 | `remove` | Remove an item from a configuration list |
+| `validate` | Validate the configuration files |
 
 ### inbox
 

--- a/docs/decisions/078-task-rendercontext-parameterless.md
+++ b/docs/decisions/078-task-rendercontext-parameterless.md
@@ -22,7 +22,7 @@ Option 3. Task.RenderContext now takes no parameters. It renders the task ID alo
 The ContextBuilder in `internal/pipeline/context.go` retains its own inline rendering that composes the full address and handles per-task `.md` reads. Over time, ContextBuilder will be refactored to delegate to the domain RenderContext methods, but that migration is a separate concern.
 
 ## Consequences
-- The `state` package no longer imports `path/filepath`. Its only remaining `os` usage is for reference file inlining, which operates on absolute paths stored in the task's References field.
+- The `state` package retains `path/filepath` and `os` only for reference file inlining, which validates and reads absolute paths stored in the task's References field. The nodeDir-dependent usage of `path/filepath` was removed.
 - Tests for Task.RenderContext no longer need temporary directories or real files for the nodeDir/.md reading path. Three such tests were removed in the refactoring commit.
-- NodeState.RenderContext and AuditState.RenderContext follow the same parameterless pattern, giving all three domain render methods a consistent shape.
+- AuditState.RenderContext follows the same parameterless pattern. NodeState.RenderContext retains a `taskID` parameter for future use (see ADR-079).
 - The pipeline's `buildIterationContext` still duplicates some rendering logic. Consolidation (having the pipeline call the domain methods and layer on its own concerns) is a planned follow-up, not part of this decision.

--- a/docs/decisions/088-daemonrepository-concrete.md
+++ b/docs/decisions/088-daemonrepository-concrete.md
@@ -1,13 +1,10 @@
 # DaemonRepository uses concrete struct with explicit parameters
 
 ## Status
-Accepted
+Accepted (partially superseded by ADR-094 for the validate-daemon boundary)
 
 ## Date
 2026-03-18
-
-## Status
-Accepted
 
 ## Context
 The daemon package had free functions (WritePID, ReadPID, RemovePID) that each independently constructed filesystem paths from a wolfcastle directory string. Stop file operations lived in daemon.go with the same scattered path construction. This made the daemon's filesystem footprint implicit and spread across files.

--- a/docs/decisions/091-task-rendercontext-parameterless.md
+++ b/docs/decisions/091-task-rendercontext-parameterless.md
@@ -1,13 +1,10 @@
 # Task.RenderContext parameterless refactoring
 
 ## Status
-Accepted
+Duplicate of ADR-078
 
 ## Date
 2026-03-18
-
-## Status
-Accepted
 
 ## Context
 Task.RenderContext originally accepted two parameters: nodeAddr (the slash-delimited node path) and nodeDir (a filesystem path for reading per-task `.md` files). This coupled the domain type to two concerns it had no business owning: full address composition (a responsibility of ContextBuilder, which knows the node hierarchy) and filesystem I/O (reading per-task markdown from the node directory). The method lived in `internal/state/render.go`, a pure domain package, yet it imported `path/filepath` and called `os.ReadFile`, meaning tests required real files on disk and the domain layer carried a transitive dependency on the operating system.
@@ -25,7 +22,7 @@ Option 3. Task.RenderContext now takes no parameters. It renders the task ID alo
 The ContextBuilder in `internal/pipeline/context.go` retains its own inline rendering that composes the full address and handles per-task `.md` reads. Over time, ContextBuilder will be refactored to delegate to the domain RenderContext methods, but that migration is a separate concern.
 
 ## Consequences
-- The `state` package no longer imports `path/filepath`. Its only remaining `os` usage is for reference file inlining, which operates on absolute paths stored in the task's References field.
+- The `state` package retains `path/filepath` and `os` only for reference file inlining, which validates and reads absolute paths stored in the task's References field. The nodeDir-dependent usage of `path/filepath` was removed.
 - Tests for Task.RenderContext no longer need temporary directories or real files for the nodeDir/.md reading path. Three such tests were removed in the refactoring commit.
-- NodeState.RenderContext and AuditState.RenderContext follow the same parameterless pattern, giving all three domain render methods a consistent shape.
+- AuditState.RenderContext follows the same parameterless pattern. NodeState.RenderContext retains a `taskID` parameter for future use (see ADR-079).
 - The pipeline's `buildIterationContext` still duplicates some rendering logic. Consolidation (having the pipeline call the domain methods and layer on its own concerns) is a planned follow-up, not part of this decision.

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -92,7 +92,7 @@
 | 088 | [DaemonRepository Uses Concrete Struct with Explicit Parameters](088-daemonrepository-concrete.md) | Accepted | 2026-03-18 |
 | 089 | [Auto-Archive Runs Inline in RunOnce](089-auto-archive-inline.md) | Accepted | 2026-03-21 |
 | 090 | [WithConfig Writes to Custom Tier](090-withconfig-custom-tier.md) | Accepted | 2026-03-18 |
-| 091 | [Task.RenderContext Parameterless Refactoring](091-task-rendercontext-parameterless.md) | Accepted | 2026-03-18 |
+| 091 | [Task.RenderContext Parameterless Refactoring](091-task-rendercontext-parameterless.md) | Duplicate of ADR-078 | 2026-03-18 |
 | 092 | [Result.Unavailable Field over Sentinel Error](092-result-unavailable-field.md) | Accepted | 2026-03-20 |
 | 093 | [Separate GIT_INDEX_FILE for Daemon Commits](093-separate-git-index-file.md) | Superseded | 2026-03-22 |
 | 094 | [PIDChecker Interface Decouples Validate from Daemon](094-pidchecker-interface.md) | Accepted (supersedes ADR-088) | 2026-03-22 |

--- a/docs/humans/README.md
+++ b/docs/humans/README.md
@@ -42,4 +42,4 @@ Each engineer gets their own namespace under `.wolfcastle/system/projects/`. No 
 
 ## [CLI Reference](cli.md)
 
-43 commands across lifecycle, task management, auditing, diagnostics, and documentation. Every command accepts `--json` and `--node` for tree addressing. Covers the inbox, installation channels, project directory layout, and new engineer setup.
+62 commands across lifecycle, task management, auditing, diagnostics, and documentation. Every command accepts `--json` and `--node` for tree addressing. Covers the inbox, installation channels, project directory layout, and new engineer setup.

--- a/docs/humans/cli/README.md
+++ b/docs/humans/cli/README.md
@@ -14,17 +14,22 @@ See the [CLI Reference](../cli.md) for the command table organized by category, 
 
 - [start](start.md) | [stop](stop.md) | [status](status.md) | [log](log.md)
 
+### Execution
+
+- [execute](execute.md) | [intake](intake.md)
+
 ### Project Tree
 
-- [project create](project-create.md) | [navigate](navigate.md) | [unblock](unblock.md) | [orchestrator criteria](orchestrator-criteria.md)
+- [project create](project-create.md) | [navigate](navigate.md) | [orchestrator criteria](orchestrator-criteria.md)
 
 ### Tasks
 
 - [task add](task-add.md) | [task amend](task-amend.md) | [task claim](task-claim.md) | [task complete](task-complete.md) | [task block](task-block.md) | [task unblock](task-unblock.md) | [task deliverable](task-deliverable.md)
+- [task scope add](task-scope-add.md) | [task scope list](task-scope-list.md) | [task scope release](task-scope-release.md)
 
 ### Configuration
 
-- [config show](config-show.md) | [config set](config-set.md) | [config unset](config-unset.md) | [config append](config-append.md) | [config remove](config-remove.md)
+- [config show](config-show.md) | [config set](config-set.md) | [config unset](config-unset.md) | [config append](config-append.md) | [config remove](config-remove.md) | [config validate](config-validate.md)
 
 ### Audit
 
@@ -42,6 +47,10 @@ See the [CLI Reference](../cli.md) for the command table organized by category, 
 
 - [adr create](adr-create.md) | [spec create](spec-create.md) | [spec link](spec-link.md) | [spec list](spec-list.md)
 
+### Knowledge
+
+- [knowledge add](knowledge-add.md) | [knowledge show](knowledge-show.md) | [knowledge edit](knowledge-edit.md) | [knowledge prune](knowledge-prune.md)
+
 ### Diagnostics
 
-- [doctor](doctor.md)
+- [doctor](doctor.md) | [unblock](unblock.md)

--- a/docs/humans/cli/task-scope-add.md
+++ b/docs/humans/cli/task-scope-add.md
@@ -21,7 +21,7 @@ wolfcastle task scope add --node <address> --task <task-id> <file> [<file>...]
 | Flag | Description |
 |------|-------------|
 | `--node <address>` | **(Required)** Node address for the task. |
-| `--task <task-id>` | **(Required when not running inside a daemon iteration)** Task ID. |
+| `--task <task-id>` | **(Required)** Task ID. |
 | `--json` | Output as structured JSON. |
 
 ## Arguments

--- a/docs/specs/2026-03-15T00-00Z-goroutine-architecture.md
+++ b/docs/specs/2026-03-15T00-00Z-goroutine-architecture.md
@@ -67,9 +67,9 @@ The channel is buffered with capacity 1. If the execute loop hasn't consumed the
 
 The `context.Context` from `signal.NotifyContext` is the shutdown signal. Both goroutines check `ctx.Done()` and exit cleanly. No additional shutdown channel needed.
 
-### 2.3 Stop file (via fsnotify)
+### 2.3 Stop file (polling)
 
-The stop file watch replaces the `os.Stat` check in `RunOnce`. When fsnotify detects the stop file's creation, it cancels the context, which propagates to both goroutines.
+The stop file is detected by the `RunOnce` polling loop via `HasStopFile()`. When the stop file is found, `RunOnce` removes it and returns `IterationStop`, which causes `Run` to exit cleanly. This is a periodic check, not an fsnotify watch.
 
 ---
 
@@ -80,21 +80,23 @@ The stop file watch replaces the `os.Stat` check in `RunOnce`. When fsnotify det
 Started by `Run()` after self-healing and branch verification. Stopped by context cancellation.
 
 ```go
-func (d *Daemon) runInboxLoop(ctx context.Context, workAvailable chan<- struct{}) {
-    watcher := fsnotify.NewWatcher()
-    watcher.Add(filepath.Join(d.Resolver.ProjectsDir(), "inbox.json"))
+func (d *Daemon) runInboxLoop(ctx context.Context) {
+    projDir := d.Store.Dir()
 
-    for {
-        select {
-        case <-ctx.Done():
+    // Watch the projects directory (not inbox.json directly) because
+    // inbox.json might not exist yet when the daemon starts.
+    watcher, err := fsnotify.NewWatcher()
+    if err == nil {
+        defer watcher.Close()
+        if watcher.Add(projDir) == nil {
+            d.runInboxWithFsnotify(ctx, watcher)
             return
-        case event := <-watcher.Events:
-            if event.Op&(fsnotify.Write|fsnotify.Create) == 0 {
-                continue
-            }
-            d.runIntakeIfNeeded(ctx, workAvailable)
         }
+        watcher.Close()
     }
+
+    // Fallback: polling
+    d.runInboxWithPolling(ctx)
 }
 ```
 

--- a/internal/state/navigation.go
+++ b/internal/state/navigation.go
@@ -272,8 +272,8 @@ func findActionableTask(addr string, loadNode func(addr string) (*NodeState, err
 // FindParallelTasks finds up to maxCount actionable tasks that can run concurrently.
 // It starts with the same DFS as FindNextTask, then scans siblings of the first
 // result's parent orchestrator for additional independent work. In-progress siblings
-// are skipped (not treated as blockers), and an unplanned orchestrator sibling stops
-// further scanning of later children.
+// are inspected for available work (not treated as blockers), and an unplanned
+// orchestrator sibling stops further scanning of later children.
 func FindParallelTasks(
 	idx *RootIndex,
 	scopeAddr string,


### PR DESCRIPTION
## Summary

- README: command count updated, parallel execution mention with ADR-095 link, typo fix
- CONTRIBUTING: package count 18→20, Mermaid diagram updated, ADR count→95, validation categories→28
- CHANGELOG: v0.3.0 entry added
- AGENTS.md: spec count→44
- Agent/human docs: CLI index updated with scope commands, config validate, knowledge, execute/intake
- ADR-091 marked as duplicate of ADR-078; accuracy fixes in ADR-078 and ADR-088
- Goroutine architecture spec: stop file polling and inbox loop signature corrected
- Navigation code comment: "skipped" → "inspected for available work"

## Test plan

- [x] `go build ./...` passes
- [x] Pure documentation changes (14 files), one code comment fix in navigation.go

🤖 Generated with [Claude Code](https://claude.com/claude-code)