### PR TITLE
Add v0.4.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.4.1
+
+### Bug Fixes
+- Orchestrators with all `not_started` children no longer show as `in_progress` after planning; the planning COMPLETE handler now defers audit task completion until all children are done and derives state via `RecomputeState` (#192)
+
+### Maintenance
+- Remove all em-dashes from Go source and test comments per VOICE.md guidelines
+- Add coverage tests for `IsBoolFlag`, `followJSON`, `printParallelStatus`, `nodeGlyphPlain`, `countOpenEscalations`, `countGaps`, `BaseVersion`
+
 ## 0.4.0
 
 ### Bug Fixes


### PR DESCRIPTION
## Summary

- Changelog entry for v0.4.1 covering #192 fix and audit maintenance work

## Test plan

- [x] No code changes, changelog only