### PR TITLE
Fix stale log display in status screen

### DIFF
--- a/cmd/daemon/status.go
+++ b/cmd/daemon/status.go
@@ -705,9 +705,23 @@ func printRecentLog(logDir string, n int) {
 		return
 	}
 
+	// Filter to exec/plan files. Intake files contain inbox processing
+	// records that the summary renderer doesn't render, and they can
+	// outnumber execution files, pushing real work out of the tail.
+	var workFiles []string
+	for _, f := range session.Files {
+		base := filepath.Base(f)
+		if !strings.Contains(base, "-intake-") {
+			workFiles = append(workFiles, f)
+		}
+	}
+	if len(workFiles) == 0 {
+		return
+	}
+
 	// Only read the last few files to avoid parsing an entire long session.
 	// Each file is one iteration; 5 files is plenty to yield 2 rendered lines.
-	files := session.Files
+	files := workFiles
 	if len(files) > 5 {
 		files = files[len(files)-5:]
 	}

--- a/cmd/daemon/status_coverage_test.go
+++ b/cmd/daemon/status_coverage_test.go
@@ -488,6 +488,36 @@ func TestPrintRecentLog_RenderedEmpty(t *testing.T) {
 	printRecentLog(logDir, 2)
 }
 
+func TestPrintRecentLog_IntakeFilesFiltered(t *testing.T) {
+	logDir := t.TempDir()
+	ts := time.Now().UTC()
+
+	// Write one exec file with a real stage_complete, then several intake
+	// files after it. Without filtering, the intake files push the exec
+	// file out of the "last 5" window and nothing renders.
+	execLine := mustJSON(map[string]any{
+		"type": "stage_complete", "stage": "execute",
+		"node": "proj/auth", "task": "task-0001",
+		"exit_code": 0, "duration_ms": 3000,
+		"timestamp": ts.Format(time.RFC3339Nano),
+	})
+	_ = os.WriteFile(filepath.Join(logDir, "0001-exec-20260405T12-00Z.jsonl"),
+		[]byte(execLine+"\n"), 0o644)
+
+	// 10 intake files after it (higher iteration numbers, later timestamps).
+	for i := 0; i < 10; i++ {
+		intakeLine := mustJSON(map[string]any{
+			"type":      "intake_complete",
+			"timestamp": ts.Add(time.Duration(i+1) * time.Minute).Format(time.RFC3339Nano),
+		})
+		name := fmt.Sprintf("%04d-intake-20260405T12-%02dZ.jsonl", 10001+i, i+1)
+		_ = os.WriteFile(filepath.Join(logDir, name), []byte(intakeLine+"\n"), 0o644)
+	}
+
+	// Should still render the exec line, not be drowned by intake files.
+	printRecentLog(logDir, 2)
+}
+
 func mustJSON(v any) string {
 	data, err := json.Marshal(v)
 	if err != nil {


### PR DESCRIPTION
## Summary

The "Recent:" section in `wolfcastle status` was showing stale or empty content. Intake log files (iteration 10000+) outnumbered exec/plan files and pushed actual work out of the "last 5 files" window. The summary renderer doesn't render intake records, so it produced no output or showed old execution results.

Now filters session files to exclude intake logs before taking the tail.

## Test plan

- [x] `TestPrintRecentLog_IntakeFilesFiltered`: 1 exec file + 10 intake files; exec line still renders
- [x] All existing `PrintRecentLog` tests pass
- [x] Full `cmd/daemon` test suite passes