### PR TITLE
Archive versioned Homebrew formula on each release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,3 +29,38 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
+      - name: Archive versioned Homebrew formula
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          MAJOR_MINOR="${TAG%.*}"
+          VERSIONED="wolfcastle@${MAJOR_MINOR}.rb"
+
+          # Fetch the formula GoReleaser just pushed
+          FORMULA=$(gh api repos/dorkusprime/homebrew-tap/contents/Formula/wolfcastle.rb --jq .content | base64 -d)
+
+          # Rewrite class name: Wolfcastle -> WolfcastleATX_Y
+          SAFE_MM=$(echo "$MAJOR_MINOR" | tr '.' '_')
+          VERSIONED_FORMULA=$(echo "$FORMULA" | sed "s/^class Wolfcastle < Formula/class WolfcastleAT${SAFE_MM} < Formula/")
+
+          # Add keg_only after the license line so it doesn't conflict
+          VERSIONED_FORMULA=$(echo "$VERSIONED_FORMULA" | sed '/^  license/a\  keg_only :versioned_formula')
+
+          # Push to tap (create or update)
+          EXISTING_SHA=$(gh api repos/dorkusprime/homebrew-tap/contents/Formula/"$VERSIONED" --jq .sha 2>/dev/null || true)
+          ENCODED=$(echo "$VERSIONED_FORMULA" | base64 -w 0)
+
+          if [ -n "$EXISTING_SHA" ]; then
+            gh api repos/dorkusprime/homebrew-tap/contents/Formula/"$VERSIONED" \
+              -X PUT \
+              -f message="Archive wolfcastle@${MAJOR_MINOR} formula for v${TAG}" \
+              -f content="$ENCODED" \
+              -f sha="$EXISTING_SHA"
+          else
+            gh api repos/dorkusprime/homebrew-tap/contents/Formula/"$VERSIONED" \
+              -X PUT \
+              -f message="Archive wolfcastle@${MAJOR_MINOR} formula for v${TAG}" \
+              -f content="$ENCODED"
+          fi


### PR DESCRIPTION
## Summary

- After GoReleaser pushes the latest formula to the tap, a new step copies it to `wolfcastle@MAJOR.MINOR.rb` with the class name adjusted and `keg_only :versioned_formula` added
- Users can now `brew install dorkusprime/tap/wolfcastle@0.4` to pin a specific major.minor series
- Backfilled `wolfcastle@0.4.rb` pointing to v0.4.1 in the tap

## How it works

Each release tag `vX.Y.Z` produces a versioned formula `wolfcastle@X.Y.rb`. Patch releases within the same minor overwrite the versioned formula, so `wolfcastle@0.4` always tracks the latest 0.4.x. The main `wolfcastle` formula continues to track the absolute latest.

## Test plan

- [x] `wolfcastle@0.4.rb` pushed to tap with correct class name (`WolfcastleAT0_4`), `keg_only`, and v0.4.1 URLs/checksums
- [x] Workflow step handles both create and update (checks for existing SHA)