### PR TITLE
Fix orchestrator state with all-not_started children (#192)

### DIFF
--- a/internal/daemon/planning.go
+++ b/internal/daemon/planning.go
@@ -229,9 +229,11 @@ func (d *Daemon) runPlanningPass(ctx context.Context, nodeAddr string, ns *state
 	switch marker {
 	case invoke.MarkerStringComplete:
 		_ = d.Logger.Log(map[string]any{"type": "planning_marker", "marker": invoke.MarkerStringComplete})
-		// Clear planning state and complete the orchestrator's audit task.
-		// Without this, the orchestrator stays in_progress because its
-		// audit never goes through the execution pipeline's TaskComplete.
+		// Clear planning state. Only complete the audit task when all
+		// children are already done; otherwise a premature audit
+		// completion breaks the allNotStarted check in RecomputeState
+		// and makes the orchestrator appear in_progress when all its
+		// children are still not_started (#192).
 		_ = d.Store.MutateNode(nodeAddr, func(ns *state.NodeState) error {
 			ns.NeedsPlanning = false
 			ns.PlanningTrigger = ""
@@ -240,35 +242,26 @@ func (d *Daemon) runPlanningPass(ctx context.Context, nodeAddr string, ns *state
 			} else {
 				ns.PendingScope = nil
 			}
-			// Complete the audit task so the node can derive to complete.
+			// Only complete the audit task when all children are done.
 			// The audit may be not_started (never executed separately for
 			// orchestrators), so set it directly rather than going through
 			// TaskComplete which requires in_progress.
-			for i := range ns.Tasks {
-				if ns.Tasks[i].IsAudit {
-					ns.Tasks[i].State = state.StatusComplete
+			allChildrenComplete := true
+			for _, c := range ns.Children {
+				if c.State != state.StatusComplete {
+					allChildrenComplete = false
 					break
 				}
 			}
-			// Recompute node state from tasks + children.
-			allDone := true
-			for _, t := range ns.Tasks {
-				s := t.State
-				if derived, has := state.DeriveParentStatus(ns, t.ID); has {
-					s = derived
-				}
-				if s != state.StatusComplete {
-					allDone = false
+			if allChildrenComplete {
+				for i := range ns.Tasks {
+					if ns.Tasks[i].IsAudit {
+						ns.Tasks[i].State = state.StatusComplete
+						break
+					}
 				}
 			}
-			for _, c := range ns.Children {
-				if c.State != state.StatusComplete {
-					allDone = false
-				}
-			}
-			if allDone {
-				ns.State = state.StatusComplete
-			}
+			ns.State = state.RecomputeState(ns.Children, ns.Tasks)
 			return nil
 		})
 		// Propagate the actual derived state. If planning created children

--- a/internal/daemon/planning_192_test.go
+++ b/internal/daemon/planning_192_test.go
@@ -1,0 +1,195 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/dorkusprime/wolfcastle/internal/config"
+	"github.com/dorkusprime/wolfcastle/internal/state"
+)
+
+// Regression test for #192: an orchestrator whose children are all
+// not_started should derive to not_started after planning completes,
+// not in_progress.
+func TestRunPlanningPass_CompleteWithNotStartedChildren(t *testing.T) {
+	t.Parallel()
+	d := testDaemon(t)
+	d.Config.Pipeline.Planning.Enabled = true
+	d.Config.Pipeline.Planning.Model = "echo"
+	d.Config.Models["echo"] = config.ModelDef{Command: "echo", Args: []string{"WOLFCASTLE_COMPLETE"}}
+
+	projDir := d.Store.Dir()
+
+	// Set up an orchestrator with two not_started children and an audit task.
+	ns := state.NewNodeState("orch", "Orch", state.NodeOrchestrator)
+	ns.NeedsPlanning = true
+	ns.State = state.StatusNotStarted
+	ns.Tasks = []state.Task{{ID: "audit-0001", Title: "Audit", IsAudit: true, State: state.StatusNotStarted}}
+	ns.Children = []state.ChildRef{
+		{ID: "alpha", Address: "orch/alpha", State: state.StatusNotStarted},
+		{ID: "beta", Address: "orch/beta", State: state.StatusNotStarted},
+	}
+	writeJSON(t, filepath.Join(projDir, "orch", "state.json"), ns)
+
+	idx := state.NewRootIndex()
+	idx.Root = []string{"orch"}
+	idx.Nodes["orch"] = state.IndexEntry{
+		Name: "Orch", Type: state.NodeOrchestrator, State: state.StatusNotStarted,
+		Address: "orch", Children: []string{"orch/alpha", "orch/beta"},
+	}
+	idx.Nodes["orch/alpha"] = state.IndexEntry{
+		Name: "Alpha", Type: state.NodeLeaf, State: state.StatusNotStarted,
+		Address: "orch/alpha", Parent: "orch",
+	}
+	idx.Nodes["orch/beta"] = state.IndexEntry{
+		Name: "Beta", Type: state.NodeLeaf, State: state.StatusNotStarted,
+		Address: "orch/beta", Parent: "orch",
+	}
+	writeJSON(t, filepath.Join(projDir, "state.json"), idx)
+
+	writePromptFile(t, d.WolfcastleDir, "stages/plan-initial.md")
+
+	_ = d.Logger.StartIteration()
+	defer d.Logger.Close()
+
+	if err := d.runPlanningPass(context.Background(), "orch", ns, idx); err != nil {
+		t.Fatalf("runPlanningPass failed: %v", err)
+	}
+
+	updated, err := d.Store.ReadNode("orch")
+	if err != nil {
+		t.Fatalf("failed to read node: %v", err)
+	}
+
+	// The orchestrator's audit task must NOT be completed when children
+	// are all not_started.
+	for _, task := range updated.Tasks {
+		if task.IsAudit && task.State == state.StatusComplete {
+			t.Error("audit task should not be completed when children are all not_started")
+		}
+	}
+
+	// The orchestrator itself must be not_started, not in_progress.
+	if updated.State != state.StatusNotStarted {
+		t.Errorf("orchestrator state = %s, want not_started (children are all not_started)", updated.State)
+	}
+}
+
+// Verify the audit task IS completed when all children are complete.
+func TestRunPlanningPass_CompleteWithAllChildrenComplete(t *testing.T) {
+	t.Parallel()
+	d := testDaemon(t)
+	d.Config.Pipeline.Planning.Enabled = true
+	d.Config.Pipeline.Planning.Model = "echo"
+	d.Config.Models["echo"] = config.ModelDef{Command: "echo", Args: []string{"WOLFCASTLE_COMPLETE"}}
+
+	projDir := d.Store.Dir()
+
+	ns := state.NewNodeState("orch", "Orch", state.NodeOrchestrator)
+	ns.NeedsPlanning = true
+	ns.State = state.StatusInProgress
+	ns.Tasks = []state.Task{{ID: "audit-0001", Title: "Audit", IsAudit: true, State: state.StatusNotStarted}}
+	ns.Children = []state.ChildRef{
+		{ID: "alpha", Address: "orch/alpha", State: state.StatusComplete},
+		{ID: "beta", Address: "orch/beta", State: state.StatusComplete},
+	}
+	writeJSON(t, filepath.Join(projDir, "orch", "state.json"), ns)
+
+	idx := state.NewRootIndex()
+	idx.Root = []string{"orch"}
+	idx.Nodes["orch"] = state.IndexEntry{
+		Name: "Orch", Type: state.NodeOrchestrator, State: state.StatusInProgress,
+		Address: "orch", Children: []string{"orch/alpha", "orch/beta"},
+	}
+	idx.Nodes["orch/alpha"] = state.IndexEntry{
+		Name: "Alpha", Type: state.NodeLeaf, State: state.StatusComplete,
+		Address: "orch/alpha", Parent: "orch",
+	}
+	idx.Nodes["orch/beta"] = state.IndexEntry{
+		Name: "Beta", Type: state.NodeLeaf, State: state.StatusComplete,
+		Address: "orch/beta", Parent: "orch",
+	}
+	writeJSON(t, filepath.Join(projDir, "state.json"), idx)
+
+	writePromptFile(t, d.WolfcastleDir, "stages/plan-initial.md")
+
+	_ = d.Logger.StartIteration()
+	defer d.Logger.Close()
+
+	if err := d.runPlanningPass(context.Background(), "orch", ns, idx); err != nil {
+		t.Fatalf("runPlanningPass failed: %v", err)
+	}
+
+	updated, err := d.Store.ReadNode("orch")
+	if err != nil {
+		t.Fatalf("failed to read node: %v", err)
+	}
+
+	// Audit task should be complete when all children are complete.
+	auditComplete := false
+	for _, task := range updated.Tasks {
+		if task.IsAudit && task.State == state.StatusComplete {
+			auditComplete = true
+		}
+	}
+	if !auditComplete {
+		t.Error("audit task should be completed when all children are complete")
+	}
+
+	// The orchestrator should derive to complete.
+	if updated.State != state.StatusComplete {
+		t.Errorf("orchestrator state = %s, want complete", updated.State)
+	}
+}
+
+// Mixed children: some complete, some not_started. Orchestrator should
+// be in_progress, audit should stay not_started.
+func TestRunPlanningPass_CompleteWithMixedChildren(t *testing.T) {
+	t.Parallel()
+	d := testDaemon(t)
+	d.Config.Pipeline.Planning.Enabled = true
+	d.Config.Pipeline.Planning.Model = "echo"
+	d.Config.Models["echo"] = config.ModelDef{Command: "echo", Args: []string{"WOLFCASTLE_COMPLETE"}}
+
+	projDir := d.Store.Dir()
+
+	ns := state.NewNodeState("orch", "Orch", state.NodeOrchestrator)
+	ns.NeedsPlanning = true
+	ns.State = state.StatusInProgress
+	ns.Tasks = []state.Task{{ID: "audit-0001", Title: "Audit", IsAudit: true, State: state.StatusNotStarted}}
+	ns.Children = []state.ChildRef{
+		{ID: "alpha", Address: "orch/alpha", State: state.StatusComplete},
+		{ID: "beta", Address: "orch/beta", State: state.StatusNotStarted},
+	}
+	writeJSON(t, filepath.Join(projDir, "orch", "state.json"), ns)
+
+	idx := state.NewRootIndex()
+	writeJSON(t, filepath.Join(projDir, "state.json"), idx)
+
+	writePromptFile(t, d.WolfcastleDir, "stages/plan-initial.md")
+
+	_ = d.Logger.StartIteration()
+	defer d.Logger.Close()
+
+	if err := d.runPlanningPass(context.Background(), "orch", ns, idx); err != nil {
+		t.Fatalf("runPlanningPass failed: %v", err)
+	}
+
+	updated, err := d.Store.ReadNode("orch")
+	if err != nil {
+		t.Fatalf("failed to read node: %v", err)
+	}
+
+	// Audit task should stay not_started with mixed children.
+	for _, task := range updated.Tasks {
+		if task.IsAudit && task.State == state.StatusComplete {
+			t.Error("audit task should not be completed when children are mixed")
+		}
+	}
+
+	// Orchestrator should be in_progress (mixed children).
+	if updated.State != state.StatusInProgress {
+		t.Errorf("orchestrator state = %s, want in_progress (mixed children)", updated.State)
+	}
+}


### PR DESCRIPTION
## Summary

- The planning COMPLETE handler was unconditionally completing the orchestrator's audit task, even when all children were `not_started`. This made `RecomputeState` return `in_progress` (because `allNotStarted` was false due to the completed audit task), making it appear the daemon was actively working on orchestrators it hadn't touched yet.
- Now the audit task is only completed when all children are already `complete`, and state is always derived via `RecomputeState` rather than manual checks.

Closes #192

## Test plan

- [x] `TestRunPlanningPass_CompleteWithNotStartedChildren`: orchestrator with all not_started children derives to `not_started` after planning (was `in_progress`)
- [x] `TestRunPlanningPass_CompleteWithAllChildrenComplete`: orchestrator with all complete children still derives to `complete` and audit task is completed
- [x] `TestRunPlanningPass_CompleteWithMixedChildren`: orchestrator with mixed children derives to `in_progress`, audit stays `not_started`
- [x] Full `go test ./...` passes (31 packages, 0 failures)