### PR TITLE
Audit fixes: em-dashes, error message, coverage gaps

### DIFF
--- a/cmd/audit/approve.go
+++ b/cmd/audit/approve.go
@@ -148,7 +148,7 @@ Examples:
 				return fmt.Errorf("finding %q not found or already decided", args[0])
 			}
 
-			// Save batch first — if this fails, no index changes are persisted,
+			// Save batch first. If this fails, no index changes are persisted,
 			// so the batch remains the source of truth for what's been decided.
 			if err := state.SaveBatch(batchPath, batch); err != nil {
 				return err

--- a/cmd/audit/approve_chmod_test.go
+++ b/cmd/audit/approve_chmod_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/dorkusprime/wolfcastle/internal/state"
 )
 
-// ── approve — filesystem error paths via chmod ──────────────────────
+// ── approve: filesystem error paths via chmod ──────────────────────
 
 func TestApprove_MkdirAllError_ReadOnly(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -96,7 +96,7 @@ func TestApprove_WriteFileError_ReadOnly(t *testing.T) {
 	t.Cleanup(func() { _ = os.Chmod(env.ProjectsDir, 0755) })
 
 	env.RootCmd.SetArgs([]string{"audit", "approve", "f-1"})
-	// MkdirAll for node dir also fails — finding is skipped.
+	// MkdirAll for node dir also fails. Finding is skipped.
 	err := env.RootCmd.Execute()
 	if err == nil {
 		t.Error("expected error since no finding was successfully approved")

--- a/cmd/audit/approve_coverage_test.go
+++ b/cmd/audit/approve_coverage_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// approve — additional approval paths
+// approve: additional approval paths
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestApprove_WithDescriptionField(t *testing.T) {

--- a/cmd/audit/approve_deep_coverage_test.go
+++ b/cmd/audit/approve_deep_coverage_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// approve — invalid slug from title
+// approve: invalid slug from title
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestApprove_InvalidSlugTitle_Skipped(t *testing.T) {
@@ -29,7 +29,7 @@ func TestApprove_InvalidSlugTitle_Skipped(t *testing.T) {
 
 	env.RootCmd.SetArgs([]string{"audit", "approve", "--all"})
 	err := env.RootCmd.Execute()
-	// Should succeed — invalid slug finding is skipped, valid one proceeds
+	// Should succeed. Invalid slug finding is skipped, valid one proceeds
 	if err != nil {
 		t.Logf("approve --all with invalid slug: %v (may be acceptable)", err)
 	}
@@ -57,7 +57,7 @@ func TestApprove_EmptyTitle_ProducesUnnamed(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// approve — finding with existing project (dedup path)
+// approve: finding with existing project (dedup path)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestApprove_ExistingProject_JSON(t *testing.T) {
@@ -84,7 +84,7 @@ func TestApprove_ExistingProject_JSON(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// approve — batch with multiple findings, approve one at a time
+// approve: batch with multiple findings, approve one at a time
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestApprove_Sequential(t *testing.T) {
@@ -148,7 +148,7 @@ func copyDir(src, dst string) error {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// finalizeBatchIfComplete — with all approved (history retention)
+// finalizeBatchIfComplete: with all approved (history retention)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestFinalizeBatchIfComplete_WithCreatedNodes(t *testing.T) {

--- a/cmd/audit/audit_chmod_test.go
+++ b/cmd/audit/audit_chmod_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/dorkusprime/wolfcastle/internal/state"
 )
 
-// ── audit breadcrumb — SaveNodeState error ──────────────────────────
+// ── audit breadcrumb: SaveNodeState error ──────────────────────────
 
 func TestBreadcrumb_SaveNodeStateError_ReadOnly(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -30,7 +30,7 @@ func TestBreadcrumb_SaveNodeStateError_ReadOnly(t *testing.T) {
 	}
 }
 
-// ── audit escalate — SaveNodeState error ────────────────────────────
+// ── audit escalate: SaveNodeState error ────────────────────────────
 
 func TestEscalate_SaveNodeStateError_ReadOnly(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -51,7 +51,7 @@ func TestEscalate_SaveNodeStateError_ReadOnly(t *testing.T) {
 	}
 }
 
-// ── audit fix-gap — SaveNodeState error ─────────────────────────────
+// ── audit fix-gap: SaveNodeState error ─────────────────────────────
 
 func TestFixGap_SaveNodeStateError_ReadOnly(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -80,7 +80,7 @@ func TestFixGap_SaveNodeStateError_ReadOnly(t *testing.T) {
 	}
 }
 
-// ── audit gap — SaveNodeState error ─────────────────────────────────
+// ── audit gap: SaveNodeState error ─────────────────────────────────
 
 func TestGap_SaveNodeStateError_ReadOnly(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -101,7 +101,7 @@ func TestGap_SaveNodeStateError_ReadOnly(t *testing.T) {
 	}
 }
 
-// ── audit resolve — SaveNodeState error ─────────────────────────────
+// ── audit resolve: SaveNodeState error ─────────────────────────────
 
 func TestResolve_SaveNodeStateError_ReadOnly(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -129,7 +129,7 @@ func TestResolve_SaveNodeStateError_ReadOnly(t *testing.T) {
 	}
 }
 
-// ── audit reject — SaveBatch error ──────────────────────────────────
+// ── audit reject: SaveBatch error ──────────────────────────────────
 
 func TestReject_SaveBatchError_ReadOnly(t *testing.T) {
 	if runtime.GOOS == "windows" {

--- a/cmd/audit/audit_edge_test.go
+++ b/cmd/audit/audit_edge_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// audit show — with scope, result summary, all sections
+// audit show: with scope, result summary, all sections
 // ---------------------------------------------------------------------------
 
 func TestShow_WithScopeAndResultSummary(t *testing.T) {
@@ -61,7 +61,7 @@ func TestShow_NoIdentity(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit scope — error paths
+// audit scope: error paths
 // ---------------------------------------------------------------------------
 
 func TestScope_NoIdentity(t *testing.T) {
@@ -109,7 +109,7 @@ func TestScope_AllFields(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit pending — with long descriptions
+// audit pending: with long descriptions
 // ---------------------------------------------------------------------------
 
 func TestPending_WithLongDescription(t *testing.T) {
@@ -153,7 +153,7 @@ func TestPending_WithMultilineDescription(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit reject — error paths
+// audit reject: error paths
 // ---------------------------------------------------------------------------
 
 func TestReject_FindingNotFound(t *testing.T) {
@@ -197,7 +197,7 @@ func TestReject_NoPendingForAll(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit approve — mixed batch (some approved, some pending)
+// audit approve: mixed batch (some approved, some pending)
 // ---------------------------------------------------------------------------
 
 func TestApprove_MixedBatch(t *testing.T) {
@@ -229,7 +229,7 @@ func TestApprove_MixedBatch(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// finalizeBatchIfComplete — with DecidedAt set
+// finalizeBatchIfComplete: with DecidedAt set
 // ---------------------------------------------------------------------------
 
 func TestFinalizeBatchIfComplete_WithDecidedAt(t *testing.T) {
@@ -268,7 +268,7 @@ func TestFinalizeBatchIfComplete_WithDecidedAt(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit gap — no resolver
+// audit gap: no resolver
 // ---------------------------------------------------------------------------
 
 func TestGap_NoIdentity(t *testing.T) {
@@ -293,7 +293,7 @@ func TestGap_NonexistentNode(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit fix-gap — no resolver
+// audit fix-gap: no resolver
 // ---------------------------------------------------------------------------
 
 func TestFixGap_NoIdentity(t *testing.T) {
@@ -318,7 +318,7 @@ func TestFixGap_NonexistentNode(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit escalate — no resolver
+// audit escalate: no resolver
 // ---------------------------------------------------------------------------
 
 func TestEscalate_NoIdentity(t *testing.T) {
@@ -346,7 +346,7 @@ func TestEscalate_NonexistentParent(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit resolve — no resolver
+// audit resolve: no resolver
 // ---------------------------------------------------------------------------
 
 func TestResolve_NoIdentity(t *testing.T) {
@@ -371,7 +371,7 @@ func TestResolve_NonexistentNode(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit breadcrumb — nonexistent node
+// audit breadcrumb: nonexistent node
 // ---------------------------------------------------------------------------
 
 func TestBreadcrumb_NonexistentNode(t *testing.T) {
@@ -385,7 +385,7 @@ func TestBreadcrumb_NonexistentNode(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit reject — JSON output with all
+// audit reject: JSON output with all
 // ---------------------------------------------------------------------------
 
 func TestReject_JSONOutput_All(t *testing.T) {
@@ -412,7 +412,7 @@ func TestReject_JSONOutput_All(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit approve — JSON output with --all
+// audit approve: JSON output with --all
 // ---------------------------------------------------------------------------
 
 func TestApprove_JSONOutput_All(t *testing.T) {
@@ -439,7 +439,7 @@ func TestApprove_JSONOutput_All(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit pending — JSON output with all reviewed
+// audit pending: JSON output with all reviewed
 // ---------------------------------------------------------------------------
 
 func TestPending_JSONOutput_AllReviewed(t *testing.T) {
@@ -464,7 +464,7 @@ func TestPending_JSONOutput_AllReviewed(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// parseFindings — numbered bold with description after
+// parseFindings: numbered bold with description after
 // ---------------------------------------------------------------------------
 
 func TestParseFindings_BoldWithDescriptionAfter(t *testing.T) {
@@ -503,11 +503,11 @@ Description of second.
 }
 
 // ---------------------------------------------------------------------------
-// audit list — no scopes (human output)
+// audit list: no scopes (human output)
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
-// audit approve — approve finding with description (covers descContent branch)
+// audit approve: approve finding with description (covers descContent branch)
 // ---------------------------------------------------------------------------
 
 func TestApprove_WithDescription(t *testing.T) {
@@ -541,7 +541,7 @@ func TestApprove_WithDescription(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit approve — approve all with mixed findings including already-decided
+// audit approve: approve all with mixed findings including already-decided
 // ---------------------------------------------------------------------------
 
 func TestApprove_AllWithMixed(t *testing.T) {
@@ -566,7 +566,7 @@ func TestApprove_AllWithMixed(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit scope — update existing scope (scope already non-nil)
+// audit scope: update existing scope (scope already non-nil)
 // ---------------------------------------------------------------------------
 
 func TestScope_UpdateExisting(t *testing.T) {
@@ -593,7 +593,7 @@ func TestScope_UpdateExisting(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit gap — multiple gaps
+// audit gap: multiple gaps
 // ---------------------------------------------------------------------------
 
 func TestGap_Multiple(t *testing.T) {
@@ -615,7 +615,7 @@ func TestGap_Multiple(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit breadcrumb — with task flag
+// audit breadcrumb: with task flag
 // ---------------------------------------------------------------------------
 
 func TestBreadcrumb_MultipleBreadcrumbs(t *testing.T) {
@@ -634,7 +634,7 @@ func TestBreadcrumb_MultipleBreadcrumbs(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit show — with all audit data populated
+// audit show: with all audit data populated
 // ---------------------------------------------------------------------------
 
 func TestShow_FullAuditState(t *testing.T) {
@@ -672,7 +672,7 @@ func TestShow_FullAuditState(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit approve — duplicate project (CreateProject error)
+// audit approve: duplicate project (CreateProject error)
 // ---------------------------------------------------------------------------
 
 func TestApprove_CreateProjectError(t *testing.T) {
@@ -698,7 +698,7 @@ func TestApprove_CreateProjectError(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit approve — LoadBatch error (invalid JSON)
+// audit approve: LoadBatch error (invalid JSON)
 // ---------------------------------------------------------------------------
 
 func TestApprove_BrokenBatchFile(t *testing.T) {
@@ -715,7 +715,7 @@ func TestApprove_BrokenBatchFile(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit reject — LoadBatch error (invalid JSON)
+// audit reject: LoadBatch error (invalid JSON)
 // ---------------------------------------------------------------------------
 
 func TestReject_BrokenBatchFile(t *testing.T) {
@@ -732,7 +732,7 @@ func TestReject_BrokenBatchFile(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit pending — LoadBatch error (invalid JSON)
+// audit pending: LoadBatch error (invalid JSON)
 // ---------------------------------------------------------------------------
 
 func TestPending_BrokenBatchFile(t *testing.T) {
@@ -749,7 +749,7 @@ func TestPending_BrokenBatchFile(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit run — LoadBatch error (invalid JSON in existing batch)
+// audit run: LoadBatch error (invalid JSON in existing batch)
 // ---------------------------------------------------------------------------
 
 func TestRunCmd_BrokenBatchFile(t *testing.T) {
@@ -772,7 +772,7 @@ func TestRunCmd_BrokenBatchFile(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit approve — LoadRootIndex error (broken root index)
+// audit approve: LoadRootIndex error (broken root index)
 // ---------------------------------------------------------------------------
 
 func TestApprove_BrokenRootIndex(t *testing.T) {
@@ -799,7 +799,7 @@ func TestApprove_BrokenRootIndex(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit breadcrumb — save error (broken state file)
+// audit breadcrumb: save error (broken state file)
 // ---------------------------------------------------------------------------
 
 func TestBreadcrumb_InvalidNodeAddress(t *testing.T) {
@@ -813,7 +813,7 @@ func TestBreadcrumb_InvalidNodeAddress(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit gap — invalid address
+// audit gap: invalid address
 // ---------------------------------------------------------------------------
 
 func TestGap_InvalidAddress(t *testing.T) {
@@ -827,7 +827,7 @@ func TestGap_InvalidAddress(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit fix-gap — invalid address
+// audit fix-gap: invalid address
 // ---------------------------------------------------------------------------
 
 func TestFixGap_InvalidAddress(t *testing.T) {
@@ -841,7 +841,7 @@ func TestFixGap_InvalidAddress(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit escalate — invalid address
+// audit escalate: invalid address
 // ---------------------------------------------------------------------------
 
 func TestEscalate_InvalidAddress(t *testing.T) {
@@ -855,7 +855,7 @@ func TestEscalate_InvalidAddress(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit resolve — invalid address
+// audit resolve: invalid address
 // ---------------------------------------------------------------------------
 
 func TestResolve_InvalidAddress(t *testing.T) {
@@ -869,7 +869,7 @@ func TestResolve_InvalidAddress(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit scope — invalid address
+// audit scope: invalid address
 // ---------------------------------------------------------------------------
 
 func TestScope_InvalidAddress(t *testing.T) {
@@ -883,7 +883,7 @@ func TestScope_InvalidAddress(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit show — invalid address
+// audit show: invalid address
 // ---------------------------------------------------------------------------
 
 func TestShow_InvalidAddress(t *testing.T) {
@@ -897,7 +897,7 @@ func TestShow_InvalidAddress(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// finalizeBatchIfComplete — LoadHistory error (invalid JSON)
+// finalizeBatchIfComplete: LoadHistory error (invalid JSON)
 // ---------------------------------------------------------------------------
 
 func TestFinalizeBatchIfComplete_BrokenHistory(t *testing.T) {
@@ -925,7 +925,7 @@ func TestFinalizeBatchIfComplete_BrokenHistory(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit approve — approve with no-description finding
+// audit approve: approve with no-description finding
 // ---------------------------------------------------------------------------
 
 func TestApprove_NoDescriptionFinding(t *testing.T) {
@@ -948,7 +948,7 @@ func TestApprove_NoDescriptionFinding(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// discoverScopes — local tier overrides
+// discoverScopes: local tier overrides
 // ---------------------------------------------------------------------------
 
 func TestDiscoverScopes_LocalOverride(t *testing.T) {
@@ -975,7 +975,7 @@ func TestDiscoverScopes_LocalOverride(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit history — LoadHistory error (invalid JSON)
+// audit history: LoadHistory error (invalid JSON)
 // ---------------------------------------------------------------------------
 
 func TestHistory_BrokenHistoryFile(t *testing.T) {
@@ -992,7 +992,7 @@ func TestHistory_BrokenHistoryFile(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// discoverScopes — skip directories and non-.md files
+// discoverScopes: skip directories and non-.md files
 // ---------------------------------------------------------------------------
 
 func TestDiscoverScopes_SkipsDirsAndNonMd(t *testing.T) {
@@ -1014,7 +1014,7 @@ func TestDiscoverScopes_SkipsDirsAndNonMd(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// discoverScopes — description from file content (non-heading line)
+// discoverScopes: description from file content (non-heading line)
 // ---------------------------------------------------------------------------
 
 func TestDiscoverScopes_DescriptionFromContent(t *testing.T) {
@@ -1038,7 +1038,7 @@ func TestDiscoverScopes_DescriptionFromContent(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// audit run — scope flag with valid scope
+// audit run: scope flag with valid scope
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------

--- a/cmd/audit_coverage_gaps_test.go
+++ b/cmd/audit_coverage_gaps_test.go
@@ -1,0 +1,106 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/dorkusprime/wolfcastle/internal/state"
+)
+
+// ═══════════════════════════════════════════════════════════════════════════
+// nodeGlyphPlain: all status branches
+// ═══════════════════════════════════════════════════════════════════════════
+
+func TestNodeGlyphPlain_AllStatuses(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		status state.NodeStatus
+		want   string
+	}{
+		{state.StatusComplete, "●"},
+		{state.StatusInProgress, "◐"},
+		{state.StatusBlocked, "☢"},
+		{state.StatusNotStarted, "◯"},
+		{"something_unexpected", "◯"},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			got := nodeGlyphPlain(tt.status)
+			if got != tt.want {
+				t.Errorf("nodeGlyphPlain(%q) = %q, want %q", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// countOpenEscalations: open, closed, mixed, empty
+// ═══════════════════════════════════════════════════════════════════════════
+
+func TestCountOpenEscalations(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		escs []state.Escalation
+		want int
+	}{
+		{"nil", nil, 0},
+		{"empty", []state.Escalation{}, 0},
+		{"all open", []state.Escalation{
+			{ID: "e1", Status: state.EscalationOpen},
+			{ID: "e2", Status: state.EscalationOpen},
+		}, 2},
+		{"all resolved", []state.Escalation{
+			{ID: "e1", Status: state.EscalationResolved},
+		}, 0},
+		{"mixed", []state.Escalation{
+			{ID: "e1", Status: state.EscalationOpen},
+			{ID: "e2", Status: state.EscalationResolved},
+			{ID: "e3", Status: state.EscalationOpen},
+		}, 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := countOpenEscalations(tt.escs)
+			if got != tt.want {
+				t.Errorf("countOpenEscalations() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// countGaps: open, fixed, mixed, empty
+// ═══════════════════════════════════════════════════════════════════════════
+
+func TestCountGaps_AllCombinations(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		gaps     []state.Gap
+		wantOpen int
+		wantFix  int
+	}{
+		{"nil", nil, 0, 0},
+		{"empty", []state.Gap{}, 0, 0},
+		{"all open", []state.Gap{
+			{ID: "g1", Status: state.GapOpen},
+			{ID: "g2", Status: state.GapOpen},
+		}, 2, 0},
+		{"all fixed", []state.Gap{
+			{ID: "g1", Status: state.GapFixed},
+		}, 0, 1},
+		{"mixed", []state.Gap{
+			{ID: "g1", Status: state.GapOpen},
+			{ID: "g2", Status: state.GapFixed},
+			{ID: "g3", Status: state.GapOpen},
+		}, 2, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			open, fixed := countGaps(tt.gaps)
+			if open != tt.wantOpen || fixed != tt.wantFix {
+				t.Errorf("countGaps() = (%d, %d), want (%d, %d)", open, fixed, tt.wantOpen, tt.wantFix)
+			}
+		})
+	}
+}

--- a/cmd/category_a_coverage_test.go
+++ b/cmd/category_a_coverage_test.go
@@ -28,7 +28,7 @@ func TestDoctorCmd_CorruptStateJSON(t *testing.T) {
 	_ = os.WriteFile(filepath.Join(env.ProjectsDir, "state.json"), []byte("corrupt json{{"), 0644)
 
 	rootCmd.SetArgs([]string{"doctor"})
-	// Should not return an error — it reports the issue via reportValidationIssues
+	// Should not return an error. It reports the issue via reportValidationIssues
 	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("doctor with corrupt state should still report: %v", err)

--- a/cmd/cmdutil/app.go
+++ b/cmd/cmdutil/app.go
@@ -110,8 +110,8 @@ func (a *App) RequireIdentity() error {
 
 // CheckOverlap scans other engineers' project names and descriptions
 // for potential scope overlap with the newly created project. Uses
-// bigram Jaccard similarity — no model invocation required (ADR-041).
-// Purely informational — failures are silently ignored (ADR-027).
+// bigram Jaccard similarity; no model invocation required (ADR-041).
+// Purely informational. Failures are silently ignored (ADR-027).
 func (a *App) CheckOverlap(projectName, description string) {
 	if a.Config == nil || a.Identity == nil {
 		return

--- a/cmd/cmdutil/completions_test.go
+++ b/cmd/cmdutil/completions_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// CompleteTaskAddresses — orchestrator nodes (non-leaf, no tasks)
+// CompleteTaskAddresses: orchestrator nodes (non-leaf, no tasks)
 // ---------------------------------------------------------------------------
 
 func TestCompleteTaskAddresses_WithOrchestrator(t *testing.T) {
@@ -70,7 +70,7 @@ func TestCompleteTaskAddresses_WithOrchestrator(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// CompleteTaskAddresses — node with invalid state file
+// CompleteTaskAddresses: node with invalid state file
 // ---------------------------------------------------------------------------
 
 func TestCompleteTaskAddresses_BrokenNodeState(t *testing.T) {
@@ -107,7 +107,7 @@ func TestCompleteTaskAddresses_BrokenNodeState(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// CheckOverlap — empty bigrams from short text
+// CheckOverlap: empty bigrams from short text
 // ---------------------------------------------------------------------------
 
 func TestCheckOverlap_ShortText(t *testing.T) {
@@ -137,7 +137,7 @@ func TestCheckOverlap_ShortText(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// loadRootIndexForCompletion — fallback to LoadConfig
+// loadRootIndexForCompletion: fallback to LoadConfig
 // ---------------------------------------------------------------------------
 
 func TestLoadRootIndexForCompletion_FallbackConfigFails(t *testing.T) {
@@ -209,7 +209,7 @@ func TestLoadConfig_MalformedConfig(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// CheckOverlap — nonexistent projects dir
+// CheckOverlap: nonexistent projects dir
 // ---------------------------------------------------------------------------
 
 func TestCheckOverlap_NonexistentProjectsDir(t *testing.T) {
@@ -232,7 +232,7 @@ func TestCheckOverlap_NonexistentProjectsDir(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// CheckOverlap — found matches (coverage of output section)
+// CheckOverlap: found matches (coverage of output section)
 // ---------------------------------------------------------------------------
 
 func TestCheckOverlap_NoMatchesBelowThreshold(t *testing.T) {

--- a/cmd/coverage_cmd_daemon_test.go
+++ b/cmd/coverage_cmd_daemon_test.go
@@ -1015,7 +1015,7 @@ func TestInitCmd_AlreadyInitializedJSON(t *testing.T) {
 // ═══════════════════════════════════════════════════════════════════════════
 // spec.go: ReadDir error via corrupted specs dir (lines 207-209)
 // This is already tested in TestSpecList_ReadDirError in category_a but
-// the line is still uncovered — possibly the test doesn't exercise this
+// the line is still uncovered: possibly the test doesn't exercise this
 // path correctly. Let's test by making the specs dir unreadable.
 // ═══════════════════════════════════════════════════════════════════════════
 

--- a/cmd/daemon/audit_coverage_gaps_test.go
+++ b/cmd/daemon/audit_coverage_gaps_test.go
@@ -1,0 +1,122 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	dmn "github.com/dorkusprime/wolfcastle/internal/daemon"
+	"github.com/dorkusprime/wolfcastle/internal/state"
+	"github.com/dorkusprime/wolfcastle/internal/testutil"
+)
+
+// ═══════════════════════════════════════════════════════════════════════════
+// modeFlag.IsBoolFlag: verify the interface method returns true
+// ═══════════════════════════════════════════════════════════════════════════
+
+func TestModeFlag_IsBoolFlag(t *testing.T) {
+	t.Parallel()
+	var m outputMode
+	f := &modeFlag{target: &m, value: modeThoughts}
+	if !f.IsBoolFlag() {
+		t.Error("IsBoolFlag() should return true")
+	}
+	if f.Type() != "bool" {
+		t.Errorf("Type() = %q, want %q", f.Type(), "bool")
+	}
+	if f.String() != "false" {
+		t.Errorf("String() = %q, want %q", f.String(), "false")
+	}
+	if err := f.Set("true"); err != nil {
+		t.Errorf("Set() error: %v", err)
+	}
+	if m != modeThoughts {
+		t.Errorf("target = %d, want modeThoughts", m)
+	}
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// followJSON: verify context cancellation stops the follow loop
+// ═══════════════════════════════════════════════════════════════════════════
+
+func TestFollowJSON_ContextCancellation(t *testing.T) {
+	t.Parallel()
+	logDir := t.TempDir()
+
+	// Write a log file so the reader has something to find.
+	_ = os.WriteFile(filepath.Join(logDir, "0001-20260321T18-00Z.jsonl"),
+		[]byte(`{"type":"daemon_start","scope":"test","timestamp":"2026-03-21T18:00:00Z"}`+"\n"), 0644)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := followJSON(ctx, logDir, func() bool { return false })
+	if err != nil {
+		t.Fatalf("followJSON with cancelled context: %v", err)
+	}
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// printParallelStatus: exercise all branches (active, yielded, scope)
+// ═══════════════════════════════════════════════════════════════════════════
+
+func TestPrintParallelStatus_AllBranches(t *testing.T) {
+	t.Parallel()
+	ps := &dmn.ParallelStatus{
+		MaxWorkers: 3,
+		Active: []dmn.ParallelWorkerEntry{
+			{Task: "leaf/task-0001", Node: "leaf", Scope: []string{"auth", "db"}},
+			{Task: "leaf/task-0002", Node: "leaf"},
+		},
+		Yielded: []dmn.ParallelYieldedEntry{
+			{Task: "leaf/task-0003", Blocker: "leaf/task-0001", YieldCount: 1},
+			{Task: "leaf/task-0004", Blocker: "leaf/task-0001", YieldCount: 3, BlockedForSecs: 120},
+		},
+	}
+	// Should not panic. Exercises active (with and without scope) and
+	// yielded (with and without multi-yield suffix).
+	printParallelStatus(ps)
+}
+
+func TestPrintParallelStatus_NoYielded(t *testing.T) {
+	t.Parallel()
+	ps := &dmn.ParallelStatus{
+		MaxWorkers: 2,
+		Active: []dmn.ParallelWorkerEntry{
+			{Task: "leaf/task-0001", Node: "leaf"},
+		},
+	}
+	printParallelStatus(ps)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// nodeGlyphPlain and countOpenEscalations: full status coverage
+// ═══════════════════════════════════════════════════════════════════════════
+
+func TestNodeGlyphPlain_AllStatuses(t *testing.T) {
+	t.Parallel()
+	env := newTestEnv(t)
+	env.env.WithProject("Proj", testutil.Leaf("proj"))
+
+	// Exercise nodeGlyphPlain through the describe command's code path
+	// by testing directly. These are unexported in cmd package so we test
+	// via the status display that uses nodeGlyph. The describe tests
+	// cover nodeGlyphPlain.
+	tests := []struct {
+		status state.NodeStatus
+		want   string
+	}{
+		{state.StatusComplete, "●"},
+		{state.StatusInProgress, "◐"},
+		{state.StatusBlocked, "☢"},
+		{state.StatusNotStarted, "◯"},
+		{"unknown_status", "◯"},
+	}
+	for _, tt := range tests {
+		got := nodeGlyph(tt.status)
+		if got != tt.want {
+			t.Errorf("nodeGlyph(%q) = %q, want %q", tt.status, got, tt.want)
+		}
+	}
+}

--- a/cmd/daemon/coverage_deep_test.go
+++ b/cmd/daemon/coverage_deep_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// printNodeTree — completed orchestrator with children (collapse path)
+// printNodeTree: completed orchestrator with children (collapse path)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestPrintNodeTree_CompletedOrchestratorCollapsed(t *testing.T) {
@@ -54,7 +54,7 @@ func TestPrintNodeTree_CompletedOrchestratorCollapsed(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// printNodeTree — completed leaf node with tasks (collapse path)
+// printNodeTree: completed leaf node with tasks (collapse path)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestPrintNodeTree_CompletedLeafWithTasks(t *testing.T) {
@@ -84,7 +84,7 @@ func TestPrintNodeTree_CompletedLeafWithTasks(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// printNodeTree — orchestrator with active audit task
+// printNodeTree: orchestrator with active audit task
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestPrintNodeTree_OrchestratorWithActiveAuditTask(t *testing.T) {
@@ -120,7 +120,7 @@ func TestPrintNodeTree_OrchestratorWithActiveAuditTask(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// printNodeTree — subtask collapsing: completed parent with all-complete children
+// printNodeTree: subtask collapsing: completed parent with all-complete children
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestPrintNodeTree_SubtaskCollapsing(t *testing.T) {
@@ -147,7 +147,7 @@ func TestPrintNodeTree_SubtaskCollapsing(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// printNodeTree — subtask NOT collapsed: parent complete but child incomplete
+// printNodeTree: subtask NOT collapsed: parent complete but child incomplete
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestPrintNodeTree_SubtaskNotCollapsed(t *testing.T) {
@@ -167,12 +167,12 @@ func TestPrintNodeTree_SubtaskNotCollapsed(t *testing.T) {
 		"proj": {entry: idx.Nodes["proj"], ns: ns},
 	}
 
-	// expand=false: parent complete but sub B incomplete — no collapse.
+	// expand=false: parent complete but sub B incomplete. No collapse.
 	printNodeTree(env.App, idx, details, "proj", "  ", treeOpts{Width: 120}, nil)
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// showTreeStatus — planning queue rendering
+// showTreeStatus: planning queue rendering
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestShowTreeStatus_PlanningQueue(t *testing.T) {
@@ -191,7 +191,7 @@ func TestShowTreeStatus_PlanningQueue(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// showTreeStatus — in-progress summary line
+// showTreeStatus: in-progress summary line
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestShowTreeStatus_InProgressCount(t *testing.T) {
@@ -211,7 +211,7 @@ func TestShowTreeStatus_InProgressCount(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// watchStatus — runs at least one full loop iteration with tree data
+// watchStatus: runs at least one full loop iteration with tree data
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestWatchStatus_RunsOneFullIteration(t *testing.T) {
@@ -260,7 +260,7 @@ func TestWatchStatus_ExpandFlag(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// newStatusCmd — watch flag path through command
+// newStatusCmd: watch flag path through command
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestStatusCmd_WatchFlag(t *testing.T) {
@@ -289,7 +289,7 @@ func TestStatusCmd_WatchFlag(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// printNodeTree — deep subtask indentation (task-0001.0002.0003)
+// printNodeTree: deep subtask indentation (task-0001.0002.0003)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestPrintNodeTree_DeepSubtaskIndent(t *testing.T) {
@@ -314,7 +314,7 @@ func TestPrintNodeTree_DeepSubtaskIndent(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// printNodeTree — completed task with collapsed subtasks (child count display)
+// printNodeTree: completed task with collapsed subtasks (child count display)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestPrintNodeTree_CompletedTaskCollapsedSubtasks(t *testing.T) {
@@ -324,7 +324,7 @@ func TestPrintNodeTree_CompletedTaskCollapsedSubtasks(t *testing.T) {
 	idx, _ := env.App.State.ReadIndex()
 	ns, _ := env.App.State.ReadNode("proj")
 	ns.Tasks = []state.Task{
-		// Completed task with children — the task itself hits the "collapsed
+		// Completed task with children. The task itself hits the "collapsed
 		// parent task: show child count" branch at line 305-316.
 		{ID: "task-0001", Title: "Done parent", State: state.StatusComplete},
 		{ID: "task-0001.0001", Title: "Child 1", State: state.StatusComplete},
@@ -342,7 +342,7 @@ func TestPrintNodeTree_CompletedTaskCollapsedSubtasks(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// showTreeStatus — completed node in non-JSON with scope
+// showTreeStatus: completed node in non-JSON with scope
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestShowTreeStatus_CompletedNodesCollapsed(t *testing.T) {
@@ -386,7 +386,7 @@ func TestStartCmd_ConfigLoadError(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// showAllStatus — file entry in projects dir (not a directory)
+// showAllStatus: file entry in projects dir (not a directory)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestShowAllStatus_FileInProjectsDir(t *testing.T) {
@@ -402,7 +402,7 @@ func TestShowAllStatus_FileInProjectsDir(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// printNodeTree — gap with IsTerminal=false (non-terminal display path)
+// printNodeTree: gap with IsTerminal=false (non-terminal display path)
 // Already tested, but this adds an explicit assertion on the output path.
 // ═══════════════════════════════════════════════════════════════════════════
 
@@ -426,14 +426,14 @@ func TestPrintNodeTree_OpenGapNonTerminal(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// startBackground — PID write failure (read-only dir)
+// startBackground: PID write failure (read-only dir)
 // ═══════════════════════════════════════════════════════════════════════════
 
 // TestStartBackground_PIDWriteFailure was removed: startBackground no
 // longer writes the PID file. The child _daemon-run process handles it.
 
 // ═══════════════════════════════════════════════════════════════════════════
-// recoverStaleDaemonState — read error on PID file (not ENOENT)
+// recoverStaleDaemonState: read error on PID file (not ENOENT)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRecoverStaleDaemonState_ReadError(t *testing.T) {
@@ -458,7 +458,7 @@ func TestRecoverStaleDaemonState_ReadError(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// showTreeStatus — empty tree path (zero total nodes)
+// showTreeStatus: empty tree path (zero total nodes)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestShowTreeStatus_EmptyTreeMessage(t *testing.T) {
@@ -472,7 +472,7 @@ func TestShowTreeStatus_EmptyTreeMessage(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// printNodeTree — orchestrator with blocked audit task
+// printNodeTree: orchestrator with blocked audit task
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestPrintNodeTree_OrchestratorBlockedAuditTask(t *testing.T) {
@@ -508,7 +508,7 @@ func TestPrintNodeTree_OrchestratorBlockedAuditTask(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// showAllStatus — truly empty projects dir (no namespaces, human output)
+// showAllStatus: truly empty projects dir (no namespaces, human output)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestShowAllStatus_EmptyProjectsDir_Human(t *testing.T) {
@@ -526,7 +526,7 @@ func TestShowAllStatus_EmptyProjectsDir_Human(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// printNodeTree — subtask with grandchild (rest contains ".", skipped)
+// printNodeTree: subtask with grandchild (rest contains ".", skipped)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestPrintNodeTree_GrandchildSkippedInCollapseCheck(t *testing.T) {
@@ -555,7 +555,7 @@ func TestPrintNodeTree_GrandchildSkippedInCollapseCheck(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// watchStatus — showAll error path inside the loop
+// watchStatus: showAll error path inside the loop
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestWatchStatus_ShowAllError(t *testing.T) {
@@ -584,7 +584,7 @@ func TestWatchStatus_ShowAllError(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// watchStatus — tree status error path inside the loop
+// watchStatus: tree status error path inside the loop
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestWatchStatus_TreeStatusError(t *testing.T) {
@@ -616,7 +616,7 @@ func TestWatchStatus_TreeStatusError(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// stop command — Signal error path
+// stop command: Signal error path
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestStopCmd_SignalError(t *testing.T) {
@@ -638,7 +638,7 @@ func TestStopCmd_SignalError(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// start.go — validation warnings printed, then proceed
+// start.go: validation warnings printed, then proceed
 // ═══════════════════════════════════════════════════════════════════════════
 
 // TestStartCmd_DaemonNewFails exercises the foreground daemon.New() error
@@ -664,7 +664,7 @@ func TestStartCmd_DaemonNewFails(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// showTreeStatus — multiple state summary parts (all states represented)
+// showTreeStatus: multiple state summary parts (all states represented)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestShowTreeStatus_AllStateCountParts(t *testing.T) {
@@ -703,7 +703,7 @@ func TestShowTreeStatus_AllStateCountParts(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// timelinePriority — all status branches
+// timelinePriority: all status branches
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestTimelinePriority_AllStatuses(t *testing.T) {

--- a/cmd/daemon/daemon_test.go
+++ b/cmd/daemon/daemon_test.go
@@ -804,7 +804,7 @@ func TestStartBackground_LogDirNotWritable(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// watchStatus — runs one cycle then context cancels
+// watchStatus: runs one cycle then context cancels
 // ---------------------------------------------------------------------------
 
 func TestWatchStatus_SingleCycle(t *testing.T) {

--- a/cmd/daemon/follow_coverage_test.go
+++ b/cmd/daemon/follow_coverage_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// newLogCmd — flag registration and RunE path coverage
+// newLogCmd: flag registration and RunE path coverage
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestLogCmd_NoLogFiles(t *testing.T) {
@@ -18,7 +18,7 @@ func TestLogCmd_NoLogFiles(t *testing.T) {
 	logDir := filepath.Join(env.WolfcastleDir, "system", "logs")
 	_ = os.MkdirAll(logDir, 0755)
 
-	// No log files present — should return an error (exit 1).
+	// No log files present. Should return an error (exit 1).
 	env.RootCmd.SetArgs([]string{"log"})
 	if err := env.RootCmd.Execute(); err == nil {
 		t.Fatal("expected error when no log files exist")

--- a/cmd/daemon/follow_test.go
+++ b/cmd/daemon/follow_test.go
@@ -439,7 +439,7 @@ func TestLogCmd_CompressedGzFiles(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// replayJSON — direct unit tests for streaming and decompression
+// replayJSON: direct unit tests for streaming and decompression
 // ═══════════════════════════════════════════════════════════════════════════
 
 // writeGzLines creates a gzip-compressed file containing newline-terminated lines.

--- a/cmd/daemon/start.go
+++ b/cmd/daemon/start.go
@@ -151,7 +151,7 @@ Examples:
 				}
 			}
 
-			// Startup validation gate — block on error-severity issues
+			// Startup validation gate: block on error-severity issues
 			if idxErr == nil {
 				engine := validate.NewEngine(app.State.Dir(), validate.DefaultNodeLoader(app.State.Dir()), dmn.NewDaemonRepository(app.Config.Root()))
 				report := engine.ValidateStartup(idx)

--- a/cmd/daemon/start_coverage_test.go
+++ b/cmd/daemon/start_coverage_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// start command — error paths (without starting the daemon loop)
+// start command: error paths (without starting the daemon loop)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestStartCmd_AlreadyRunning_OwnPID(t *testing.T) {
@@ -102,7 +102,7 @@ func TestStartCmd_StalePIDRecoveredBeforeStart(t *testing.T) {
 // Validation-only paths are tested by TestStartCmd_ValidationBlocksWithErrors.
 
 // ═══════════════════════════════════════════════════════════════════════════
-// recoverStaleDaemonState — edge cases
+// recoverStaleDaemonState: edge cases
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRecoverStaleDaemonState_ValidPIDNotRunning(t *testing.T) {

--- a/cmd/daemon/start_deep_coverage_test.go
+++ b/cmd/daemon/start_deep_coverage_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// recoverStaleDaemonState — additional PID states
+// recoverStaleDaemonState: additional PID states
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRecoverStaleDaemonState_EmptyPidFile(t *testing.T) {
@@ -19,7 +19,7 @@ func TestRecoverStaleDaemonState_EmptyPidFile(t *testing.T) {
 	_ = os.WriteFile(filepath.Join(tmp, "system", "wolfcastle.pid"), []byte(""), 0644)
 	recoverStaleDaemonState(tmp)
 
-	// Empty PID parses as error — file should be cleaned
+	// Empty PID parses as error. File should be cleaned
 	if _, err := os.Stat(filepath.Join(tmp, "system", "wolfcastle.pid")); !os.IsNotExist(err) {
 		t.Error("empty PID file should be removed")
 	}
@@ -72,7 +72,7 @@ func TestRecoverStaleDaemonState_DeadProcessCleansAllFiles(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// start command — worktree flags (parsed but not executed)
+// start command: worktree flags (parsed but not executed)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestStartCmd_FlagsRegistered(t *testing.T) {
@@ -91,7 +91,7 @@ func TestStartCmd_FlagsRegistered(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// start command — already running with own PID (error message quality)
+// start command: already running with own PID (error message quality)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestStartCmd_AlreadyRunning_ErrorContainsPID(t *testing.T) {

--- a/cmd/daemon/start_test.go
+++ b/cmd/daemon/start_test.go
@@ -158,7 +158,7 @@ func TestStopCmd_ForceFlag(t *testing.T) {
 
 func TestStopCmd_RunningProcess(t *testing.T) {
 	env := newTestEnv(t)
-	// Use our own PID — it's running, but signal will succeed
+	// Use our own PID. It's running, but signal will succeed
 	pid := os.Getpid()
 	_ = os.MkdirAll(filepath.Join(env.WolfcastleDir, "system"), 0755)
 	_ = os.WriteFile(filepath.Join(env.WolfcastleDir, "system", "wolfcastle.pid"), []byte(fmt.Sprintf("%d", pid)), 0644)
@@ -173,7 +173,7 @@ func TestStopCmd_JSONOutput(t *testing.T) {
 	env.App.JSON = true
 	defer func() { env.App.JSON = false }()
 
-	// No PID file — should error
+	// No PID file. Should error
 	env.RootCmd.SetArgs([]string{"stop"})
 	err := env.RootCmd.Execute()
 	if err == nil {
@@ -182,7 +182,7 @@ func TestStopCmd_JSONOutput(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// showAllStatus edge case — missing projects dir
+// showAllStatus edge case: missing projects dir
 // ---------------------------------------------------------------------------
 
 func TestShowAllStatus_MissingProjectsDir(t *testing.T) {
@@ -197,7 +197,7 @@ func TestShowAllStatus_MissingProjectsDir(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// status command — node scope with nodes
+// status command: node scope with nodes
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------

--- a/cmd/daemon/start_validation_test.go
+++ b/cmd/daemon/start_validation_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// newStartCmd — RequireIdentity failure
+// newStartCmd: RequireIdentity failure
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestStartCmd_RequireIdentityFailure(t *testing.T) {
@@ -31,7 +31,7 @@ func TestStartCmd_RequireIdentityFailure(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// newStartCmd — verbose flag sets log level
+// newStartCmd: verbose flag sets log level
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestStartCmd_VerboseSetsDebugLogLevel(t *testing.T) {
@@ -62,7 +62,7 @@ func TestStartCmd_VerboseSetsDebugLogLevel(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// newStartCmd — validation gate: errors block startup
+// newStartCmd: validation gate: errors block startup
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestStartCmd_ValidationErrorsBlockStartup(t *testing.T) {
@@ -99,7 +99,7 @@ func TestStartCmd_ValidationErrorsBlockStartup(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// newStartCmd — validation gate: warnings proceed
+// newStartCmd: validation gate: warnings proceed
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestStartCmd_ValidationWarningsProceed(t *testing.T) {
@@ -145,7 +145,7 @@ func TestStartCmd_ValidationWarningsProceed(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// newStartCmd — already-running daemon detection (error message quality)
+// newStartCmd: already-running daemon detection (error message quality)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestStartCmd_AlreadyRunningErrorMessage(t *testing.T) {
@@ -179,7 +179,7 @@ func TestStartCmd_AlreadyRunningErrorMessage(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// newStartCmd — background mode flag triggers startBackground path
+// newStartCmd: background mode flag triggers startBackground path
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestStartCmd_BackgroundFlag(t *testing.T) {
@@ -203,7 +203,7 @@ func TestStartCmd_BackgroundFlag(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// newStartCmd — stale PID recovered before lock acquisition
+// newStartCmd: stale PID recovered before lock acquisition
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestStartCmd_StalePIDRecovery(t *testing.T) {
@@ -232,7 +232,7 @@ func TestStartCmd_StalePIDRecovery(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// newStartCmd — global lock acquisition failure
+// newStartCmd: global lock acquisition failure
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestStartCmd_GlobalLockConflict(t *testing.T) {
@@ -257,7 +257,7 @@ func TestStartCmd_GlobalLockConflict(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// newStartCmd — worktree flag with invalid branch (exercising error path)
+// newStartCmd: worktree flag with invalid branch (exercising error path)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestStartCmd_WorktreeCreationFailure(t *testing.T) {

--- a/cmd/daemon/status_coverage_test.go
+++ b/cmd/daemon/status_coverage_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// nodeGlyph — all NodeStatus values (non-terminal mode, which is what tests get)
+// nodeGlyph: all NodeStatus values (non-terminal mode, which is what tests get)
 // ---------------------------------------------------------------------------
 
 func TestNodeGlyph_AllStatuses(t *testing.T) {
@@ -40,7 +40,7 @@ func TestNodeGlyph_AllStatuses(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// taskGlyph — all NodeStatus values
+// taskGlyph: all NodeStatus values
 // ---------------------------------------------------------------------------
 
 func TestTaskGlyph_AllStatuses(t *testing.T) {
@@ -65,7 +65,7 @@ func TestTaskGlyph_AllStatuses(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// printNodeTree — coverage for task rendering edge cases
+// printNodeTree: coverage for task rendering edge cases
 // ---------------------------------------------------------------------------
 
 func TestPrintNodeTree_OrchestratorRecursion(t *testing.T) {
@@ -187,7 +187,7 @@ func TestPrintNodeTree_TaskDescriptionFallback(t *testing.T) {
 
 	idx, _ := env.App.State.ReadIndex()
 	ns, _ := env.App.State.ReadNode("proj")
-	// Task with no Title, only Description — label falls back to Description.
+	// Task with no Title, only Description. Label falls back to Description.
 	ns.Tasks = []state.Task{
 		{
 			ID:          "task-0001",
@@ -204,7 +204,7 @@ func TestPrintNodeTree_TaskDescriptionFallback(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// showTreeStatus — JSON output path with audit counts, inbox rendering
+// showTreeStatus: JSON output path with audit counts, inbox rendering
 // ---------------------------------------------------------------------------
 
 func TestShowTreeStatus_JSONWithAuditData(t *testing.T) {
@@ -285,7 +285,7 @@ func TestShowTreeStatus_NodeReadError(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// showAllStatus — error and empty paths
+// showAllStatus: error and empty paths
 // ---------------------------------------------------------------------------
 
 func TestShowAllStatus_ProjectsDirRemoved(t *testing.T) {
@@ -307,7 +307,7 @@ func TestShowAllStatus_EmptyJSONOutput(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// watchStatus — context cancellation and error paths
+// watchStatus: context cancellation and error paths
 // ---------------------------------------------------------------------------
 
 func TestWatchStatus_ImmediateCancel(t *testing.T) {
@@ -384,7 +384,7 @@ func TestWatchStatus_ScopedWithCancel(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// newStatusCmd — flag combinations
+// newStatusCmd: flag combinations
 // ---------------------------------------------------------------------------
 
 func TestStatusCmd_AllWithJSON(t *testing.T) {
@@ -497,7 +497,7 @@ func mustJSON(v any) string {
 }
 
 // ---------------------------------------------------------------------------
-// showTreeStatus JSON — daemon activity fields
+// showTreeStatus JSON: daemon activity fields
 // ---------------------------------------------------------------------------
 
 func TestShowTreeStatus_JSONWithDaemonActivity(t *testing.T) {

--- a/cmd/inbox/inbox_chmod_test.go
+++ b/cmd/inbox/inbox_chmod_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-// ── inbox add — SaveInbox error ─────────────────────────────────────
+// ── inbox add: SaveInbox error ─────────────────────────────────────
 
 func TestInboxAdd_SaveInboxError_ReadOnly(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -26,7 +26,7 @@ func TestInboxAdd_SaveInboxError_ReadOnly(t *testing.T) {
 	}
 }
 
-// ── inbox clear — SaveInbox error ───────────────────────────────────
+// ── inbox clear: SaveInbox error ───────────────────────────────────
 
 func TestInboxClear_SaveInboxError_ReadOnly(t *testing.T) {
 	if runtime.GOOS == "windows" {

--- a/cmd/inbox/inbox_edge_test.go
+++ b/cmd/inbox/inbox_edge_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// inbox add — error paths
+// inbox add: error paths
 // ---------------------------------------------------------------------------
 
 func TestInboxAdd_JSONOutput_Multiple(t *testing.T) {
@@ -31,7 +31,7 @@ func TestInboxAdd_JSONOutput_Multiple(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// inbox list — error paths
+// inbox list: error paths
 // ---------------------------------------------------------------------------
 
 func TestInboxList_NoIdentity(t *testing.T) {
@@ -46,7 +46,7 @@ func TestInboxList_NoIdentity(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// inbox clear — error paths
+// inbox clear: error paths
 // ---------------------------------------------------------------------------
 
 func TestInboxClear_NoIdentity(t *testing.T) {
@@ -129,11 +129,11 @@ func TestInboxClear_AllClearsNewItems(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// inbox list — empty inbox path
+// inbox list: empty inbox path
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
-// inbox add — LoadInbox error (invalid JSON in inbox file)
+// inbox add: LoadInbox error (invalid JSON in inbox file)
 // ---------------------------------------------------------------------------
 
 func TestInboxAdd_BrokenInboxFile(t *testing.T) {
@@ -151,7 +151,7 @@ func TestInboxAdd_BrokenInboxFile(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// inbox list — LoadInbox error (invalid JSON)
+// inbox list: LoadInbox error (invalid JSON)
 // ---------------------------------------------------------------------------
 
 func TestInboxList_BrokenInboxFile(t *testing.T) {
@@ -168,7 +168,7 @@ func TestInboxList_BrokenInboxFile(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// inbox clear — LoadInbox error (invalid JSON)
+// inbox clear: LoadInbox error (invalid JSON)
 // ---------------------------------------------------------------------------
 
 func TestInboxClear_BrokenInboxFile(t *testing.T) {

--- a/cmd/install_coverage_test.go
+++ b/cmd/install_coverage_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// ensureSkillSource — additional coverage
+// ensureSkillSource: additional coverage
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestEnsureSkillSource_FileAlreadyExistsWithDifferentContent(t *testing.T) {

--- a/cmd/knowledge/register.go
+++ b/cmd/knowledge/register.go
@@ -1,5 +1,5 @@
 // Package knowledge implements the knowledge command group for managing
-// codebase knowledge files — the living, growing "what you need to know"
+// codebase knowledge files: the living, growing "what you need to know"
 // documents that accumulate across tasks.
 package knowledge
 

--- a/cmd/project/create_chmod_test.go
+++ b/cmd/project/create_chmod_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/dorkusprime/wolfcastle/internal/state"
 )
 
-// ── project create — filesystem error paths via chmod ────────────────
+// ── project create: filesystem error paths via chmod ────────────────
 
 func TestProjectCreate_SaveNodeState_PromotedParent_ReadOnly(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -18,7 +18,7 @@ func TestProjectCreate_SaveNodeState_PromotedParent_ReadOnly(t *testing.T) {
 
 	env := newTestEnv(t)
 
-	// Create a leaf node (no non-audit tasks — eligible for promotion).
+	// Create a leaf node (no non-audit tasks. Eligible for promotion).
 	env.RootCmd.SetArgs([]string{"project", "create", "--type", "leaf", "parent-leaf"})
 	if err := env.RootCmd.Execute(); err != nil {
 		t.Fatal(err)

--- a/cmd/project/project_edge_test.go
+++ b/cmd/project/project_edge_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// project create — overlap advisory enabled
+// project create: overlap advisory enabled
 // ---------------------------------------------------------------------------
 
 func TestProjectCreate_OverlapEnabled(t *testing.T) {
@@ -34,7 +34,7 @@ func TestProjectCreate_OverlapEnabled(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// project create — invalid slug
+// project create: invalid slug
 // ---------------------------------------------------------------------------
 
 func TestProjectCreate_InvalidSlug(t *testing.T) {
@@ -49,7 +49,7 @@ func TestProjectCreate_InvalidSlug(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// project create — auto promote leaf with audit-only tasks
+// project create: auto promote leaf with audit-only tasks
 // ---------------------------------------------------------------------------
 
 func TestProjectCreate_AutoPromoteLeafWithAuditOnly(t *testing.T) {
@@ -84,7 +84,7 @@ func TestProjectCreate_AutoPromoteLeafWithAuditOnly(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// project create — child under orchestrator (no promotion needed)
+// project create: child under orchestrator (no promotion needed)
 // ---------------------------------------------------------------------------
 
 func TestProjectCreate_ChildUnderOrchestrator(t *testing.T) {
@@ -112,7 +112,7 @@ func TestProjectCreate_ChildUnderOrchestrator(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// project create — duplicate child name
+// project create: duplicate child name
 // ---------------------------------------------------------------------------
 
 func TestProjectCreate_DuplicateChildName(t *testing.T) {
@@ -132,7 +132,7 @@ func TestProjectCreate_DuplicateChildName(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// project create — root metadata not set on second project
+// project create: root metadata not set on second project
 // ---------------------------------------------------------------------------
 
 func TestProjectCreate_SecondRootProjectNoMetadataOverwrite(t *testing.T) {
@@ -151,11 +151,11 @@ func TestProjectCreate_SecondRootProjectNoMetadataOverwrite(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// project create — child with JSON output
+// project create: child with JSON output
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
-// project create — with all overlapping namespaces
+// project create: with all overlapping namespaces
 // ---------------------------------------------------------------------------
 
 func TestProjectCreate_OverlapWithMultipleEngineers(t *testing.T) {
@@ -181,7 +181,7 @@ func TestProjectCreate_OverlapWithMultipleEngineers(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// project create — loading root index error (broken state.json)
+// project create: loading root index error (broken state.json)
 // ---------------------------------------------------------------------------
 
 func TestProjectCreate_BrokenRootIndex(t *testing.T) {
@@ -198,7 +198,7 @@ func TestProjectCreate_BrokenRootIndex(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// project create — nested child (3 levels deep)
+// project create: nested child (3 levels deep)
 // ---------------------------------------------------------------------------
 
 func TestProjectCreate_NestedChild(t *testing.T) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -101,7 +101,7 @@ func setupCommands() {
 }
 
 // executeRoot runs the root command and returns any error along with
-// whether JSON mode was active — allowing the caller to format the
+// whether JSON mode was active, allowing the caller to format the
 // error appropriately. Separated from Execute for testability.
 func executeRoot() error {
 	setupCommands()

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -145,7 +145,7 @@ func TestArchiveAddCmd_NoIdentity(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestSetupCommands(t *testing.T) {
-	// setupCommands is idempotent — calling it again should not panic
+	// setupCommands is idempotent. Calling it again should not panic
 	setupCommands()
 
 	// Verify groups are assigned
@@ -644,7 +644,7 @@ func TestDoctorCmd_Fix_WithFixableIssues(t *testing.T) {
 	_ = state.SaveNodeState(nodeStatePath(env.ProjectsDir, parsed), ns)
 
 	rootCmd.SetArgs([]string{"doctor", "--fix"})
-	// Should not error — it reports and fixes
+	// Should not error. It reports and fixes
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("doctor --fix with fixable issues failed: %v", err)
 	}

--- a/cmd/spec_chmod_test.go
+++ b/cmd/spec_chmod_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-// ── spec create — MkdirAll error ────────────────────────────────────
+// ── spec create: MkdirAll error ────────────────────────────────────
 
 func TestSpecCreate_MkdirAllError_ReadOnly(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -33,7 +33,7 @@ func TestSpecCreate_MkdirAllError_ReadOnly(t *testing.T) {
 	}
 }
 
-// ── spec create — WriteFile error ───────────────────────────────────
+// ── spec create: WriteFile error ───────────────────────────────────
 
 func TestSpecCreate_WriteFileError_ReadOnly(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -58,7 +58,7 @@ func TestSpecCreate_WriteFileError_ReadOnly(t *testing.T) {
 	}
 }
 
-// ── spec create — SaveNodeState error ───────────────────────────────
+// ── spec create: SaveNodeState error ───────────────────────────────
 
 func TestSpecCreate_SaveNodeStateError_ReadOnly(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -89,7 +89,7 @@ func TestSpecCreate_SaveNodeStateError_ReadOnly(t *testing.T) {
 	}
 }
 
-// ── spec link — SaveNodeState error ─────────────────────────────────
+// ── spec link: SaveNodeState error ─────────────────────────────────
 
 func TestSpecLink_SaveNodeStateError_ReadOnly(t *testing.T) {
 	if runtime.GOOS == "windows" {

--- a/cmd/task/task_chmod_test.go
+++ b/cmd/task/task_chmod_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-// ── task commands — SaveNodeState error via read-only state dir ──────
+// ── task commands: SaveNodeState error via read-only state dir ──────
 
 func TestTaskAdd_SaveNodeStateError_ReadOnly(t *testing.T) {
 	if runtime.GOOS == "windows" {

--- a/cmd/task/task_coverage_test.go
+++ b/cmd/task/task_coverage_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// findFilesByName — unit tests
+// findFilesByName: unit tests
 // ---------------------------------------------------------------------------
 
 func TestFindFilesByName_SkipsWolfcastleDir(t *testing.T) {
@@ -99,7 +99,7 @@ func TestFindFilesByName_WalkErrorPermission(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// isGlobPath — unit tests
+// isGlobPath: unit tests
 // ---------------------------------------------------------------------------
 
 func TestIsGlobPath(t *testing.T) {
@@ -121,7 +121,7 @@ func TestIsGlobPath(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// deliverable command — uncovered branches
+// deliverable command: uncovered branches
 // ---------------------------------------------------------------------------
 
 func TestTaskDeliverable_EmptyPath(t *testing.T) {
@@ -272,7 +272,7 @@ func TestTaskDeliverable_ExistingFileNoWarning(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// add command — uncovered flag combinations
+// add command: uncovered flag combinations
 // ---------------------------------------------------------------------------
 
 func TestTaskAdd_WithBody(t *testing.T) {
@@ -450,7 +450,7 @@ func TestTaskAdd_JSONOutputWithDeliverables(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// writeTaskMD — coverage for body inclusion and error path
+// writeTaskMD: coverage for body inclusion and error path
 // ---------------------------------------------------------------------------
 
 // newTaskPrompts creates a PromptRepository with the task template seeded.
@@ -529,7 +529,7 @@ func TestWriteTaskMD_NonexistentDir(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// amend command — remaining uncovered branches
+// amend command: remaining uncovered branches
 // ---------------------------------------------------------------------------
 
 func TestTaskAmend_NoIdentity(t *testing.T) {

--- a/cmd/task/task_edge_test.go
+++ b/cmd/task/task_edge_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// task block — error paths
+// task block: error paths
 // ---------------------------------------------------------------------------
 
 func TestTaskBlock_NoIdentity(t *testing.T) {
@@ -46,7 +46,7 @@ func TestTaskBlock_NonexistentNode(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// task claim — error paths
+// task claim: error paths
 // ---------------------------------------------------------------------------
 
 func TestTaskClaim_NoIdentity(t *testing.T) {
@@ -71,7 +71,7 @@ func TestTaskClaim_NonexistentNode(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// task complete — error paths
+// task complete: error paths
 // ---------------------------------------------------------------------------
 
 func TestTaskComplete_NoIdentity(t *testing.T) {
@@ -86,7 +86,7 @@ func TestTaskComplete_NoIdentity(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// task unblock — error paths
+// task unblock: error paths
 // ---------------------------------------------------------------------------
 
 func TestTaskUnblock_NoIdentity(t *testing.T) {
@@ -121,7 +121,7 @@ func TestTaskUnblock_NonexistentNode(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// task block — ParseAddress error after SplitTaskAddress succeeds
+// task block: ParseAddress error after SplitTaskAddress succeeds
 // ---------------------------------------------------------------------------
 
 func TestTaskBlock_InvalidNodeAfterSplit(t *testing.T) {
@@ -135,7 +135,7 @@ func TestTaskBlock_InvalidNodeAfterSplit(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// task claim — ParseAddress error after SplitTaskAddress succeeds
+// task claim: ParseAddress error after SplitTaskAddress succeeds
 // ---------------------------------------------------------------------------
 
 func TestTaskClaim_InvalidNodeAfterSplit(t *testing.T) {
@@ -148,7 +148,7 @@ func TestTaskClaim_InvalidNodeAfterSplit(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// task complete — ParseAddress error after SplitTaskAddress succeeds
+// task complete: ParseAddress error after SplitTaskAddress succeeds
 // ---------------------------------------------------------------------------
 
 func TestTaskComplete_InvalidNodeAfterSplit(t *testing.T) {
@@ -161,7 +161,7 @@ func TestTaskComplete_InvalidNodeAfterSplit(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// task unblock — ParseAddress error after SplitTaskAddress succeeds
+// task unblock: ParseAddress error after SplitTaskAddress succeeds
 // ---------------------------------------------------------------------------
 
 func TestTaskUnblock_InvalidNodeAfterSplit(t *testing.T) {
@@ -174,7 +174,7 @@ func TestTaskUnblock_InvalidNodeAfterSplit(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// task complete — validation edge cases
+// task complete: validation edge cases
 // ---------------------------------------------------------------------------
 
 func TestTaskComplete_ValidationDefaultTimeout(t *testing.T) {
@@ -219,7 +219,7 @@ func TestTaskComplete_DefaultConfig(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// task complete — JSON output when node becomes complete
+// task complete: JSON output when node becomes complete
 // ---------------------------------------------------------------------------
 
 func TestTaskComplete_JSONOutput_NodeComplete(t *testing.T) {
@@ -248,11 +248,11 @@ func TestTaskComplete_JSONOutput_NodeComplete(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// task complete — human output when node becomes complete
+// task complete: human output when node becomes complete
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
-// task claim — broken root index is non-fatal (MutateNode propagation
+// task claim: broken root index is non-fatal (MutateNode propagation
 // silently skips when the index can't be loaded)
 // ---------------------------------------------------------------------------
 
@@ -277,7 +277,7 @@ func TestTaskClaim_BrokenIndexStillClaims(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// task block — PropagateState error (broken root index)
+// task block: PropagateState error (broken root index)
 // ---------------------------------------------------------------------------
 
 func TestTaskBlock_BrokenIndexStillBlocks(t *testing.T) {
@@ -303,7 +303,7 @@ func TestTaskBlock_BrokenIndexStillBlocks(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// task complete — broken root index is non-fatal (MutateNode propagation
+// task complete: broken root index is non-fatal (MutateNode propagation
 // silently skips when the index can't be loaded)
 // ---------------------------------------------------------------------------
 
@@ -330,7 +330,7 @@ func TestTaskComplete_BrokenIndexStillCompletes(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// task unblock — broken root index is non-fatal (MutateNode propagation
+// task unblock: broken root index is non-fatal (MutateNode propagation
 // silently skips when the index can't be loaded)
 // ---------------------------------------------------------------------------
 
@@ -359,7 +359,7 @@ func TestTaskUnblock_BrokenIndexStillUnblocks(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// task add — TaskAdd error (non-leaf node)
+// task add: TaskAdd error (non-leaf node)
 // ---------------------------------------------------------------------------
 
 func TestTaskAdd_NonLeafNode(t *testing.T) {
@@ -402,7 +402,7 @@ func TestTaskComplete_NodeBecomeComplete(t *testing.T) {
 	env.RootCmd.SetArgs([]string{"task", "complete", "--node", "my-project/task-0001"})
 	_ = env.RootCmd.Execute()
 
-	// Complete audit task — node should become complete
+	// Complete audit task. Node should become complete
 	env.RootCmd.SetArgs([]string{"task", "claim", "--node", "my-project/audit"})
 	_ = env.RootCmd.Execute()
 

--- a/internal/archive/rollup_coverage_test.go
+++ b/internal/archive/rollup_coverage_test.go
@@ -20,7 +20,7 @@ func TestResolveOptionalClock_NilSlice(t *testing.T) {
 	if clk == nil {
 		t.Error("expected non-nil clock for nil slice")
 	}
-	// Should be real clock — just verify it returns a time
+	// Should be real clock. Just verify it returns a time
 	now := clk.Now()
 	if now.IsZero() {
 		t.Error("expected non-zero time from real clock")
@@ -103,7 +103,7 @@ func TestCollapseHyphens_LeadingTrailing(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// GenerateEntry — long slug truncation
+// GenerateEntry: long slug truncation
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestGenerateEntry_LongSlugTruncation(t *testing.T) {
@@ -179,7 +179,7 @@ func TestGenerateEntry_ConsecutiveHyphensInAddress(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// GenerateEntry — various node shapes
+// GenerateEntry: various node shapes
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestGenerateEntry_OrchestratorNode(t *testing.T) {

--- a/internal/config/audit_coverage_gaps_test.go
+++ b/internal/config/audit_coverage_gaps_test.go
@@ -1,0 +1,92 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dorkusprime/wolfcastle/internal/config"
+	"github.com/dorkusprime/wolfcastle/internal/testutil"
+)
+
+// ═══════════════════════════════════════════════════════════════════════════
+// BaseVersion: all branches (valid override, missing file, bad JSON, no field)
+// ═══════════════════════════════════════════════════════════════════════════
+
+func TestBaseVersion_DefaultFromEnvironment(t *testing.T) {
+	t.Parallel()
+	env := testutil.NewEnvironment(t)
+	repo := config.NewRepositoryWithTiers(env.Tiers, env.Root)
+
+	// NewEnvironment writes the default config (version 2) to base tier.
+	got := repo.BaseVersion()
+	if got != config.CurrentVersion {
+		t.Errorf("BaseVersion() = %d, want %d", got, config.CurrentVersion)
+	}
+}
+
+func TestBaseVersion_OverriddenVersion(t *testing.T) {
+	t.Parallel()
+	env := testutil.NewEnvironment(t)
+
+	// Overwrite the base config with a different version.
+	if err := env.Tiers.WriteBase("config.json", []byte(`{"version": 99}`)); err != nil {
+		t.Fatalf("writing base config: %v", err)
+	}
+
+	repo := config.NewRepositoryWithTiers(env.Tiers, env.Root)
+	got := repo.BaseVersion()
+	if got != 99 {
+		t.Errorf("BaseVersion() = %d, want 99", got)
+	}
+}
+
+func TestBaseVersion_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	env := testutil.NewEnvironment(t)
+
+	// Write invalid JSON to the base config.
+	if err := env.Tiers.WriteBase("config.json", []byte(`{not valid json`)); err != nil {
+		t.Fatalf("writing base config: %v", err)
+	}
+
+	repo := config.NewRepositoryWithTiers(env.Tiers, env.Root)
+	got := repo.BaseVersion()
+	if got != 0 {
+		t.Errorf("BaseVersion() = %d, want 0 for invalid JSON", got)
+	}
+}
+
+func TestBaseVersion_MissingFile(t *testing.T) {
+	t.Parallel()
+	env := testutil.NewEnvironment(t)
+
+	// Remove the base config file.
+	dirs := env.Tiers.TierDirs()
+	if len(dirs) > 0 {
+		_ = os.Remove(filepath.Join(dirs[0], "config.json"))
+	}
+
+	repo := config.NewRepositoryWithTiers(env.Tiers, env.Root)
+	got := repo.BaseVersion()
+	if got != 0 {
+		t.Errorf("BaseVersion() = %d, want 0 for missing file", got)
+	}
+}
+
+func TestBaseVersion_NoVersionField(t *testing.T) {
+	t.Parallel()
+	env := testutil.NewEnvironment(t)
+
+	// Write valid JSON without a version field.
+	if err := env.Tiers.WriteBase("config.json", []byte(`{"daemon": {}}`)); err != nil {
+		t.Fatalf("writing base config: %v", err)
+	}
+
+	repo := config.NewRepositoryWithTiers(env.Tiers, env.Root)
+	// Missing version field is treated as implicit v1 by configVersion().
+	got := repo.BaseVersion()
+	if got != 1 {
+		t.Errorf("BaseVersion() = %d, want 1 for missing version field (implicit v1)", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -263,7 +263,7 @@ func Load(wolfcastleDir string) (*Config, error) {
 
 	cfg.Warnings = warnings
 
-	// Validate structural integrity (skip identity — handled by resolver)
+	// Validate structural integrity (skip identity; handled by resolver)
 	if err := ValidateStructure(&cfg); err != nil {
 		return nil, fmt.Errorf("config validation failed: %w", err)
 	}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -203,7 +203,7 @@ func Validate(cfg *Config) error {
 		errs = append(errs, "unblock.prompt_file must not be empty")
 	}
 
-	// Overlap advisory model is optional — algorithmic detection (ADR-041)
+	// Overlap advisory model is optional. Algorithmic detection (ADR-041)
 	// does not require a model. The model field is retained for potential
 	// future hybrid use but is not validated.
 
@@ -217,7 +217,7 @@ func Validate(cfg *Config) error {
 
 	// Check identity presence
 	if cfg.Identity == nil {
-		errs = append(errs, "identity not configured. Run 'wolfcastle init' first")
+		errs = append(errs, "identity not configured")
 	}
 
 	if len(errs) > 0 {

--- a/internal/daemon/audit_coverage_test.go
+++ b/internal/daemon/audit_coverage_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// sleepWithContext — both branches
+// sleepWithContext: both branches
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestSleepWithContext_FullSleep(t *testing.T) {
@@ -49,7 +49,7 @@ func TestSleepWithContext_ContextCancelledDuringSleep(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runInboxWithPolling — context cancellation exits cleanly
+// runInboxWithPolling: context cancellation exits cleanly
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunInboxWithPolling_ExitsOnCancel(t *testing.T) {
@@ -111,7 +111,7 @@ func TestRunInboxWithPolling_BlockedPollFallback(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runInboxLoop — polling fallback when fsnotify fails
+// runInboxLoop: polling fallback when fsnotify fails
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunInboxLoop_ExitsOnCancel(t *testing.T) {
@@ -126,7 +126,7 @@ func TestRunInboxLoop_ExitsOnCancel(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// git.CurrentBranch — fallback paths
+// git.CurrentBranch: fallback paths
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestCurrentBranch_NotAGitRepo(t *testing.T) {
@@ -156,7 +156,7 @@ func TestCurrentBranch_EmptyRepo(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// processInbox — no matching intake stage
+// processInbox: no matching intake stage
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestProcessInbox_NoIntakeStage(t *testing.T) {
@@ -183,7 +183,7 @@ func TestProcessInbox_IntakeStageDisabled(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// RunOnce — iteration cap (new test, stop/shutdown covered elsewhere)
+// RunOnce: iteration cap (new test, stop/shutdown covered elsewhere)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunOnce_IterationCapReached(t *testing.T) {
@@ -204,7 +204,7 @@ func TestRunOnce_IterationCapReached(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIntakeStage — error paths
+// runIntakeStage: error paths
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIntakeStage_MissingModel(t *testing.T) {
@@ -284,7 +284,7 @@ func TestRunIntakeStage_WithExistingTree(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// checkInboxForNew — the stages.go variant
+// checkInboxForNew: the stages.go variant
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestCheckInboxForNew_MissingFile(t *testing.T) {

--- a/internal/daemon/category_a_test.go
+++ b/internal/daemon/category_a_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// selfHeal — multiple in-progress tasks are healed (reset to not_started)
+// selfHeal: multiple in-progress tasks are healed (reset to not_started)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestSelfHeal_MultipleInProgress_ResetsAll(t *testing.T) {
@@ -69,7 +69,7 @@ func TestSelfHeal_MultipleInProgress_ResetsAll(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// RunOnce — branch change detection via d.branch mismatch
+// RunOnce: branch change detection via d.branch mismatch
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunOnce_BranchMismatchDetection(t *testing.T) {
@@ -125,7 +125,7 @@ func catAFindRepoRoot() string {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// iteration.go — invoke error return path
+// iteration.go: invoke error return path
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_InvokeErrorReturnsError(t *testing.T) {
@@ -154,7 +154,7 @@ func TestRunIteration_InvokeErrorReturnsError(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// iteration.go — failure escalation: decomposition threshold with depth OK
+// iteration.go: failure escalation: decomposition threshold with depth OK
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_DecompThreshold_SetsNeedsDecomposition(t *testing.T) {
@@ -203,7 +203,7 @@ func TestRunIteration_DecompThreshold_SetsNeedsDecomposition(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// iteration.go — failure escalation: decomposition at max depth (auto-block)
+// iteration.go: failure escalation: decomposition at max depth (auto-block)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_DecompAtMaxDepth_TaskAutoBlocked(t *testing.T) {
@@ -264,7 +264,7 @@ func TestRunIteration_DecompAtMaxDepth_TaskAutoBlocked(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// iteration.go — hard cap auto-block path
+// iteration.go: hard cap auto-block path
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_HardCapReached_TaskAutoBlocked(t *testing.T) {
@@ -315,7 +315,7 @@ func TestRunIteration_HardCapReached_TaskAutoBlocked(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// iteration.go — IncrementFailure error path
+// iteration.go: IncrementFailure error path
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_NoTerminalMarker_FailureIncremented(t *testing.T) {
@@ -346,7 +346,7 @@ func TestRunIteration_NoTerminalMarker_FailureIncremented(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// propagate.go — ParseAddress error in loadNode callback
+// propagate.go: ParseAddress error in loadNode callback
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestPropagateState_EmptyParentAddr_LoadNodeError(t *testing.T) {
@@ -373,7 +373,7 @@ func TestPropagateState_EmptyParentAddr_LoadNodeError(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// propagate.go — saveNode callback exercised via valid propagation
+// propagate.go: saveNode callback exercised via valid propagation
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestPropagateState_SaveNodeCallbackExercised(t *testing.T) {
@@ -409,7 +409,7 @@ func TestPropagateState_SaveNodeCallbackExercised(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// retry.go — context cancellation before invocation
+// retry.go: context cancellation before invocation
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestInvokeWithRetry_PreCancelledContext(t *testing.T) {
@@ -430,7 +430,7 @@ func TestInvokeWithRetry_PreCancelledContext(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// retry.go — context cancellation during backoff wait
+// retry.go: context cancellation during backoff wait
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestInvokeWithRetry_CancelDuringBackoff(t *testing.T) {
@@ -457,7 +457,7 @@ func TestInvokeWithRetry_CancelDuringBackoff(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// stages.go — model not found in intake stage (with prompt file present)
+// stages.go: model not found in intake stage (with prompt file present)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIntakeStage_MissingModelWithPrompt(t *testing.T) {
@@ -483,7 +483,7 @@ func TestRunIntakeStage_MissingModelWithPrompt(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// stages.go — invoke error in intake stage
+// stages.go: invoke error in intake stage
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIntakeStage_BrokenCommand(t *testing.T) {
@@ -508,7 +508,7 @@ func TestRunIntakeStage_BrokenCommand(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// stages.go — prompt assembly error in intake stage
+// stages.go: prompt assembly error in intake stage
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIntakeStage_MissingPromptFile(t *testing.T) {

--- a/internal/daemon/coverage_test.go
+++ b/internal/daemon/coverage_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// New — error paths
+// New: error paths
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestNew_LogDirCreationFails(t *testing.T) {
@@ -56,7 +56,7 @@ func TestNew_ResumesIteration(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// RunOnce — additional scenarios
+// RunOnce: additional scenarios
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunOnce_NoRootIndex(t *testing.T) {
@@ -156,7 +156,7 @@ func TestResolveContextHeader_WithTemplate(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// propagateState — edge cases
+// propagateState: edge cases
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestPropagateState_MissingRootIndex(t *testing.T) {
@@ -166,7 +166,7 @@ func TestPropagateState_MissingRootIndex(t *testing.T) {
 	idx.Nodes["node-a"] = state.IndexEntry{
 		Name: "A", Type: state.NodeLeaf, State: state.StatusNotStarted, Address: "node-a",
 	}
-	// Don't write the root index to disk — SaveRootIndex will be attempted
+	// Don't write the root index to disk. SaveRootIndex will be attempted
 	// but the projects dir exists, so propagateState should still attempt to save.
 	err := d.propagateState("node-a", state.StatusInProgress, idx)
 	// This should succeed as it only needs to save the index
@@ -218,7 +218,7 @@ func TestPropagateState_DeepHierarchy(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// selfHeal — skips bad addresses, missing state files
+// selfHeal: skips bad addresses, missing state files
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestSelfHeal_BadAddressSkipped(t *testing.T) {
@@ -250,7 +250,7 @@ func TestSelfHeal_MissingStateFileSkipped(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIteration — intake stage is skipped in the iteration pipeline
+// runIteration: intake stage is skipped in the iteration pipeline
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_IntakeStageSkipped(t *testing.T) {
@@ -277,7 +277,7 @@ func TestRunIteration_IntakeStageSkipped(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// RunWithSupervisor — restart after crash
+// RunWithSupervisor: restart after crash
 // ═══════════════════════════════════════════════════════════════════════════
 
 // RunWithSupervisor restart path cannot be tested under -race because
@@ -286,7 +286,7 @@ func TestRunIteration_IntakeStageSkipped(t *testing.T) {
 // structurally simple and verified by code review.
 
 // ═══════════════════════════════════════════════════════════════════════════
-// git.CurrentBranch — success case in current repo
+// git.CurrentBranch: success case in current repo
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestCurrentBranch_CurrentRepo(t *testing.T) {
@@ -309,7 +309,7 @@ func TestCurrentBranch_CurrentRepo(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIntakeStage — invocation timeout path
+// runIntakeStage: invocation timeout path
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIntakeStage_InvocationTimeout(t *testing.T) {
@@ -331,7 +331,7 @@ func TestRunIntakeStage_InvocationTimeout(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIntakeStage — zero invocation timeout (no timeout set)
+// runIntakeStage: zero invocation timeout (no timeout set)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIntakeStage_NoInvocationTimeout(t *testing.T) {
@@ -353,7 +353,7 @@ func TestRunIntakeStage_NoInvocationTimeout(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Run — integration coverage for main loop paths
+// Run: integration coverage for main loop paths
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRun_AllComplete_ExitsCleanly(t *testing.T) {
@@ -461,7 +461,7 @@ func TestRun_BranchVerifyEnabled(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
-	// Should succeed — branch won't change during the test
+	// Should succeed. Branch won't change during the test
 	err := d.Run(ctx)
 	if err != nil {
 		t.Skipf("Run() error (possibly not in git repo): %v", err)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -11,15 +11,15 @@
 //
 // File layout follows ADR-045:
 //
-//   - daemon.go    — Daemon struct, New, Run, RunWithSupervisor, RunOnce
-//   - iteration.go   — per-iteration pipeline dispatch, terminal marker scanning
-//   - stages.go      — intake stage handler, parallel inbox goroutine
-//   - deliverables.go — deliverable file verification
-//   - retry.go       — invocation retry with exponential backoff
-//   - propagate.go   — state propagation via Store
-//   - pid.go             — PID file operations
-//   - signals_unix.go    — shutdown signals (Unix)
-//   - signals_windows.go — shutdown signals (Windows)
+//   - daemon.go   : Daemon struct, New, Run, RunWithSupervisor, RunOnce
+//   - iteration.go  : per-iteration pipeline dispatch, terminal marker scanning
+//   - stages.go     : intake stage handler, parallel inbox goroutine
+//   - deliverables.go: deliverable file verification
+//   - retry.go      : invocation retry with exponential backoff
+//   - propagate.go  : state propagation via Store
+//   - pid.go            : PID file operations
+//   - signals_unix.go   : shutdown signals (Unix)
+//   - signals_windows.go: shutdown signals (Windows)
 package daemon
 
 import (
@@ -572,7 +572,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 			case <-d.workAvailable:
 				// New work arrived from inbox goroutine
 			case <-time.After(time.Duration(d.Config.Daemon.BlockedPollIntervalSeconds) * time.Second):
-				// Poll timeout — loop back to RunOnce, spinner stays alive
+				// Poll timeout. Loop back to RunOnce, spinner stays alive
 				continue
 			}
 			// Leaving idle state: stop and discard spinner

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -592,7 +592,7 @@ func TestRunOnce_BranchChange(t *testing.T) {
 
 	// Git service points at temp dir (no git repo) so CurrentBranch errors
 	result, err := d.RunOnce(context.Background())
-	// Either branch check errors or root index load errors — both acceptable
+	// Either branch check errors or root index load errors. Both acceptable
 	_ = result
 	_ = err
 }

--- a/internal/daemon/deep_coverage_test.go
+++ b/internal/daemon/deep_coverage_test.go
@@ -9,17 +9,17 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// propagateState — error paths and deep hierarchies
+// propagateState: error paths and deep hierarchies
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestPropagateState_NodeNotInIndex(t *testing.T) {
 	d := testDaemon(t)
 	idx := state.NewRootIndex()
 
-	// Node not in index — propagateState succeeds but does nothing meaningful
+	// Node not in index. PropagateState succeeds but does nothing meaningful
 	// since there's nothing to propagate up from
 	err := d.propagateState("nonexistent-node", state.StatusInProgress, idx)
-	// Should succeed — the function just saves the index
+	// Should succeed. The function just saves the index
 	if err != nil {
 		t.Logf("propagateState for missing node: %v (may be acceptable)", err)
 	}
@@ -41,7 +41,7 @@ func TestPropagateState_ParentLoadError(t *testing.T) {
 	}
 	writeJSON(t, filepath.Join(d.Store.Dir(), "state.json"), idx)
 
-	// Don't create parent state.json on disk — loadNode for parent will fail
+	// Don't create parent state.json on disk. LoadNode for parent will fail
 	// but propagateState should still succeed or return an error gracefully
 	err := d.propagateState("parent/child", state.StatusInProgress, idx)
 	// This exercises the loadNode error path inside state.Propagate
@@ -104,7 +104,7 @@ func TestPropagateState_FourLevelHierarchy(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// checkInboxState — various states
+// checkInboxState: various states
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestCheckInboxState_NoFile(t *testing.T) {

--- a/internal/daemon/edge_cases_test.go
+++ b/internal/daemon/edge_cases_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// scanTerminalMarker — malformed and garbage model output
+// scanTerminalMarker: malformed and garbage model output
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestScanTerminalMarker_MalformedResponses(t *testing.T) {
@@ -146,7 +146,7 @@ func TestScanTerminalMarker_MalformedResponses(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// extractAssistantText — edge cases
+// extractAssistantText: edge cases
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestExtractAssistantText_EdgeCases(t *testing.T) {
@@ -179,7 +179,7 @@ func TestExtractAssistantText_EdgeCases(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// sleepWithContext — unit tests
+// sleepWithContext: unit tests
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestSleepWithContext_CompletesNormally(t *testing.T) {
@@ -201,7 +201,7 @@ func TestSleepWithContext_PreCancelledContext(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// invokeWithRetry — unlimited retries (-1), exponential backoff doubling
+// invokeWithRetry: unlimited retries (-1), exponential backoff doubling
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestInvokeWithRetry_UnlimitedRetriesRespectsContextCancel(t *testing.T) {
@@ -250,7 +250,7 @@ func TestInvokeWithRetry_ZeroMaxRetries_NoRetry(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIteration — model outputs plain text (no CLI commands, no marker)
+// runIteration: model outputs plain text (no CLI commands, no marker)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_PlainTextOutput_NoToolUse(t *testing.T) {
@@ -304,7 +304,7 @@ echo "Let me know if you have questions."`},
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIteration — model command fails with nonzero exit code
+// runIteration: model command fails with nonzero exit code
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_NonzeroExitCode_NoMarker(t *testing.T) {
@@ -353,7 +353,7 @@ func TestRunIteration_NonzeroExitCode_NoMarker(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIteration — model produces COMPLETE with warning-level output
+// runIteration: model produces COMPLETE with warning-level output
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_CompleteWithWarnings(t *testing.T) {
@@ -402,7 +402,7 @@ echo "WOLFCASTLE_COMPLETE"`},
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIntakeStage — nonzero exit code leaves items as "new"
+// runIntakeStage: nonzero exit code leaves items as "new"
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIntakeStage_NonzeroExitCode_ItemsStayNew(t *testing.T) {
@@ -436,7 +436,7 @@ func TestRunIntakeStage_NonzeroExitCode_ItemsStayNew(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIntakeStage — includes existing tree context in prompt
+// runIntakeStage: includes existing tree context in prompt
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIntakeStage_IncludesExistingTreeContext(t *testing.T) {
@@ -490,7 +490,7 @@ echo "WOLFCASTLE_COMPLETE"
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// selfHeal — single interrupted task with multiple complete tasks
+// selfHeal: single interrupted task with multiple complete tasks
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestSelfHeal_OneInProgressAmongManyComplete(t *testing.T) {
@@ -523,7 +523,7 @@ func TestSelfHeal_OneInProgressAmongManyComplete(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIteration — context cancelled during model execution
+// runIteration: context cancelled during model execution
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_ContextCancelledDuringExecution(t *testing.T) {
@@ -566,7 +566,7 @@ func TestRunIteration_ContextCancelledDuringExecution(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIteration — model produces partial marker output
+// runIteration: model produces partial marker output
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_PartialMarkerOutput(t *testing.T) {
@@ -641,7 +641,7 @@ func TestRunIteration_PartialMarkerOutput(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIteration — model writes garbage JSON to stdout
+// runIteration: model writes garbage JSON to stdout
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_GarbageJSONOutput(t *testing.T) {
@@ -692,7 +692,7 @@ echo 'random text at the end'`},
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIteration — empty stdout from model
+// runIteration: empty stdout from model
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_EmptyOutput(t *testing.T) {
@@ -737,7 +737,7 @@ func TestRunIteration_EmptyOutput(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIteration — prompt assembly error
+// runIteration: prompt assembly error
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_PromptAssemblyError(t *testing.T) {
@@ -767,7 +767,7 @@ func TestRunIteration_PromptAssemblyError(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// RunOnce — empty tree (no root index entries)
+// RunOnce: empty tree (no root index entries)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunOnce_EmptyTree(t *testing.T) {
@@ -788,7 +788,7 @@ func TestRunOnce_EmptyTree(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIteration — deliverables unchanged rejects COMPLETE
+// runIteration: deliverables unchanged rejects COMPLETE
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_NoGitProgress_RejectsComplete(t *testing.T) {
@@ -874,7 +874,7 @@ func initTestGitRepo(t *testing.T, dir string) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// RunOnce — state error from RunOnce returns IterationStop
+// RunOnce: state error from RunOnce returns IterationStop
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunOnce_StateError_ReturnsFatal(t *testing.T) {
@@ -909,7 +909,7 @@ func TestRunOnce_StateError_ReturnsFatal(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// workAvailable channel — intake signals execute loop
+// workAvailable channel: intake signals execute loop
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestIntakeStage_SignalsWorkAvailable(t *testing.T) {
@@ -943,7 +943,7 @@ func TestIntakeStage_SignalsWorkAvailable(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// RunOnce — repeated NoWork messages are deduplicated
+// RunOnce: repeated NoWork messages are deduplicated
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunOnce_NoWorkDeduplication(t *testing.T) {
@@ -975,11 +975,11 @@ func TestRunOnce_NoWorkDeduplication(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// checkDeliverables — glob pattern with subdirectory
+// checkDeliverables: glob pattern with subdirectory
 // ═══════════════════════════════════════════════════════════════════════════
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIteration — multiple stages, only execute runs (intake skipped)
+// runIteration: multiple stages, only execute runs (intake skipped)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_MultipleStages_CustomStagesRun(t *testing.T) {
@@ -1020,7 +1020,7 @@ func TestRunIteration_MultipleStages_CustomStagesRun(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// checkInboxForNew vs checkInboxState — exercise both code paths
+// checkInboxForNew vs checkInboxState: exercise both code paths
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestCheckInboxForNew_InvalidJSON(t *testing.T) {

--- a/internal/daemon/iteration.go
+++ b/internal/daemon/iteration.go
@@ -136,7 +136,7 @@ func (d *Daemon) runIteration(ctx context.Context, nav *state.NavigationResult, 
 			"duration_ms": stageDuration.Milliseconds(),
 		})
 
-		// Reload state from disk — CLI commands invoked by the model may
+		// Reload state from disk. CLI commands invoked by the model may
 		// have mutated state.json during execution (breadcrumbs, gaps, scope, etc.)
 		ns, err = d.Store.ReadNode(nav.NodeAddress)
 		if err != nil {

--- a/internal/daemon/iteration_coverage_test.go
+++ b/internal/daemon/iteration_coverage_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIteration — already in_progress task skips claim
+// runIteration: already in_progress task skips claim
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_AlreadyInProgress_SkipsClaim(t *testing.T) {
@@ -50,7 +50,7 @@ func TestRunIteration_AlreadyInProgress_SkipsClaim(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIteration — WOLFCASTLE_YIELD with planning disabled + new tasks
+// runIteration: WOLFCASTLE_YIELD with planning disabled + new tasks
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_YieldDecomposition_PlanningDisabled(t *testing.T) {
@@ -110,7 +110,7 @@ with open('%s','w') as f: json.dump(data, f)
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIteration — WOLFCASTLE_YIELD with planning enabled + new tasks
+// runIteration: WOLFCASTLE_YIELD with planning enabled + new tasks
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_YieldDecomposition_PlanningEnabled(t *testing.T) {
@@ -165,7 +165,7 @@ with open('%s','w') as f: json.dump(data, f)
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIteration — WOLFCASTLE_YIELD with no new tasks
+// runIteration: WOLFCASTLE_YIELD with no new tasks
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_YieldNoNewTasks(t *testing.T) {
@@ -204,7 +204,7 @@ func TestRunIteration_YieldNoNewTasks(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIteration — WOLFCASTLE_BLOCKED with superseded detection
+// runIteration: WOLFCASTLE_BLOCKED with superseded detection
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_BlockedSuperseded_TreatedAsSkip(t *testing.T) {
@@ -245,7 +245,7 @@ func TestRunIteration_BlockedSuperseded_TreatedAsSkip(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIteration — WOLFCASTLE_BLOCKED triggers remediation subtasks
+// runIteration: WOLFCASTLE_BLOCKED triggers remediation subtasks
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_BlockedAudit_CreatesRemediationSubtasks(t *testing.T) {
@@ -348,7 +348,7 @@ func TestRunIteration_RemediationSubtasks_InheritClass(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIteration — WOLFCASTLE_BLOCKED normal path (propagateState)
+// runIteration: WOLFCASTLE_BLOCKED normal path (propagateState)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_BlockedNormal_BlocksAndPropagates(t *testing.T) {
@@ -391,7 +391,7 @@ func TestRunIteration_BlockedNormal_BlocksAndPropagates(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIteration — WOLFCASTLE_COMPLETE with missing deliverables (warning)
+// runIteration: WOLFCASTLE_COMPLETE with missing deliverables (warning)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_Complete_MissingDeliverables(t *testing.T) {
@@ -429,7 +429,7 @@ func TestRunIteration_Complete_MissingDeliverables(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIteration — WOLFCASTLE_COMPLETE for audit task (skips git check)
+// runIteration: WOLFCASTLE_COMPLETE for audit task (skips git check)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_CompleteAudit_SkipsGitCheck(t *testing.T) {
@@ -463,7 +463,7 @@ func TestRunIteration_CompleteAudit_SkipsGitCheck(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIteration — WOLFCASTLE_COMPLETE with no git progress (non-audit)
+// runIteration: WOLFCASTLE_COMPLETE with no git progress (non-audit)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_CompleteNoGitProgress_FailsTask(t *testing.T) {
@@ -513,7 +513,7 @@ func TestRunIteration_CompleteNoGitProgress_FailsTask(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIteration — WOLFCASTLE_SKIP with planning disabled (autoComplete)
+// runIteration: WOLFCASTLE_SKIP with planning disabled (autoComplete)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_Skip_AutoCompleteDecomposedParent(t *testing.T) {
@@ -957,7 +957,7 @@ func TestCommitWithSeparateIndex_TempFileCleanedUp(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// autoCompleteDecomposedParents — edge cases
+// autoCompleteDecomposedParents: edge cases
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestAutoCompleteDecomposedParents_MissingSubtask(t *testing.T) {
@@ -1062,7 +1062,7 @@ func TestIsSupersededBlock_TaskNotFound(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// findNewTasks — audit exclusion
+// findNewTasks: audit exclusion
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestFindNewTasks_ExcludesAuditTasks(t *testing.T) {
@@ -1090,7 +1090,7 @@ func TestFindNewTasks_ExcludesAuditTasks(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIteration — failure type detection
+// runIteration: failure type detection
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_NoProgress_FailureType(t *testing.T) {

--- a/internal/daemon/iteration_test.go
+++ b/internal/daemon/iteration_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// commitAfterIteration — config flag combinations
+// commitAfterIteration: config flag combinations
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestCommitAfterIteration_AutoCommitDisabled(t *testing.T) {
@@ -211,7 +211,7 @@ func TestCommitAfterIteration_InvalidTaskID_Skips(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// commitAfterIteration — enriched commit messages
+// commitAfterIteration: enriched commit messages
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestCommitAfterIteration_EnrichedMessages(t *testing.T) {
@@ -366,7 +366,7 @@ func TestCommitAfterIteration_EnrichedMessages(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIteration — success-path commit integration
+// runIteration: success-path commit integration
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_SuccessCommit_CreatesCommit(t *testing.T) {
@@ -517,7 +517,7 @@ func TestRunIteration_SuccessCommit_SkippedWhenAutoCommitDisabled(t *testing.T) 
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIteration — failure-path commit integration
+// runIteration: failure-path commit integration
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_FailureCommit_CreatesCommit(t *testing.T) {
@@ -614,7 +614,7 @@ func TestRunIteration_FailureCommit_SkippedWhenDisabled(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIteration — clean working tree skip (no empty commits)
+// runIteration: clean working tree skip (no empty commits)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIteration_SuccessCleanTree_NoEmptyCommit(t *testing.T) {
@@ -659,7 +659,7 @@ func TestRunIteration_SuccessCleanTree_NoEmptyCommit(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// commitDirect — scope-aware behavior
+// commitDirect: scope-aware behavior
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestCommitDirect_NilScope_StagesEverything(t *testing.T) {
@@ -813,7 +813,7 @@ func TestCommitDirect_NonNilScope_CommitStateFalse_ExcludesWolfcastle(t *testing
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// commitAfterIteration — scope-aware behavior
+// commitAfterIteration: scope-aware behavior
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestCommitAfterIteration_NilScope_GlobalStatusCheck(t *testing.T) {

--- a/internal/daemon/knowledge_maintenance.go
+++ b/internal/daemon/knowledge_maintenance.go
@@ -62,7 +62,7 @@ func (d *Daemon) checkKnowledgeBudget(nodeAddr string) bool {
 			"1. Remove entries that are stale or no longer accurate\n"+
 			"2. Consolidate related entries into single, concise bullets\n"+
 			"3. Remove entries that duplicate information in README, CONTRIBUTING.md, specs, or ADRs\n"+
-			"4. If an entry describes an enforceable convention or coding standard (naming rules, import patterns, style requirements), migrate it to the appropriate class file or rule fragment instead of keeping it in the knowledge file — knowledge entries should be observations, not rules\n"+
+			"4. If an entry describes an enforceable convention or coding standard (naming rules, import patterns, style requirements), migrate it to the appropriate class file or rule fragment instead of keeping it in the knowledge file. Knowledge entries should be observations, not rules\n"+
 			"5. Bring the total under %d tokens\n\n"+
 			"Use `wolfcastle knowledge show` to view the current file and `wolfcastle knowledge prune` to edit it.",
 		ns, tokens, maxTokens,

--- a/internal/daemon/planning_coverage_test.go
+++ b/internal/daemon/planning_coverage_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// dfsFindPlanning — coverage gaps
+// dfsFindPlanning: coverage gaps
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestDfsFindPlanning_ReadNodeError(t *testing.T) {
@@ -215,7 +215,7 @@ func TestFindPlanningTarget_ScopeNodePath(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runPlanningPass — coverage gaps
+// runPlanningPass: coverage gaps
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunPlanningPass_ModelNotFound(t *testing.T) {
@@ -490,7 +490,7 @@ func TestRunPlanningPass_EmptyTriggerDefaultsToInitial(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// recordPlanningPass — history cap
+// recordPlanningPass: history cap
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRecordPlanningPass_CapsAtFiveEntries(t *testing.T) {
@@ -518,7 +518,7 @@ func TestRecordPlanningPass_CapsAtFiveEntries(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// incrementReplanCount — config fallback and default
+// incrementReplanCount: config fallback and default
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestIncrementReplanCount_UsesConfigMaxReplans(t *testing.T) {
@@ -576,7 +576,7 @@ func TestIncrementReplanCount_DefaultMaxReplansThree(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// checkReplanningTriggers — coverage gaps
+// checkReplanningTriggers: coverage gaps
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestCheckReplanningTriggers_PlanningDisabled(t *testing.T) {
@@ -822,7 +822,7 @@ func TestCheckReplanningTriggers_MixedChildStates(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// deliverPendingScope — ReadNode error
+// deliverPendingScope: ReadNode error
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestDeliverPendingScope_ReadNodeError(t *testing.T) {

--- a/internal/daemon/remediation_test.go
+++ b/internal/daemon/remediation_test.go
@@ -172,7 +172,7 @@ func TestRunIteration_MissingDeliverables_WarnsButCompletes(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// findNewTasks — detects new non-audit tasks between snapshots
+// findNewTasks: detects new non-audit tasks between snapshots
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestFindNewTasks(t *testing.T) {
@@ -230,7 +230,7 @@ func TestFindNewTasks_NoNewTasks(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// autoCompleteDecomposedParents — blocked parent auto-completes
+// autoCompleteDecomposedParents: blocked parent auto-completes
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestAutoCompleteDecomposedParents(t *testing.T) {

--- a/internal/daemon/retry.go
+++ b/internal/daemon/retry.go
@@ -13,7 +13,7 @@ import (
 
 // invokeWithRetry wraps ProcessInvoker.Invoke with exponential backoff
 // governed by the config's retries settings. Only invocation errors (non-nil
-// error returns) are retried — a successful process exit (even with a
+// error returns) are retried. A successful process exit (even with a
 // non-zero exit code captured in Result) is not retried here.
 func (d *Daemon) invokeWithRetry(ctx context.Context, model config.ModelDef, prompt string, workDir string, logWriter io.Writer, stageName string) (*invoke.Result, error) {
 	rc := d.Config.Retries
@@ -31,7 +31,7 @@ func (d *Daemon) invokeWithRetry(ctx context.Context, model config.ModelDef, pro
 			return result, nil
 		}
 
-		// Context cancellation is not retryable — the daemon is shutting down.
+		// Context cancellation is not retryable; the daemon is shutting down.
 		if ctx.Err() != nil {
 			return result, err
 		}

--- a/internal/daemon/run_loop_test.go
+++ b/internal/daemon/run_loop_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Run — stop-file detection mid-loop
+// Run: stop-file detection mid-loop
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRun_StopFileMidLoop(t *testing.T) {
@@ -53,7 +53,7 @@ func TestRun_StopFileMidLoop(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Run — shutdown channel closes during idle select
+// Run: shutdown channel closes during idle select
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRun_ShutdownDuringIdle(t *testing.T) {
@@ -82,7 +82,7 @@ func TestRun_ShutdownDuringIdle(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Run — workAvailable channel wakes idle loop
+// Run: workAvailable channel wakes idle loop
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRun_WorkAvailableWakesIdleLoop(t *testing.T) {
@@ -137,7 +137,7 @@ func TestRun_WorkAvailableWakesIdleLoop(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Run — context cancellation at top of loop (with spinner active)
+// Run: context cancellation at top of loop (with spinner active)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRun_ContextCancelAtLoopTop(t *testing.T) {
@@ -165,7 +165,7 @@ func TestRun_ContextCancelAtLoopTop(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Run — IterationError path sleeps then retries
+// Run: IterationError path sleeps then retries
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRun_IterationErrorSleepsAndRetries(t *testing.T) {
@@ -205,7 +205,7 @@ func TestRun_IterationErrorSleepsAndRetries(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Run — IterationError with context cancel during sleep
+// Run: IterationError with context cancel during sleep
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRun_IterationErrorContextCancelDuringSleep(t *testing.T) {
@@ -236,7 +236,7 @@ func TestRun_IterationErrorContextCancelDuringSleep(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Run — IterationDidWork exercises log retention
+// Run: IterationDidWork exercises log retention
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRun_DidWorkEnforcesLogRetention(t *testing.T) {
@@ -264,7 +264,7 @@ func TestRun_DidWorkEnforcesLogRetention(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Run — context cancelled during idle select (ctx.Done case, lines 338-340)
+// Run: context cancelled during idle select (ctx.Done case, lines 338-340)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRun_ContextCancelDuringIdleSelect(t *testing.T) {

--- a/internal/daemon/runonce_branches_test.go
+++ b/internal/daemon/runonce_branches_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// RunOnce — context cancelled after navigation (line 436-438)
+// RunOnce: context cancelled after navigation (line 436-438)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunOnce_ContextCancelledBeforeExecution(t *testing.T) {
@@ -41,7 +41,7 @@ func TestRunOnce_ContextCancelledBeforeExecution(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// RunOnce — planning pass success returns IterationDidWork (lines 449-455)
+// RunOnce: planning pass success returns IterationDidWork (lines 449-455)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunOnce_PlanningPassSuccess(t *testing.T) {
@@ -80,7 +80,7 @@ func TestRunOnce_PlanningPassSuccess(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// RunOnce — planning pass error returns IterationError (lines 450-453)
+// RunOnce: planning pass error returns IterationError (lines 450-453)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunOnce_PlanningPassError(t *testing.T) {
@@ -116,7 +116,7 @@ func TestRunOnce_PlanningPassError(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// RunOnce — default no-work reason (lines 467-468)
+// RunOnce: default no-work reason (lines 467-468)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunOnce_DefaultNoWorkReason(t *testing.T) {
@@ -159,7 +159,7 @@ func TestRunOnce_DefaultNoWorkReason(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// RunOnce — StateError from runIteration returns fatal (lines 496-499)
+// RunOnce: StateError from runIteration returns fatal (lines 496-499)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunOnce_StateErrorIsFatal(t *testing.T) {
@@ -216,7 +216,7 @@ func TestRunOnce_StateErrorIsFatal(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// RunOnce — replanning triggers after successful work (lines 506-511)
+// RunOnce: replanning triggers after successful work (lines 506-511)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunOnce_ReplanningTriggersAfterWork(t *testing.T) {
@@ -272,7 +272,7 @@ func TestRunOnce_ReplanningTriggersAfterWork(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// RunOnce — nodeLoader parse error (line 425-427)
+// RunOnce: nodeLoader parse error (line 425-427)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunOnce_NodeLoaderParseError(t *testing.T) {
@@ -300,7 +300,7 @@ func TestRunOnce_NodeLoaderParseError(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// RunOnce — RunOnce error from runIteration (non-StateError) returns
+// RunOnce: RunOnce error from runIteration (non-StateError) returns
 // IterationError (line 501)
 // ═══════════════════════════════════════════════════════════════════════════
 
@@ -329,7 +329,7 @@ func TestRunOnce_NonStateErrorReturnsIterationError(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// RunOnce — branch verification detects change (lines 406-411)
+// RunOnce: branch verification detects change (lines 406-411)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunOnce_BranchChangeDetected(t *testing.T) {

--- a/internal/daemon/stages_chmod_test.go
+++ b/internal/daemon/stages_chmod_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/dorkusprime/wolfcastle/internal/state"
 )
 
-// ── runIntakeStage — SaveInbox error after intake ───────────────────
+// ── runIntakeStage: SaveInbox error after intake ───────────────────
 
 func TestRunIntakeStage_SaveInboxError_ReadOnly(t *testing.T) {
 	if runtime.GOOS == "windows" {

--- a/internal/daemon/stages_coverage_test.go
+++ b/internal/daemon/stages_coverage_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runInboxLoop — fallback to polling when watcher.Add fails
+// runInboxLoop: fallback to polling when watcher.Add fails
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunInboxLoop_FallbackToPolling_WatcherAddFails(t *testing.T) {
@@ -40,7 +40,7 @@ func TestRunInboxLoop_FallbackToPolling_WatcherAddFails(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runInboxWithFsnotify — watcher.Events channel closed
+// runInboxWithFsnotify: watcher.Events channel closed
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunInboxWithFsnotify_EventsChannelClosed(t *testing.T) {
@@ -72,7 +72,7 @@ func TestRunInboxWithFsnotify_EventsChannelClosed(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runInboxWithFsnotify — watcher error event
+// runInboxWithFsnotify: watcher error event
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunInboxWithFsnotify_WatcherError(t *testing.T) {
@@ -110,7 +110,7 @@ func TestRunInboxWithFsnotify_WatcherError(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runInboxWithFsnotify — context done during select
+// runInboxWithFsnotify: context done during select
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunInboxWithFsnotify_ContextCancelledDuringLoop(t *testing.T) {
@@ -136,7 +136,7 @@ func TestRunInboxWithFsnotify_ContextCancelledDuringLoop(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// processInbox — intake stage error propagation
+// processInbox: intake stage error propagation
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestProcessInbox_IntakeStageError(t *testing.T) {
@@ -163,7 +163,7 @@ func TestProcessInbox_IntakeStageError(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// processInbox — no intake stage configured (empty stages)
+// processInbox: no intake stage configured (empty stages)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestProcessInbox_DisabledIntakeStage(t *testing.T) {
@@ -180,7 +180,7 @@ func TestProcessInbox_DisabledIntakeStage(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIntakeStage — LoadInbox error (corrupt JSON)
+// runIntakeStage: LoadInbox error (corrupt JSON)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIntakeStage_LoadInboxError(t *testing.T) {
@@ -201,7 +201,7 @@ func TestRunIntakeStage_LoadInboxError(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIntakeStage — planning enabled switches prompt file
+// runIntakeStage: planning enabled switches prompt file
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIntakeStage_PlanningEnabled(t *testing.T) {
@@ -232,7 +232,7 @@ func TestRunIntakeStage_PlanningEnabled(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIntakeStage — prompt assembly error
+// runIntakeStage: prompt assembly error
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIntakeStage_PromptAssemblyError(t *testing.T) {
@@ -254,7 +254,7 @@ func TestRunIntakeStage_PromptAssemblyError(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIntakeStage — invocation error (bad model command)
+// runIntakeStage: invocation error (bad model command)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIntakeStage_InvocationError(t *testing.T) {
@@ -281,7 +281,7 @@ func TestRunIntakeStage_InvocationError(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIntakeStage — non-zero exit code (items not filed)
+// runIntakeStage: non-zero exit code (items not filed)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIntakeStage_NonZeroExitCode(t *testing.T) {
@@ -313,7 +313,7 @@ func TestRunIntakeStage_NonZeroExitCode(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIntakeStage — existing tree context included in prompt
+// runIntakeStage: existing tree context included in prompt
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIntakeStage_ExistingTreeContext(t *testing.T) {
@@ -339,7 +339,7 @@ func TestRunIntakeStage_ExistingTreeContext(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIntakeStage — existing tree with parent node context
+// runIntakeStage: existing tree with parent node context
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIntakeStage_ExistingTreeWithParent(t *testing.T) {
@@ -375,7 +375,7 @@ func TestRunIntakeStage_ExistingTreeWithParent(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIntakeStage — planning enabled with overlap markers in output
+// runIntakeStage: planning enabled with overlap markers in output
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIntakeStage_PlanningWithOverlapMarkers(t *testing.T) {
@@ -417,7 +417,7 @@ func TestRunIntakeStage_PlanningWithOverlapMarkers(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIntakeStage — workAvailable channel already full (default branch)
+// runIntakeStage: workAvailable channel already full (default branch)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIntakeStage_WorkAvailableAlreadyFull(t *testing.T) {
@@ -442,7 +442,7 @@ func TestRunIntakeStage_WorkAvailableAlreadyFull(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// runIntakeStage — result.Summary logging
+// runIntakeStage: result.Summary logging
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRunIntakeStage_LogsSummary(t *testing.T) {
@@ -469,7 +469,7 @@ func TestRunIntakeStage_LogsSummary(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// parseOverlapMarkers — malformed markers
+// parseOverlapMarkers: malformed markers
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestParseOverlapMarkers_MissingOpenQuote(t *testing.T) {

--- a/internal/invoke/invoker.go
+++ b/internal/invoke/invoker.go
@@ -335,7 +335,7 @@ func detectMarkers(output string, result *Result) {
 func detectLineMarker(line string, result *Result) {
 	trimmed := strings.TrimSpace(line)
 
-	// Terminal markers — only record the first one encountered.
+	// Terminal markers: only record the first one encountered.
 	if result.TerminalMarker == MarkerNone {
 		switch {
 		case strings.Contains(trimmed, MarkerStringComplete):
@@ -351,7 +351,7 @@ func detectLineMarker(line string, result *Result) {
 		}
 	}
 
-	// Summary marker — can appear alongside a terminal marker.
+	// Summary marker: can appear alongside a terminal marker.
 	if strings.HasPrefix(trimmed, MarkerStringSummary) {
 		text := strings.TrimSpace(strings.TrimPrefix(trimmed, MarkerStringSummary))
 		if text != "" {

--- a/internal/invoke/invoker_test.go
+++ b/internal/invoke/invoker_test.go
@@ -551,7 +551,7 @@ func TestProcessGroupKill_NonStreamingCancelKillsChildren(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	// Cancel after a short delay — enough for the script to start
+	// Cancel after a short delay. Enough for the script to start
 	// its background child and echo "started".
 	go func() {
 		time.Sleep(500 * time.Millisecond)

--- a/internal/invoke/retry.go
+++ b/internal/invoke/retry.go
@@ -25,8 +25,8 @@ type RetryLogger interface {
 // governed by the project's retry configuration (ADR-019).
 //
 // Only invocation errors (non-nil error returns from Invoke) are retried.
-// A successful process exit — even with a non-zero exit code captured in
-// Result — is not retried, since that represents the model running to
+// A successful process exit (even with a non-zero exit code captured in
+// Result) is not retried, since that represents the model running to
 // completion and returning a meaningful (if unsuccessful) outcome.
 type RetryInvoker struct {
 	// Inner is the underlying invoker to wrap with retries.
@@ -65,7 +65,7 @@ func (r *RetryInvoker) Invoke(ctx context.Context, model config.ModelDef, prompt
 			return result, nil
 		}
 
-		// Context cancellation is never retryable — the caller is
+		// Context cancellation is never retryable; the caller is
 		// shutting down or the invocation timed out.
 		if ctx.Err() != nil {
 			return result, fmt.Errorf("invocation cancelled: %w", err)
@@ -106,7 +106,7 @@ func (r *RetryInvoker) Invoke(ctx context.Context, model config.ModelDef, prompt
 }
 
 // IsRetryableError returns true if the error represents a condition worth
-// retrying — process spawn failures, pipe errors, and similar infrastructure
+// retrying: process spawn failures, pipe errors, and similar infrastructure
 // issues. Context cancellation and deadline exceeded errors are not retryable.
 func IsRetryableError(err error) bool {
 	if err == nil {

--- a/internal/invoke/retry_test.go
+++ b/internal/invoke/retry_test.go
@@ -468,7 +468,7 @@ func TestRetryInvoker_DefaultSleepFunc(t *testing.T) {
 		},
 	}
 	ri := NewRetryInvoker(inner, defaultRetryConfig(), nil)
-	// Do NOT set SleepFunc — exercise the nil branch.
+	// Do NOT set SleepFunc. Exercise the nil branch.
 	result, err := ri.Invoke(context.Background(), config.ModelDef{}, "", "", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/logging/category_a_test.go
+++ b/internal/logging/category_a_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// logger.go — Log: pass map with unmarshalable value
+// logger.go: Log: pass map with unmarshalable value
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestLog_UnmarshalableMapValue(t *testing.T) {

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -313,7 +313,7 @@ func EnforceRetention(logDir string, maxFiles int, maxAgeDays int, opts ...Reten
 				uncompressed = append(uncompressed, e)
 			}
 		}
-		// Keep the newest uncompressed file open — compress only older ones.
+		// Keep the newest uncompressed file open. Compress only older ones.
 		if len(uncompressed) > 1 {
 			sort.Slice(uncompressed, func(i, j int) bool {
 				return uncompressed[i].Name() < uncompressed[j].Name()
@@ -321,7 +321,7 @@ func EnforceRetention(logDir string, maxFiles int, maxAgeDays int, opts ...Reten
 			for _, e := range uncompressed[:len(uncompressed)-1] {
 				src := filepath.Join(logDir, e.Name())
 				if err := compressFile(src); err != nil {
-					// Non-fatal — the file simply stays uncompressed.
+					// Non-fatal: the file simply stays uncompressed.
 					continue
 				}
 			}

--- a/internal/logging/logger_chmod_test.go
+++ b/internal/logging/logger_chmod_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-// ── compressFile — permission-based error paths ─────────────────────
+// ── compressFile: permission-based error paths ─────────────────────
 
 func TestCompressFile_UnreadableSource_Chmod(t *testing.T) {
 	if runtime.GOOS == "windows" {

--- a/internal/logging/logger_compress_test.go
+++ b/internal/logging/logger_compress_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// compressFile — successful compression and read error paths
+// compressFile: successful compression and read error paths
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestCompressFile_SuccessfulRoundTrip(t *testing.T) {

--- a/internal/logging/logger_coverage_test.go
+++ b/internal/logging/logger_coverage_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// compressFile — additional error paths
+// compressFile: additional error paths
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestCompressFile_ValidContent(t *testing.T) {
@@ -74,7 +74,7 @@ func TestCompressFile_EmptyFile(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// EnforceRetention — age-based cleanup with frozen clock
+// EnforceRetention: age-based cleanup with frozen clock
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestEnforceRetention_AgeCutoff_WithFrozenClock(t *testing.T) {
@@ -187,7 +187,7 @@ func TestEnforceRetention_CountDeletesOldestFirst(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// StartIteration — error path
+// StartIteration: error path
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestStartIteration_ErrorOnReadOnlyDir(t *testing.T) {
@@ -210,7 +210,7 @@ func TestStartIteration_ErrorOnReadOnlyDir(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// WatchForNewFiles — additional scenarios
+// WatchForNewFiles: additional scenarios
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestWatchForNewFiles_ImmediateNewFile(t *testing.T) {
@@ -246,7 +246,7 @@ func TestWatchForNewFiles_DoneBeforePoll(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// EnforceRetention — compression with read-only target (non-fatal)
+// EnforceRetention: compression with read-only target (non-fatal)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestEnforceRetention_CompressionErrorNonFatal(t *testing.T) {
@@ -264,14 +264,14 @@ func TestEnforceRetention_CompressionErrorNonFatal(t *testing.T) {
 	_ = os.Chmod(filepath.Join(dir, "0001-20260101T00-00Z.jsonl"), 0000)
 	defer func() { _ = os.Chmod(filepath.Join(dir, "0001-20260101T00-00Z.jsonl"), 0644) }()
 
-	// Should not error — compression failures are non-fatal
+	// Should not error. Compression failures are non-fatal
 	if err := EnforceRetention(dir, 100, 365, WithCompression()); err != nil {
 		t.Fatal(err)
 	}
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// compressFile — error during gzip write and close
+// compressFile: error during gzip write and close
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestCompressFile_DestCannotBeCreated(t *testing.T) {
@@ -325,7 +325,7 @@ func TestCompressFile_OriginalRemovedOnSuccess(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// EnforceRetention — retention with only gz files
+// EnforceRetention: retention with only gz files
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestEnforceRetention_OnlyGzFiles_NoCompression(t *testing.T) {
@@ -337,7 +337,7 @@ func TestEnforceRetention_OnlyGzFiles_NoCompression(t *testing.T) {
 		_ = os.WriteFile(name, []byte("compressed"), 0644)
 	}
 
-	// No uncompressed files — compression pass should be a no-op
+	// No uncompressed files. Compression pass should be a no-op
 	if err := EnforceRetention(dir, 100, 365, WithCompression()); err != nil {
 		t.Fatal(err)
 	}
@@ -388,7 +388,7 @@ func TestEnforceRetention_NoUncompressedFiles_SkipsCompression(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 
-	// Only .gz files — compression step should be a no-op
+	// Only .gz files. Compression step should be a no-op
 	_ = os.WriteFile(filepath.Join(dir, "0001-20260101T00-00Z.jsonl.gz"), []byte("gz1"), 0644)
 	_ = os.WriteFile(filepath.Join(dir, "0002-20260102T00-00Z.jsonl.gz"), []byte("gz2"), 0644)
 
@@ -446,7 +446,7 @@ func TestEnforceRetention_AgeAndCountCombined(t *testing.T) {
 	}
 }
 
-// ── StartIteration — previous file leak prevention ──────────────
+// ── StartIteration: previous file leak prevention ──────────────
 
 func TestStartIteration_ClosePreviousBeforeNew(t *testing.T) {
 	t.Parallel()
@@ -458,7 +458,7 @@ func TestStartIteration_ClosePreviousBeforeNew(t *testing.T) {
 
 	defer logger.Close()
 
-	// Start 3 iterations rapidly — should close each previous
+	// Start 3 iterations rapidly. Should close each previous
 	for i := 0; i < 3; i++ {
 		if err := logger.StartIteration(); err != nil {
 			t.Fatalf("iteration %d: %v", i, err)
@@ -480,7 +480,7 @@ func TestStartIteration_ClosePreviousBeforeNew(t *testing.T) {
 	}
 }
 
-// ── compressFile — simulate errors via special files ──────────────
+// ── compressFile: simulate errors via special files ──────────────
 
 func TestEnforceRetention_SymlinkInfoError(t *testing.T) {
 	t.Parallel()
@@ -489,7 +489,7 @@ func TestEnforceRetention_SymlinkInfoError(t *testing.T) {
 	// Create a normal file and a broken symlink
 	_ = os.WriteFile(filepath.Join(dir, "0001-20260101T00-00Z.jsonl"), []byte("{}"), 0644)
 
-	// Create a symlink to a nonexistent target — os.DirEntry.Info() will error
+	// Create a symlink to a nonexistent target. Os.DirEntry.Info() will error
 	brokenTarget := filepath.Join(dir, "nonexistent_target.jsonl")
 	brokenLink := filepath.Join(dir, "0002-20260102T00-00Z.jsonl")
 	_ = os.Symlink(brokenTarget, brokenLink)
@@ -540,7 +540,7 @@ func TestCompressFile_SourceOpenButDstDirGone(t *testing.T) {
 	}
 }
 
-// ── Log — write error path ──────────────────────────────────────
+// ── Log: write error path ──────────────────────────────────────
 
 func TestLog_WriteError(t *testing.T) {
 	t.Parallel()

--- a/internal/logging/logger_deep_coverage_test.go
+++ b/internal/logging/logger_deep_coverage_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// compressFile — nonexistent source
+// compressFile: nonexistent source
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestCompressFile_NonexistentSource(t *testing.T) {
@@ -20,7 +20,7 @@ func TestCompressFile_NonexistentSource(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Level — String and ParseLevel coverage
+// Level: String and ParseLevel coverage
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestLevel_String_Unknown(t *testing.T) {
@@ -57,7 +57,7 @@ func TestParseLevel_AllLevels(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Logger — Log with no active iteration
+// Logger: Log with no active iteration
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestLog_NoActiveIteration(t *testing.T) {
@@ -69,7 +69,7 @@ func TestLog_NoActiveIteration(t *testing.T) {
 	}
 	defer logger.Close()
 
-	// Don't call StartIteration — file is nil
+	// Don't call StartIteration. File is nil
 	err = logger.Log(map[string]any{"msg": "test"})
 	if err == nil {
 		t.Error("expected error when logging without active iteration")
@@ -77,7 +77,7 @@ func TestLog_NoActiveIteration(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// AssistantWriter — nil and active
+// AssistantWriter: nil and active
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestAssistantWriter_NilWhenNoIteration(t *testing.T) {
@@ -192,7 +192,7 @@ func TestLatestLogFile_WithGzAndPlain(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// NewLogger — error path
+// NewLogger: error path
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestNewLogger_DirectoryCreationFails(t *testing.T) {
@@ -209,7 +209,7 @@ func TestNewLogger_DirectoryCreationFails(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Close — idempotent
+// Close: idempotent
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestClose_Idempotent(t *testing.T) {
@@ -229,7 +229,7 @@ func TestClose_Idempotent(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// EnforceRetention — read-only directory (error path)
+// EnforceRetention: read-only directory (error path)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestEnforceRetention_UnreadableDirectory(t *testing.T) {

--- a/internal/logging/logger_errorpath_test.go
+++ b/internal/logging/logger_errorpath_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// compressFile — io.Copy failure via read permission revoked mid-stream,
+// compressFile: io.Copy failure via read permission revoked mid-stream,
 // and gz.Close / out.Close error paths.
 // ═══════════════════════════════════════════════════════════════════════════
 
@@ -52,7 +52,7 @@ func TestCompressFile_EmptyFile_ErrorPath(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// EnforceRetention — compress path with unreadable source triggers
+// EnforceRetention: compress path with unreadable source triggers
 // non-fatal continue in the compression loop.
 // ═══════════════════════════════════════════════════════════════════════════
 
@@ -108,7 +108,7 @@ func TestEnforceRetention_CompressWithReadOnlyDestDir(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// EnforceRetention — age-based deletion with old files
+// EnforceRetention: age-based deletion with old files
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestEnforceRetention_DeletesByCount(t *testing.T) {
@@ -140,7 +140,7 @@ func TestEnforceRetention_DeletesByCount(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// IterationFromDir — with non-log files
+// IterationFromDir: with non-log files
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestIterationFromDir_MixedFiles(t *testing.T) {

--- a/internal/output/spinner.go
+++ b/internal/output/spinner.go
@@ -141,7 +141,7 @@ func (s *Spinner) resumeAfterMessage() {
 func (s *Spinner) run() {
 	defer close(s.done)
 
-	// No cursor hide/show — if the process is killed mid-animation,
+	// No cursor hide/show. If the process is killed mid-animation,
 	// hidden cursor persists in the terminal. The pause/resume system
 	// handles flicker prevention instead.
 

--- a/internal/pipeline/category_a_test.go
+++ b/internal/pipeline/category_a_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// fragments.go — include list references missing fragment
+// fragments.go: include list references missing fragment
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestResolveAllFragments_IncludeListMissingFragment(t *testing.T) {
@@ -35,7 +35,7 @@ func TestResolveAllFragments_IncludeListMissingFragment(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// fragments.go — invalid Go template syntax
+// fragments.go: invalid Go template syntax
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestResolvePromptTemplate_InvalidGoTemplateSyntax(t *testing.T) {
@@ -57,7 +57,7 @@ func TestResolvePromptTemplate_InvalidGoTemplateSyntax(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// prompt.go — skip assembly error path
+// prompt.go: skip assembly error path
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestAssemblePrompt_SkipAssembly_MissingPromptFile(t *testing.T) {
@@ -80,7 +80,7 @@ func TestAssemblePrompt_SkipAssembly_MissingPromptFile(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// prompt.go — fragment resolution error path
+// prompt.go: fragment resolution error path
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestAssemblePrompt_FragmentResolutionError(t *testing.T) {

--- a/internal/pipeline/prompt.go
+++ b/internal/pipeline/prompt.go
@@ -23,7 +23,7 @@ func cwdSection(wolfcastleDir string) string {
 
 Your working directory is %s. Do not change it.
 Do not cd to any other directory. Do not follow branch rules or directory
-instructions from .claude/CLAUDE.md — those apply to the human, not you.
+instructions from .claude/CLAUDE.md. Those apply to the human, not you.
 Run all commands from your current directory. You work HERE.`, repoDir)
 }
 
@@ -31,7 +31,7 @@ Run all commands from your current directory. You work HERE.`, repoDir)
 // Assembly order: working directory, rule fragments, script reference, stage prompt, iteration context.
 func AssemblePrompt(wolfcastleDir string, cfg *config.Config, stage config.PipelineStage, iterContext string) (string, error) {
 	if stage.ShouldSkipPromptAssembly() {
-		// Lightweight stage — stage prompt + iteration context only
+		// Lightweight stage: stage prompt + iteration context only
 		content, err := ResolveFragment(wolfcastleDir, "prompts/"+stage.PromptFile)
 		if err != nil {
 			return "", err

--- a/internal/selfupdate/updater_deep_coverage_test.go
+++ b/internal/selfupdate/updater_deep_coverage_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Apply — exercises the full code path including the unavailable branch
+// Apply: exercises the full code path including the unavailable branch
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestStubUpdater_Apply_FullPath(t *testing.T) {

--- a/internal/state/audit_lifecycle_test.go
+++ b/internal/state/audit_lifecycle_test.go
@@ -96,7 +96,7 @@ func TestSyncAuditLifecycle_InProgressRecordsStartedAtOnce(t *testing.T) {
 	SyncAuditLifecycle(ns)
 	firstStartedAt := ns.Audit.StartedAt
 
-	// Call again — should not change StartedAt
+	// Call again. Should not change StartedAt
 	SyncAuditLifecycle(ns)
 	if ns.Audit.StartedAt != firstStartedAt {
 		t.Error("StartedAt should not change on subsequent calls")

--- a/internal/state/category_a_test.go
+++ b/internal/state/category_a_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// filelock.go — stale lock cleanup triggers retry
+// filelock.go: stale lock cleanup triggers retry
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestAcquire_StaleLockCleanupTriggersRetry(t *testing.T) {

--- a/internal/state/filelock_deep_coverage_test.go
+++ b/internal/state/filelock_deep_coverage_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// tryCleanStaleLock — various PID states
+// tryCleanStaleLock: various PID states
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestTryCleanStaleLock_EmptyFile(t *testing.T) {
@@ -62,7 +62,7 @@ func TestTryCleanStaleLock_LiveProcess(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Write our own PID — this process is alive
+	// Write our own PID. This process is alive
 	pid := os.Getpid()
 	_, _ = fmt.Fprintf(f, "%d\n", pid)
 	_ = f.Sync()
@@ -99,7 +99,7 @@ func TestTryCleanStaleLock_DeadProcess(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Acquire / Release — basic lifecycle
+// Acquire / Release: basic lifecycle
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestAcquireRelease_BasicCycle(t *testing.T) {
@@ -147,7 +147,7 @@ func TestAcquire_Timeout_WhenHeld(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// WithLock — success path
+// WithLock: success path
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestWithLock_Success(t *testing.T) {
@@ -167,7 +167,7 @@ func TestWithLock_Success(t *testing.T) {
 		t.Error("fn should have been called")
 	}
 
-	// Lock should be released — verify by acquiring again
+	// Lock should be released. Verify by acquiring again
 	fl2 := NewFileLock(dir, 200*time.Millisecond)
 	if err := fl2.Acquire(); err != nil {
 		t.Fatalf("could not acquire after WithLock: %v", err)
@@ -176,7 +176,7 @@ func TestWithLock_Success(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Acquire — writes PID to lock file
+// Acquire: writes PID to lock file
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestAcquire_WritesPIDToLockFile(t *testing.T) {
@@ -201,7 +201,7 @@ func TestAcquire_WritesPIDToLockFile(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// signalProcess — live and dead process
+// signalProcess: live and dead process
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestSignalProcess_LiveProcess(t *testing.T) {

--- a/internal/state/filelock_test.go
+++ b/internal/state/filelock_test.go
@@ -102,14 +102,14 @@ func TestFileLock_ConcurrentAcquisition(t *testing.T) {
 func TestFileLock_Timeout(t *testing.T) {
 	dir := t.TempDir()
 
-	// First lock — held for the duration of the test.
+	// First lock. Held for the duration of the test.
 	holder := NewFileLock(dir, DefaultLockTimeout)
 	if err := holder.Acquire(); err != nil {
 		t.Fatalf("holder Acquire failed: %v", err)
 	}
 	defer holder.Release()
 
-	// Second lock — should time out quickly.
+	// Second lock. Should time out quickly.
 	waiter := NewFileLock(dir, 200*time.Millisecond)
 	start := time.Now()
 	err := waiter.Acquire()
@@ -234,7 +234,7 @@ func TestFileLock_CreatesDirectory(t *testing.T) {
 func TestFileLock_ReentrantAcquireFails(t *testing.T) {
 	// flock is per-file-description, so opening a second fd and trying
 	// to lock it from the same process should still work (flock is not
-	// per-process exclusive on the same file — it's per open-file-description).
+	// per-process exclusive on the same file. It's per open-file-description).
 	// This test documents that behaviour: a second FileLock in the same process
 	// CAN acquire the lock because it opens a new file descriptor.
 	dir := t.TempDir()

--- a/internal/state/io_chmod_test.go
+++ b/internal/state/io_chmod_test.go
@@ -26,7 +26,7 @@ func TestAtomicWriteJSON_MkdirAll_ReadOnlyParent(t *testing.T) {
 	t.Parallel()
 
 	roDir := readOnlyDir(t)
-	// MkdirAll needs to create "sub" inside read-only parent — should fail.
+	// MkdirAll needs to create "sub" inside read-only parent. Should fail.
 	path := filepath.Join(roDir, "sub", "state.json")
 
 	err := atomicWriteJSON(path, map[string]string{"k": "v"})
@@ -66,7 +66,7 @@ func TestAtomicWriteJSON_Rename_TargetIsDir(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	// Place a directory where the destination file should be — rename fails.
+	// Place a directory where the destination file should be. Rename fails.
 	target := filepath.Join(dir, "state.json")
 	if err := os.MkdirAll(target, 0755); err != nil {
 		t.Fatal(err)

--- a/internal/state/io_coverage_test.go
+++ b/internal/state/io_coverage_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// atomicWriteJSON — error path coverage
+// atomicWriteJSON: error path coverage
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestAtomicWriteJSON_TmpFileCreationFailure(t *testing.T) {

--- a/internal/state/io_deep_coverage_test.go
+++ b/internal/state/io_deep_coverage_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// atomicWriteJSON — success with nested directories and content verification
+// atomicWriteJSON: success with nested directories and content verification
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestAtomicWriteJSON_ContentMatchesInput(t *testing.T) {
@@ -66,7 +66,7 @@ func TestAtomicWriteJSON_OverwritesExistingFile(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// LoadRootIndex — error paths
+// LoadRootIndex: error paths
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestLoadRootIndex_NonexistentPath(t *testing.T) {
@@ -105,7 +105,7 @@ func TestLoadRootIndex_InitializesNilNodes(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// LoadNodeState — error paths
+// LoadNodeState: error paths
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestLoadNodeState_NonexistentPath(t *testing.T) {
@@ -163,7 +163,7 @@ func TestLoadNodeState_NormalizesAuditState(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// SaveRootIndex / SaveNodeState — round-trip
+// SaveRootIndex / SaveNodeState: round-trip
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestSaveAndLoadRootIndex_RoundTrip(t *testing.T) {
@@ -226,7 +226,7 @@ func TestSaveAndLoadNodeState_RoundTrip(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// normalizeAuditState — already-set fields preserved
+// normalizeAuditState: already-set fields preserved
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestNormalizeAuditState_PreservesExistingStatus(t *testing.T) {

--- a/internal/state/mutations_coverage_test.go
+++ b/internal/state/mutations_coverage_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// AddEscalation — clock parameter and nested address coverage
+// AddEscalation: clock parameter and nested address coverage
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestAddEscalation_WithNestedAddress(t *testing.T) {

--- a/internal/state/navigation.go
+++ b/internal/state/navigation.go
@@ -101,7 +101,7 @@ func dfs(idx *RootIndex, addr string, loadNode func(addr string) (*NodeState, er
 	if entry.Type == NodeOrchestrator {
 		// Pass 1: Creation-order scan for new work. Blocked children
 		// are skipped here and handled in pass 2. If an earlier
-		// non-blocked child is incomplete, stop — creation order is
+		// non-blocked child is incomplete, stop. Creation order is
 		// enforced for progressive work.
 		for _, childAddr := range entry.Children {
 			childEntry, childOk := idx.Nodes[childAddr]
@@ -152,11 +152,11 @@ func dfs(idx *RootIndex, addr string, loadNode func(addr string) (*NodeState, er
 			}
 		}
 
-		// Children exhausted — check orchestrator's own tasks (e.g. audit)
+		// Children exhausted. check orchestrator's own tasks (e.g. audit)
 		return findActionableTask(addr, loadNode)
 	}
 
-	// Leaf node — find next actionable task
+	// Leaf node: find next actionable task
 	return findActionableTask(addr, loadNode)
 }
 
@@ -208,7 +208,7 @@ func findActionableTask(addr string, loadNode func(addr string) (*NodeState, err
 	allNonAuditDone := nonAuditDone == nonAuditCount
 	if ns.Type == NodeLeaf && nonAuditCount == 0 {
 		// Leaf with no real tasks. Only run the audit if the parent
-		// orchestrator has finished planning — otherwise tasks may
+		// orchestrator has finished planning. Otherwise tasks may
 		// still be incoming. Root-level leaves (no parent) stay
 		// blocked as a safe default.
 		allNonAuditDone = false

--- a/internal/state/navigation_extra_test.go
+++ b/internal/state/navigation_extra_test.go
@@ -288,7 +288,7 @@ func TestFindNextTask_AuditOnlyNode_NoNonAuditTasks(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// A root-level leaf with only an audit task stays blocked — no parent
+	// A root-level leaf with only an audit task stays blocked. No parent
 	// orchestrator to confirm that planning is complete.
 	if result.Found {
 		t.Error("expected not found: root-level audit-only node has no parent to confirm planning")
@@ -392,7 +392,7 @@ func TestFindNextTask_AuditOnlyLeaf_ParentDonePlanning(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Parent orchestrator is done planning. The empty leaf's audit is
-	// the only work — it should be actionable.
+	// the only work. It should be actionable.
 	if !result.Found {
 		t.Fatal("expected audit task to be found when parent is done planning")
 	}
@@ -421,7 +421,7 @@ func TestFindNextTask_AuditOnlyLeaf_ParentStillPlanning(t *testing.T) {
 	}
 
 	orchNS := NewNodeState("orch", "Orchestrator", NodeOrchestrator)
-	orchNS.NeedsPlanning = true // still planning — tasks may be incoming
+	orchNS.NeedsPlanning = true // still planning; tasks may be incoming
 	orchNS.Children = []ChildRef{{ID: "empty-leaf", Address: "orch/empty-leaf", State: StatusNotStarted}}
 
 	leafNS := NewNodeState("empty-leaf", "Empty Leaf", NodeLeaf)
@@ -436,7 +436,7 @@ func TestFindNextTask_AuditOnlyLeaf_ParentStillPlanning(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Parent is still planning — tasks may still be added to this leaf.
+	// Parent is still planning. Tasks may still be added to this leaf.
 	// The audit must not run yet.
 	if result.Found {
 		t.Error("expected not found: parent still planning, audit should be blocked")
@@ -477,7 +477,7 @@ func TestFindNextTask_BlockedSiblingRemediation_FoundAfterCreationBlock(t *testi
 	alphaNS.Tasks = []Task{
 		{ID: "task-0001", State: StatusComplete},
 		// audit is not_started but gated (allNonAuditDone is true, so it
-		// WOULD be actionable — but we need alpha to produce no result
+		// WOULD be actionable. But we need alpha to produce no result
 		// from findActionableTask). Actually, the audit IS actionable here.
 		// Let's make alpha an incomplete node with no actionable tasks:
 		// a single not_started task that has incomplete children.

--- a/internal/state/near_threshold_coverage_test.go
+++ b/internal/state/near_threshold_coverage_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// MutateNode — propagation path coverage (46.4% → target ~90%)
+// MutateNode: propagation path coverage (46.4% → target ~90%)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestMutateNode_PropagatesStateToIndex(t *testing.T) {
@@ -174,7 +174,7 @@ func TestMutateNode_SaveError_AfterMutation(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// ReadNode / ReadIndex — non-ErrNotExist errors (corrupt JSON)
+// ReadNode / ReadIndex: non-ErrNotExist errors (corrupt JSON)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestReadNode_CorruptJSON_ReturnsError(t *testing.T) {
@@ -212,7 +212,7 @@ func TestReadIndex_CorruptJSON_ReturnsError(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// nodePath — edge cases
+// nodePath: edge cases
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestNodePath_DotSegment_ReturnsError(t *testing.T) {
@@ -260,7 +260,7 @@ func TestNodePath_TabInSegment_ReturnsError(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// MutateIndex — corrupt JSON (non-ErrNotExist) error
+// MutateIndex: corrupt JSON (non-ErrNotExist) error
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestMutateIndex_CorruptJSON_ReturnsError(t *testing.T) {
@@ -279,7 +279,7 @@ func TestMutateIndex_CorruptJSON_ReturnsError(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// InboxMutate — callback error and save failure
+// InboxMutate: callback error and save failure
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestInboxMutate_CallbackError(t *testing.T) {
@@ -348,7 +348,7 @@ func TestInboxAppend_SaveFailure(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// parentInList — no-dot edge case
+// parentInList: no-dot edge case
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestParentInList_NoDot_ReturnsFalse(t *testing.T) {
@@ -376,7 +376,7 @@ func TestParentInList_ParentExists(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// TaskBlock — edge cases
+// TaskBlock: edge cases
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestTaskBlock_CompleteTask_ReturnsError(t *testing.T) {
@@ -452,7 +452,7 @@ func TestTaskBlock_NotFoundTask_ReturnsError(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// RecomputeState — blocked derivation
+// RecomputeState: blocked derivation
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRecomputeState_AllNonCompleteBlocked_CompleteAndBlocked(t *testing.T) {
@@ -508,7 +508,7 @@ func TestRecomputeState_WithTasks_AllComplete(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// LoadInbox — permission error (non-ErrNotExist)
+// LoadInbox: permission error (non-ErrNotExist)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestLoadInbox_PermissionError(t *testing.T) {
@@ -549,7 +549,7 @@ func TestLoadInbox_CorruptJSON(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// MutateInbox — corrupt inbox triggers load error
+// MutateInbox: corrupt inbox triggers load error
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestMutateInbox_CorruptInbox_ReturnsError(t *testing.T) {
@@ -568,7 +568,7 @@ func TestMutateInbox_CorruptInbox_ReturnsError(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// PropagateUp — error paths
+// PropagateUp: error paths
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestPropagateUp_LoadParentError_ReturnsWrapped(t *testing.T) {
@@ -633,7 +633,7 @@ func TestPropagateUp_CycleDetection(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Propagate — error in re-walk ancestors
+// Propagate: error in re-walk ancestors
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestPropagate_LoadParentForIndex_Error(t *testing.T) {
@@ -671,7 +671,7 @@ func TestPropagate_LoadParentForIndex_Error(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// normalizeAuditState — coverage for default paths
+// normalizeAuditState: coverage for default paths
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestNormalizeAuditState_DefaultsAllNilSlices(t *testing.T) {
@@ -712,7 +712,7 @@ func TestNormalizeAuditState_PreservesExistingInProgressStatus(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// LoadNodeState / LoadRootIndex — parse errors
+// LoadNodeState / LoadRootIndex: parse errors
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestLoadNodeState_CorruptJSON(t *testing.T) {
@@ -747,7 +747,7 @@ func TestLoadRootIndex_NilNodesInitialized(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "state.json")
-	// Valid JSON with no "nodes" field — should initialize the map.
+	// Valid JSON with no "nodes" field. Should initialize the map.
 	if err := os.WriteFile(path, []byte(`{"version":1}`), 0644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/state/propagate.go
+++ b/internal/state/propagate.go
@@ -3,7 +3,7 @@ package state
 import "fmt"
 
 // Propagate updates a node's state, propagates to all ancestors, and updates
-// the root index. This is the single authoritative mutation path — both CLI
+// the root index. This is the single authoritative mutation path; both CLI
 // commands and the daemon must use it to stay ADR-024 compliant.
 func Propagate(
 	nodeAddr string,

--- a/internal/state/propagate_test.go
+++ b/internal/state/propagate_test.go
@@ -133,7 +133,7 @@ func TestPropagate_BlockOnlyWhenAllNonCompleteBlocked(t *testing.T) {
 		return nil
 	}
 
-	// Block c — now b and c are blocked, a is complete
+	// Block c. Now b and c are blocked, a is complete
 	err := Propagate("root/c", StatusBlocked, idx, loadNode, saveNode)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -177,7 +177,7 @@ func TestPropagate_BlockDoesNotBubbleWithAvailableSiblings(t *testing.T) {
 		return nil
 	}
 
-	// Block b — but a is still not_started, so root stays in_progress
+	// Block b. But a is still not_started, so root stays in_progress
 	err := Propagate("root/b", StatusBlocked, idx, loadNode, saveNode)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/state/review_io_test.go
+++ b/internal/state/review_io_test.go
@@ -499,7 +499,7 @@ func TestSaveHistory_CreatesDirectories(t *testing.T) {
 func TestRemoveBatch_NonNotExistError(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	// Create a non-empty directory — os.Remove on it returns a non-NotExist error.
+	// Create a non-empty directory. Os.Remove on it returns a non-NotExist error.
 	nested := filepath.Join(dir, "subdir")
 	if err := os.Mkdir(nested, 0755); err != nil {
 		t.Fatal(err)

--- a/internal/testutil/category_a_test.go
+++ b/internal/testutil/category_a_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// helpers.go — WriteJSON: pass unmarshalable value (channel)
+// helpers.go: WriteJSON: pass unmarshalable value (channel)
 //
 // WriteJSON calls t.Fatalf on marshal error, which invokes runtime.Goexit.
 // We run the call inside a separate goroutine so Goexit terminates only
@@ -39,7 +39,7 @@ func TestWriteJSON_UnmarshalableValue_Channel(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// helpers.go — WriteJSON: MkdirAll error (file blocks directory creation)
+// helpers.go: WriteJSON: MkdirAll error (file blocks directory creation)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestWriteJSON_MkdirAllError_Fatals(t *testing.T) {
@@ -62,7 +62,7 @@ func TestWriteJSON_MkdirAllError_Fatals(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// helpers.go — WriteJSON: WriteFile error (read-only directory)
+// helpers.go: WriteJSON: WriteFile error (read-only directory)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestWriteJSON_WriteFileError_Fatals(t *testing.T) {
@@ -90,7 +90,7 @@ func TestWriteJSON_WriteFileError_Fatals(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// helpers.go — ReadJSON: pass nonexistent path
+// helpers.go: ReadJSON: pass nonexistent path
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestReadJSON_NonexistentPath_Fatals(t *testing.T) {
@@ -111,7 +111,7 @@ func TestReadJSON_NonexistentPath_Fatals(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// helpers.go — ReadJSON: pass invalid JSON file
+// helpers.go: ReadJSON: pass invalid JSON file
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestReadJSON_InvalidJSONFile_Fatals(t *testing.T) {

--- a/internal/testutil/helpers_deep_coverage_test.go
+++ b/internal/testutil/helpers_deep_coverage_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// WriteJSON — creates nested directories
+// WriteJSON: creates nested directories
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestWriteJSON_CreatesNestedDirectories(t *testing.T) {
@@ -47,7 +47,7 @@ func TestWriteJSON_ComplexObject(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// ReadJSON — complex types
+// ReadJSON: complex types
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestReadJSON_NodeState(t *testing.T) {
@@ -77,7 +77,7 @@ func TestReadJSON_NodeState(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// SetupWolfcastle — verifies all key directories
+// SetupWolfcastle: verifies all key directories
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestSetupWolfcastle_AllDirectoriesExist(t *testing.T) {
@@ -132,7 +132,7 @@ func TestSetupWolfcastle_RootIndexExists(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// SetupTree — verify tree structure deeply
+// SetupTree: verify tree structure deeply
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestSetupTree_ChildAHasTasks(t *testing.T) {
@@ -184,7 +184,7 @@ func TestSetupTree_IndexHasCorrectParents(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// SaveNode — verify persistence
+// SaveNode: verify persistence
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestSaveNode_PreservesAllFields(t *testing.T) {

--- a/internal/validate/audit_coverage_test.go
+++ b/internal/validate/audit_coverage_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// RecoveringNodeLoader — normal load, recovery, and error paths
+// RecoveringNodeLoader: normal load, recovery, and error paths
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRecoveringNodeLoader_NormalLoad(t *testing.T) {

--- a/internal/validate/category_a_test.go
+++ b/internal/validate/category_a_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// fix.go — FixWithVerification: LoadRootIndex error in loop (corrupt index)
+// fix.go: FixWithVerification: LoadRootIndex error in loop (corrupt index)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestFixWithVerification_CorruptIndexMidPass(t *testing.T) {
@@ -27,7 +27,7 @@ func TestFixWithVerification_CorruptIndexMidPass(t *testing.T) {
 	ns := state.NewNodeState("fixable", "Fixable", state.NodeLeaf)
 	ns.Tasks = []state.Task{
 		{ID: "task-0001", Description: "work", State: state.StatusNotStarted},
-		// Missing audit task — triggers fix
+		// Missing audit task. Triggers fix
 	}
 	_ = state.SaveNodeState(filepath.Join(leafDir, "state.json"), ns)
 
@@ -60,7 +60,7 @@ func TestFixWithVerification_CorruptIndexMidPass(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// fix.go — FixWithVerification: zero fixes break (report with issues but
+// fix.go: FixWithVerification: zero fixes break (report with issues but
 // none auto-fixable triggers the len(fixes)==0 break)
 // ═══════════════════════════════════════════════════════════════════════════
 
@@ -102,7 +102,7 @@ func TestFixWithVerification_HasAutoFixableButZeroApplied(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// model_fix.go — invoke error (nonexistent command)
+// model_fix.go: invoke error (nonexistent command)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestTryModelAssistedFix_InvokeError(t *testing.T) {
@@ -138,7 +138,7 @@ func TestTryModelAssistedFix_InvokeError(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// model_fix.go — JSON parse error (mock returning non-JSON)
+// model_fix.go: JSON parse error (mock returning non-JSON)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestTryModelAssistedFix_JSONParseError(t *testing.T) {

--- a/internal/validate/coverage_test.go
+++ b/internal/validate/coverage_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// checkOrphanedStateFiles — direct method tests
+// checkOrphanedStateFiles: direct method tests
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestCheckOrphanedStateFiles_NestedOrphan(t *testing.T) {
@@ -80,7 +80,7 @@ func TestCheckOrphanedStateFiles_KnownNodeNotFlagged(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// checkOrphanedDefinitions — direct method tests
+// checkOrphanedDefinitions: direct method tests
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestCheckOrphanedDefinitions_NestedOrphanMD(t *testing.T) {
@@ -150,7 +150,7 @@ func TestCheckOrphanedDefinitions_ArchiveSkipped(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// FixWithVerification — multi-pass convergence
+// FixWithVerification: multi-pass convergence
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestFixWithVerification_MultiplePassesConverge(t *testing.T) {
@@ -233,7 +233,7 @@ func TestFixWithVerification_WithWolfcastleDirArg(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// TryModelAssistedFix — coverage for all code paths
+// TryModelAssistedFix: coverage for all code paths
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestTryModelAssistedFix_InvalidModelResponse(t *testing.T) {
@@ -341,7 +341,7 @@ func TestTryModelAssistedFix_MissingNodeState(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// ApplyDeterministicFixes — orphan definition and audit gap
+// ApplyDeterministicFixes: orphan definition and audit gap
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestApplyDeterministicFixes_OrphanDefinitionEntry(t *testing.T) {

--- a/internal/validate/edge_cases_test.go
+++ b/internal/validate/edge_cases_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// RecoverNodeState — advanced corruption scenarios
+// RecoverNodeState: advanced corruption scenarios
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRecoverNodeState_BOMPlusTruncation(t *testing.T) {
@@ -150,7 +150,7 @@ func TestRecoverNodeState_NormalizesAuditFields(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// RecoverRootIndex — edge cases
+// RecoverRootIndex: edge cases
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRecoverRootIndex_Unrecoverable(t *testing.T) {
@@ -187,7 +187,7 @@ func TestRecoverRootIndex_MissingNodesField(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// RecoveringNodeLoader — recovery callback and error paths
+// RecoveringNodeLoader: recovery callback and error paths
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRecoveringNodeLoader_ValidNode_NoRecovery(t *testing.T) {
@@ -294,7 +294,7 @@ func TestRecoveringNodeLoader_NilCallback_StillRecovers(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// loadOrRecoverRootIndex — error paths
+// loadOrRecoverRootIndex: error paths
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestLoadOrRecoverRootIndex_ValidIndex(t *testing.T) {
@@ -355,7 +355,7 @@ func TestLoadOrRecoverRootIndex_CompletelyCorrupt(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// NormalizeStateValue — table-driven edge cases
+// NormalizeStateValue: table-driven edge cases
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestNormalizeStateValue_EdgeCases(t *testing.T) {
@@ -403,7 +403,7 @@ func TestNormalizeStateValue_EdgeCases(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// FixWithVerification — malformed root index triggers recovery
+// FixWithVerification: malformed root index triggers recovery
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestFixWithVerification_MalformedIndex_RecoversAndFixes(t *testing.T) {
@@ -441,7 +441,7 @@ func TestFixWithVerification_MalformedIndex_RecoversAndFixes(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Engine.ValidateStartup — verifies subset of categories
+// Engine.ValidateStartup: verifies subset of categories
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestEngine_ValidateStartup_OnlyStartupCategories(t *testing.T) {
@@ -482,7 +482,7 @@ func TestEngine_ValidateStartup_OnlyStartupCategories(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Engine — blocked task without reason
+// Engine: blocked task without reason
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestEngine_BlockedWithoutReason_Detected(t *testing.T) {
@@ -522,7 +522,7 @@ func TestEngine_BlockedWithoutReason_Detected(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Engine — complete node with incomplete tasks
+// Engine: complete node with incomplete tasks
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestEngine_CompleteWithIncomplete_Detected(t *testing.T) {
@@ -560,7 +560,7 @@ func TestEngine_CompleteWithIncomplete_Detected(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Engine — negative failure count
+// Engine: negative failure count
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestEngine_NegativeFailureCount_Detected(t *testing.T) {
@@ -600,7 +600,7 @@ func TestEngine_NegativeFailureCount_Detected(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// sanitizeJSON — no BOM, no null bytes, no whitespace
+// sanitizeJSON: no BOM, no null bytes, no whitespace
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestSanitizeJSON_OnlyWhitespace(t *testing.T) {
@@ -620,7 +620,7 @@ func TestSanitizeJSON_OnlyWhitespace(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// tryStripTrailing — edge cases
+// tryStripTrailing: edge cases
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestTryStripTrailing_EmptyInput(t *testing.T) {
@@ -651,7 +651,7 @@ func TestTryStripTrailing_ArrayInput(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// tryCloseTruncated — edge cases
+// tryCloseTruncated: edge cases
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestTryCloseTruncated_EmptyInput(t *testing.T) {
@@ -728,7 +728,7 @@ func TestReport_HasErrors_NoErrors(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Engine — dangling reference detection
+// Engine: dangling reference detection
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestEngine_DanglingRef_DetectedAndFixable(t *testing.T) {
@@ -760,7 +760,7 @@ func TestEngine_DanglingRef_DetectedAndFixable(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Engine — multiple in-progress tasks
+// Engine: multiple in-progress tasks
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestEngine_MultipleInProgress_Detected(t *testing.T) {
@@ -808,7 +808,7 @@ func TestEngine_MultipleInProgress_Detected(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Engine — invalid audit status
+// Engine: invalid audit status
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestEngine_InvalidAuditStatus_Detected(t *testing.T) {

--- a/internal/validate/engine_test.go
+++ b/internal/validate/engine_test.go
@@ -376,7 +376,7 @@ func TestValidateAll_DetectsDepthMismatch(t *testing.T) {
 	parentNS.Children = []state.ChildRef{{ID: "child", Address: "parent/child", State: state.StatusNotStarted}}
 	_ = state.SaveNodeState(filepath.Join(parentDir, "state.json"), parentNS)
 
-	// Child with depth 1 (less than parent — invalid)
+	// Child with depth 1 (less than parent. Invalid)
 	childDir := filepath.Join(dir, "parent", "child")
 	_ = os.MkdirAll(childDir, 0755)
 	childNS := state.NewNodeState("child", "Child", state.NodeLeaf)
@@ -473,7 +473,7 @@ func TestValidateStartup_OnlyRunsSubset(t *testing.T) {
 		Name: "Leaf", Type: state.NodeLeaf, State: state.StatusNotStarted, Address: "leaf",
 	}
 
-	// Write an orphan .md file — ORPHAN_DEFINITION is not in startup subset
+	// Write an orphan .md file. ORPHAN_DEFINITION is not in startup subset
 	_ = os.WriteFile(filepath.Join(dir, "nonexistent", "readme.md"), []byte("orphan"), 0644)
 
 	engine := NewEngine(dir, DefaultNodeLoader(dir))
@@ -609,7 +609,7 @@ func TestValidateAll_DetectsAuditStatusTaskMismatch(t *testing.T) {
 	_ = os.MkdirAll(leafDir, 0755)
 	ns := state.NewNodeState("mismatch", "Mismatch", state.NodeLeaf)
 	ns.State = state.StatusInProgress
-	ns.Audit.Status = state.AuditPassed // wrong — should be in_progress
+	ns.Audit.Status = state.AuditPassed // wrong; should be in_progress
 	ns.Tasks = []state.Task{
 		{ID: "task-0001", Description: "work", State: state.StatusInProgress},
 		{ID: "audit", Description: "audit", State: state.StatusNotStarted, IsAudit: true},

--- a/internal/validate/fix_chmod_test.go
+++ b/internal/validate/fix_chmod_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/dorkusprime/wolfcastle/internal/state"
 )
 
-// ── FixWithVerification — ApplyDeterministicFixes error via chmod ────
+// ── FixWithVerification: ApplyDeterministicFixes error via chmod ────
 
 func TestFixWithVerification_ApplyFixesError_ReadOnlyStateFiles(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -20,7 +20,7 @@ func TestFixWithVerification_ApplyFixesError_ReadOnlyStateFiles(t *testing.T) {
 	dir := t.TempDir()
 	idx := state.NewRootIndex()
 
-	// Create a node with a missing audit task — triggers MISSING_AUDIT_TASK fix.
+	// Create a node with a missing audit task. Triggers MISSING_AUDIT_TASK fix.
 	leafDir := filepath.Join(dir, "perm-node")
 	_ = os.MkdirAll(leafDir, 0755)
 	ns := state.NewNodeState("perm-node", "Perm", state.NodeLeaf)

--- a/internal/validate/fix_coverage_test.go
+++ b/internal/validate/fix_coverage_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// FixWithVerification — additional coverage paths
+// FixWithVerification: additional coverage paths
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestFixWithVerification_PerfectlyCleanTree_NilFixes(t *testing.T) {
@@ -78,7 +78,7 @@ func TestFixWithVerification_CascadingMultiPassFixes(t *testing.T) {
 	ns.Tasks = []state.Task{
 		{ID: "task-0001", Description: "work", State: state.StatusNotStarted, FailureCount: -1},
 	}
-	// No audit task — triggers MISSING_AUDIT_TASK
+	// No audit task. Triggers MISSING_AUDIT_TASK
 	_ = state.SaveNodeState(filepath.Join(leafDir, "state.json"), ns)
 
 	idx.Root = []string{"cascade-node"}
@@ -237,7 +237,7 @@ func TestFixWithVerification_DepthMismatchFix(t *testing.T) {
 	childDir := filepath.Join(dir, "parent", "child")
 	_ = os.MkdirAll(childDir, 0755)
 	childNS := state.NewNodeState("child", "Child", state.NodeLeaf)
-	childNS.DecompositionDepth = 1 // Wrong — should match parent
+	childNS.DecompositionDepth = 1 // Wrong; should match parent
 	childNS.Tasks = []state.Task{
 		{ID: "task-0001", Description: "work", State: state.StatusNotStarted},
 		{ID: "audit", Description: "audit", State: state.StatusNotStarted, IsAudit: true},

--- a/internal/validate/fix_deep_coverage_test.go
+++ b/internal/validate/fix_deep_coverage_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// FixWithVerification — error during ApplyDeterministicFixes
+// FixWithVerification: error during ApplyDeterministicFixes
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestFixWithVerification_ApplyFixesError_ReadOnlyDir(t *testing.T) {
@@ -50,7 +50,7 @@ func TestFixWithVerification_ApplyFixesError_ReadOnlyDir(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// FixWithVerification — invalid state value normalization
+// FixWithVerification: invalid state value normalization
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestFixWithVerification_InvalidStateValueFix(t *testing.T) {
@@ -95,7 +95,7 @@ func TestFixWithVerification_InvalidStateValueFix(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// FixWithVerification — missing required fields
+// FixWithVerification: missing required fields
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestFixWithVerification_MissingRequiredFields(t *testing.T) {
@@ -138,7 +138,7 @@ func TestFixWithVerification_MissingRequiredFields(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// FixWithVerification — negative failure count
+// FixWithVerification: negative failure count
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestFixWithVerification_NegativeFailureCount(t *testing.T) {
@@ -181,7 +181,7 @@ func TestFixWithVerification_NegativeFailureCount(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// FixWithVerification — invalid audit status
+// FixWithVerification: invalid audit status
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestFixWithVerification_InvalidAuditStatus(t *testing.T) {
@@ -217,7 +217,7 @@ func TestFixWithVerification_InvalidAuditStatus(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// FixWithVerification — stale PID and stop file cleanup
+// FixWithVerification: stale PID and stop file cleanup
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestFixWithVerification_StalePIDFileFix(t *testing.T) {
@@ -259,7 +259,7 @@ func TestFixWithVerification_StalePIDFileFix(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// FixWithVerification — audit status/task mismatch
+// FixWithVerification: audit status/task mismatch
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestFixWithVerification_AuditStatusTaskMismatch(t *testing.T) {
@@ -296,7 +296,7 @@ func TestFixWithVerification_AuditStatusTaskMismatch(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// FixWithVerification — invalid audit gap metadata
+// FixWithVerification: invalid audit gap metadata
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestFixWithVerification_InvalidAuditGapMetadata(t *testing.T) {
@@ -334,7 +334,7 @@ func TestFixWithVerification_InvalidAuditGapMetadata(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// FixWithVerification — propagation mismatch with orchestrator
+// FixWithVerification: propagation mismatch with orchestrator
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestFixWithVerification_PropagationMismatch(t *testing.T) {
@@ -346,7 +346,7 @@ func TestFixWithVerification_PropagationMismatch(t *testing.T) {
 	parentDir := filepath.Join(dir, "orch")
 	_ = os.MkdirAll(parentDir, 0755)
 	parentNS := state.NewNodeState("orch", "Orch", state.NodeOrchestrator)
-	parentNS.State = state.StatusNotStarted // Wrong — child is in_progress
+	parentNS.State = state.StatusNotStarted // Wrong; child is in_progress
 	parentNS.Children = []state.ChildRef{
 		{ID: "leaf", Address: "orch/leaf", State: state.StatusInProgress},
 	}
@@ -388,7 +388,7 @@ func TestFixWithVerification_PropagationMismatch(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// FixWithVerification — root index missing entry (orphan detected on disk)
+// FixWithVerification: root index missing entry (orphan detected on disk)
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestFixWithVerification_RootIndexMissingEntry(t *testing.T) {
@@ -406,7 +406,7 @@ func TestFixWithVerification_RootIndexMissingEntry(t *testing.T) {
 	}
 	_ = state.SaveNodeState(filepath.Join(orphanDir, "state.json"), ns)
 
-	// Index is empty — no reference to the orphan
+	// Index is empty. No reference to the orphan
 	idxPath := filepath.Join(dir, "state.json")
 	_ = state.SaveRootIndex(idxPath, idx)
 

--- a/internal/validate/fix_test.go
+++ b/internal/validate/fix_test.go
@@ -172,7 +172,7 @@ func TestFix_MissingEntry_TopLevel(t *testing.T) {
 	dir := t.TempDir()
 	idx := state.NewRootIndex()
 
-	// Node on disk but not in index — top-level (no parent)
+	// Node on disk but not in index. Top-level (no parent)
 	ns := state.NewNodeState("orphan", "Orphan Node", state.NodeLeaf)
 	ns.State = state.StatusInProgress
 	ns.DecompositionDepth = 2
@@ -281,7 +281,7 @@ func TestFix_PropagationMismatch(t *testing.T) {
 	dir := t.TempDir()
 	idx := state.NewRootIndex()
 
-	// Orchestrator with wrong state — children say not_started
+	// Orchestrator with wrong state. Children say not_started
 	orchNS := state.NewNodeState("orch", "Orch", state.NodeOrchestrator)
 	orchNS.State = state.StatusComplete // wrong
 	orchNS.Children = []state.ChildRef{
@@ -381,7 +381,7 @@ func TestFix_InvalidStateValue(t *testing.T) {
 	idx := state.NewRootIndex()
 
 	ns := state.NewNodeState("leaf", "Leaf", state.NodeLeaf)
-	ns.State = "completed" // typo — should normalize to "complete"
+	ns.State = "completed" // typo; should normalize to "complete"
 	ns.Tasks = []state.Task{
 		{ID: "audit", Description: "audit", State: state.StatusNotStarted, IsAudit: true},
 	}
@@ -642,7 +642,7 @@ func TestFix_AuditStatusTaskMismatch(t *testing.T) {
 
 	ns := state.NewNodeState("leaf", "Leaf", state.NodeLeaf)
 	ns.State = state.StatusInProgress
-	ns.Audit.Status = state.AuditPassed // wrong — should be in_progress
+	ns.Audit.Status = state.AuditPassed // wrong; should be in_progress
 	ns.Tasks = []state.Task{
 		{ID: "t1", Description: "work", State: state.StatusInProgress},
 		{ID: "audit", Description: "audit", State: state.StatusNotStarted, IsAudit: true},
@@ -798,7 +798,7 @@ func TestFix_StalePIDFile_NoWolfcastleDir(t *testing.T) {
 		CanAutoFix: true, FixType: FixDeterministic,
 	}}
 
-	// No wolfcastleDir passed — fix should silently do nothing
+	// No wolfcastleDir passed. Fix should silently do nothing
 	fixes, _, err := ApplyDeterministicFixes(idx, issues, dir, idxPath)
 	if err != nil {
 		t.Fatal(err)
@@ -914,7 +914,7 @@ func TestDetect_StalePIDFile_NoPIDFile(t *testing.T) {
 	wolfcastleDir := t.TempDir()
 	idx := state.NewRootIndex()
 
-	// No PID file — should not report
+	// No PID file. Should not report
 	engine := NewEngine(dir, DefaultNodeLoader(dir), daemon.NewDaemonRepository(wolfcastleDir))
 	report := engine.ValidateAll(idx)
 
@@ -956,7 +956,7 @@ func TestDetect_StaleStopFile(t *testing.T) {
 func TestIsDaemonAlive_NoWolfcastleDir(t *testing.T) {
 	t.Parallel()
 	engine := NewEngine(t.TempDir(), DefaultNodeLoader(t.TempDir()))
-	// wolfcastleDir is "" — should return false
+	// wolfcastleDir is "". Should return false
 	if engine.isDaemonAlive() {
 		t.Error("expected false when wolfcastleDir is empty")
 	}
@@ -1008,7 +1008,7 @@ func TestIsDaemonAlive_DeadProcess(t *testing.T) {
 func TestIsDaemonAlive_LiveProcess(t *testing.T) {
 	t.Parallel()
 	wolfcastleDir := t.TempDir()
-	// Use our own PID — we know we're alive
+	// Use our own PID. We know we're alive
 	_ = os.MkdirAll(filepath.Join(wolfcastleDir, "system"), 0755)
 	_ = os.WriteFile(filepath.Join(wolfcastleDir, "system", "wolfcastle.pid"),
 		[]byte(fmt.Sprintf("%d", os.Getpid())), 0644)
@@ -1336,7 +1336,7 @@ func TestDetect_AuditStatusMismatch_CompleteWithOpenGaps(t *testing.T) {
 
 	ns := state.NewNodeState("leaf", "Leaf", state.NodeLeaf)
 	ns.State = state.StatusComplete
-	ns.Audit.Status = state.AuditPassed // wrong — has open gaps, should be failed
+	ns.Audit.Status = state.AuditPassed // wrong; has open gaps, should be failed
 	ns.Audit.Gaps = []state.Gap{
 		{ID: "g1", Description: "open gap", Status: state.GapOpen},
 	}
@@ -1371,7 +1371,7 @@ func TestDetect_AuditStatusMismatch_CompleteNoGaps(t *testing.T) {
 
 	ns := state.NewNodeState("leaf", "Leaf", state.NodeLeaf)
 	ns.State = state.StatusComplete
-	ns.Audit.Status = state.AuditFailed // wrong — no open gaps, should be passed
+	ns.Audit.Status = state.AuditFailed // wrong; no open gaps, should be passed
 	ns.Tasks = []state.Task{
 		{ID: "t1", Description: "work", State: state.StatusComplete},
 		{ID: "audit", Description: "audit", State: state.StatusComplete, IsAudit: true},
@@ -1457,7 +1457,7 @@ func TestDetect_StalePIDFile_NoWolfcastleDir(t *testing.T) {
 	dir := t.TempDir()
 	idx := state.NewRootIndex()
 
-	// No wolfcastleDir — stale PID/stop should not be checked
+	// No wolfcastleDir. Stale PID/stop should not be checked
 	engine := NewEngine(dir, DefaultNodeLoader(dir))
 	report := engine.ValidateAll(idx)
 
@@ -1485,7 +1485,7 @@ func TestValidate_SkipsInvalidAddressInIndex(t *testing.T) {
 		Name: "Leaf", Type: state.NodeLeaf, State: state.StatusNotStarted, Address: "leaf",
 	}
 
-	// Add an entry with an invalid address (contains uppercase — invalid slug)
+	// Add an entry with an invalid address (contains uppercase. Invalid slug)
 	idx.Nodes["INVALID ADDRESS"] = state.IndexEntry{
 		Name: "Bad", Type: state.NodeLeaf, State: state.StatusNotStarted, Address: "INVALID ADDRESS",
 	}
@@ -1624,7 +1624,7 @@ func TestFix_CacheHit_TwoFixesSameNode(t *testing.T) {
 	}
 	idxPath := saveIndex(t, dir, idx)
 
-	// Two fixes on the same node — the second should hit the cache
+	// Two fixes on the same node. The second should hit the cache
 	issues := []Issue{
 		{Severity: SeverityError, Category: CatBlockedWithoutReason, Node: "leaf", CanAutoFix: true, FixType: FixDeterministic},
 		{Severity: SeverityError, Category: CatInvalidAuditStatus, Node: "leaf", CanAutoFix: true, FixType: FixDeterministic},

--- a/internal/validate/model_fix.go
+++ b/internal/validate/model_fix.go
@@ -29,7 +29,7 @@ type DoctorPromptContext struct {
 
 // TryModelAssistedFix invokes the configured doctor model to resolve an ambiguous issue.
 // Returns true if the fix was applied successfully.
-// wolfcastleDir is optional — when provided, the doctor prompt is loaded from
+// wolfcastleDir is optional. When provided, the doctor prompt is loaded from
 // the three-tier template system; otherwise a hardcoded fallback is used.
 func TryModelAssistedFix(ctx context.Context, invoker invoke.Invoker, model config.ModelDef, issue Issue, projectsDir string, wolfcastleDirs ...string) (bool, error) {
 	if issue.Node == "" {

--- a/internal/validate/recover_detectloss_test.go
+++ b/internal/validate/recover_detectloss_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// detectLoss — direct unit tests
+// detectLoss: direct unit tests
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestDetectLoss_NoLoss_TasksOnly(t *testing.T) {
@@ -123,7 +123,7 @@ func TestDetectLoss_NoChildrenSection(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// RecoverNodeState — sanitizeJSON edge cases exercising detectLoss paths
+// RecoverNodeState: sanitizeJSON edge cases exercising detectLoss paths
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestRecoverNodeState_NullBytesDetected(t *testing.T) {

--- a/test/integration/lifecycle_test.go
+++ b/test/integration/lifecycle_test.go
@@ -174,7 +174,7 @@ func TestSpecLifecycle(t *testing.T) {
 	// Create a second spec and link it manually
 	run(t, dir, "spec", "create", "Standalone Spec")
 	// Link it to the project
-	// We need to find the filename — it includes a timestamp, so list all specs
+	// We need to find the filename. It includes a timestamp, so list all specs
 	out = run(t, dir, "spec", "list")
 	// The standalone spec should appear in the full list
 	if !strings.Contains(out, "standalone-spec") {


### PR DESCRIPTION
## Summary

- Replace all em-dashes (` — `) in Go source and test files with voice-appropriate alternatives (colons, periods, semicolons, parentheses) per `docs/agents/VOICE.md` line 75
- Remove remedy text from library-level identity validation error in `internal/config/validate.go` (the command layer in `cmd/cmdutil/app.go` already provides it)
- Add coverage tests for Category A gaps: `modeFlag.IsBoolFlag`, `followJSON`, `printParallelStatus`, `nodeGlyphPlain`, `countOpenEscalations`, `countGaps`, `config.BaseVersion`

99 files changed, 820 insertions, 500 deletions. The only em-dash remaining in the codebase is a string literal in `cmd/audit/codebase.go:341` that parses actual content, and a test data string in `cmd/audit/audit_edge_test.go:474`.

## Test plan

- [x] `go test ./...` passes (31 packages)
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` reports 0 issues
- [x] `gofmt -l .` reports no unformatted files
- [x] All 5 cross-compile targets build
- [x] New coverage tests pass: `TestModeFlag_IsBoolFlag`, `TestFollowJSON_ContextCancellation`, `TestPrintParallelStatus_*`, `TestNodeGlyphPlain_AllStatuses`, `TestCountOpenEscalations`, `TestCountGaps_AllCombinations`, `TestBaseVersion_*`