### PR TITLE
Reclaim orphaned in_progress tasks at runtime (#201)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.3
+
+### Bug Fixes
+- In parallel mode, orphaned `in_progress` tasks (lost worker, stall kill) are now reclaimed at runtime, not just on startup. The dispatcher scans for tasks with no active worker each iteration and resets them to `not_started`. (#201)
+- Status screen "Recent:" section no longer shows stale content when intake log files outnumber execution files (#203)
+
 ## 0.4.2
 
 ### Features

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -828,10 +828,13 @@ func (d *Daemon) runOnceParallel(ctx context.Context, idx *state.RootIndex) (Ite
 		}
 	}
 
-	// Step 2: Fill open worker slots with eligible tasks.
+	// Step 2: Reclaim orphaned in_progress tasks whose workers are gone.
+	pd.reclaimOrphans(idx)
+
+	// Step 3: Fill open worker slots with eligible tasks.
 	launched := pd.fillSlots(ctx, idx)
 
-	// Step 3: Determine the iteration outcome.
+	// Step 4: Determine the iteration outcome.
 	pd.mu.Lock()
 	activeCount := len(pd.active)
 	pd.mu.Unlock()

--- a/internal/daemon/parallel.go
+++ b/internal/daemon/parallel.go
@@ -349,6 +349,71 @@ done:
 	return collected
 }
 
+// reclaimOrphans finds in_progress tasks with no active worker and resets
+// them to not_started. This handles the case where a worker was lost (stall
+// kill, daemon restart) and its task was never cleaned up. Without this,
+// orphaned tasks stay in_progress forever because fillSlots can't claim
+// them and the navigator returns them ahead of not_started tasks.
+func (pd *ParallelDispatcher) reclaimOrphans(idx *state.RootIndex) int {
+	d := pd.daemon
+	reclaimed := 0
+
+	for addr, entry := range idx.Nodes {
+		if entry.Type != state.NodeLeaf {
+			continue
+		}
+		if entry.State != state.StatusInProgress {
+			continue
+		}
+
+		ns, err := d.Store.ReadNode(addr)
+		if err != nil {
+			continue
+		}
+
+		for _, task := range ns.Tasks {
+			if task.State != state.StatusInProgress {
+				continue
+			}
+			// Parent tasks (with children) derive their status; skip them.
+			if state.TaskChildren(ns, task.ID) {
+				continue
+			}
+
+			taskAddr := addr + "/" + task.ID
+			pd.mu.Lock()
+			_, active := pd.active[taskAddr]
+			pd.mu.Unlock()
+			if active {
+				continue
+			}
+
+			// This task is in_progress but no worker owns it. Reset it.
+			if err := d.Store.MutateNode(addr, func(mns *state.NodeState) error {
+				for i := range mns.Tasks {
+					if mns.Tasks[i].ID == task.ID && mns.Tasks[i].State == state.StatusInProgress {
+						mns.Tasks[i].State = state.StatusNotStarted
+						break
+					}
+				}
+				mns.State = state.RecomputeState(mns.Children, mns.Tasks)
+				return nil
+			}); err != nil {
+				continue
+			}
+
+			_ = d.Logger.Log(map[string]any{
+				"type": "reclaim_orphan",
+				"task": taskAddr,
+				"node": addr,
+			})
+			reclaimed++
+		}
+	}
+
+	return reclaimed
+}
+
 // fillSlots finds eligible parallel tasks and launches workers for them,
 // up to the number of available slots. Returns the count of workers launched.
 func (pd *ParallelDispatcher) fillSlots(ctx context.Context, idx *state.RootIndex) int {

--- a/internal/daemon/reclaim_test.go
+++ b/internal/daemon/reclaim_test.go
@@ -1,0 +1,163 @@
+package daemon
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/dorkusprime/wolfcastle/internal/state"
+)
+
+// Regression test for #201: in_progress tasks with no active worker
+// should be reset to not_started by reclaimOrphans.
+func TestReclaimOrphans_ResetsOrphanedTask(t *testing.T) {
+	t.Parallel()
+	d := testDaemon(t)
+	pd := NewParallelDispatcher(d, 4)
+	d.dispatcher = pd
+
+	projDir := d.Store.Dir()
+	_ = d.Logger.StartIteration()
+	defer d.Logger.Close()
+
+	// Set up a leaf with one in_progress task (orphaned, no worker).
+	ns := state.NewNodeState("leaf", "Leaf", state.NodeLeaf)
+	ns.State = state.StatusInProgress
+	ns.Tasks = []state.Task{
+		{ID: "task-0001", Title: "Orphaned", State: state.StatusInProgress},
+		{ID: "audit-0001", Title: "Audit", IsAudit: true, State: state.StatusNotStarted},
+	}
+	writeJSON(t, filepath.Join(projDir, "leaf", "state.json"), ns)
+
+	idx := state.NewRootIndex()
+	idx.Root = []string{"leaf"}
+	idx.Nodes["leaf"] = state.IndexEntry{
+		Name: "Leaf", Type: state.NodeLeaf, State: state.StatusInProgress, Address: "leaf",
+	}
+	writeJSON(t, filepath.Join(projDir, "state.json"), idx)
+
+	// No active workers in the dispatcher.
+	reclaimed := pd.reclaimOrphans(idx)
+	if reclaimed != 1 {
+		t.Errorf("expected 1 reclaimed, got %d", reclaimed)
+	}
+
+	updated, err := d.Store.ReadNode("leaf")
+	if err != nil {
+		t.Fatalf("reading node: %v", err)
+	}
+
+	for _, task := range updated.Tasks {
+		if task.ID == "task-0001" && task.State != state.StatusNotStarted {
+			t.Errorf("task-0001 state = %s, want not_started", task.State)
+		}
+	}
+	if updated.State != state.StatusNotStarted {
+		t.Errorf("node state = %s, want not_started", updated.State)
+	}
+}
+
+// Active workers should not be reclaimed.
+func TestReclaimOrphans_SkipsActiveWorker(t *testing.T) {
+	t.Parallel()
+	d := testDaemon(t)
+	pd := NewParallelDispatcher(d, 4)
+	d.dispatcher = pd
+
+	projDir := d.Store.Dir()
+	_ = d.Logger.StartIteration()
+	defer d.Logger.Close()
+
+	ns := state.NewNodeState("leaf", "Leaf", state.NodeLeaf)
+	ns.State = state.StatusInProgress
+	ns.Tasks = []state.Task{
+		{ID: "task-0001", Title: "Active", State: state.StatusInProgress},
+	}
+	writeJSON(t, filepath.Join(projDir, "leaf", "state.json"), ns)
+
+	idx := state.NewRootIndex()
+	idx.Root = []string{"leaf"}
+	idx.Nodes["leaf"] = state.IndexEntry{
+		Name: "Leaf", Type: state.NodeLeaf, State: state.StatusInProgress, Address: "leaf",
+	}
+	writeJSON(t, filepath.Join(projDir, "state.json"), idx)
+
+	// Register an active worker for this task.
+	pd.mu.Lock()
+	pd.active["leaf/task-0001"] = &WorkerSlot{Node: "leaf", Task: "task-0001"}
+	pd.mu.Unlock()
+
+	reclaimed := pd.reclaimOrphans(idx)
+	if reclaimed != 0 {
+		t.Errorf("expected 0 reclaimed (worker active), got %d", reclaimed)
+	}
+
+	updated, _ := d.Store.ReadNode("leaf")
+	for _, task := range updated.Tasks {
+		if task.ID == "task-0001" && task.State != state.StatusInProgress {
+			t.Errorf("active task should stay in_progress, got %s", task.State)
+		}
+	}
+}
+
+// Completed and not_started tasks should be ignored.
+func TestReclaimOrphans_IgnoresNonInProgressTasks(t *testing.T) {
+	t.Parallel()
+	d := testDaemon(t)
+	pd := NewParallelDispatcher(d, 4)
+	d.dispatcher = pd
+
+	projDir := d.Store.Dir()
+	_ = d.Logger.StartIteration()
+	defer d.Logger.Close()
+
+	ns := state.NewNodeState("leaf", "Leaf", state.NodeLeaf)
+	ns.State = state.StatusInProgress
+	ns.Tasks = []state.Task{
+		{ID: "task-0001", Title: "Done", State: state.StatusComplete},
+		{ID: "task-0002", Title: "Waiting", State: state.StatusNotStarted},
+	}
+	writeJSON(t, filepath.Join(projDir, "leaf", "state.json"), ns)
+
+	idx := state.NewRootIndex()
+	idx.Root = []string{"leaf"}
+	idx.Nodes["leaf"] = state.IndexEntry{
+		Name: "Leaf", Type: state.NodeLeaf, State: state.StatusInProgress, Address: "leaf",
+	}
+	writeJSON(t, filepath.Join(projDir, "state.json"), idx)
+
+	reclaimed := pd.reclaimOrphans(idx)
+	if reclaimed != 0 {
+		t.Errorf("expected 0 reclaimed (no in_progress tasks), got %d", reclaimed)
+	}
+}
+
+// Orchestrators should be skipped (only leaf tasks are dispatched).
+func TestReclaimOrphans_SkipsOrchestrators(t *testing.T) {
+	t.Parallel()
+	d := testDaemon(t)
+	pd := NewParallelDispatcher(d, 4)
+	d.dispatcher = pd
+
+	projDir := d.Store.Dir()
+	_ = d.Logger.StartIteration()
+	defer d.Logger.Close()
+
+	ns := state.NewNodeState("orch", "Orch", state.NodeOrchestrator)
+	ns.State = state.StatusInProgress
+	ns.Tasks = []state.Task{
+		{ID: "task-0001", Title: "Orphaned", State: state.StatusInProgress},
+	}
+	writeJSON(t, filepath.Join(projDir, "orch", "state.json"), ns)
+
+	idx := state.NewRootIndex()
+	idx.Root = []string{"orch"}
+	idx.Nodes["orch"] = state.IndexEntry{
+		Name: "Orch", Type: state.NodeOrchestrator, State: state.StatusInProgress, Address: "orch",
+	}
+	writeJSON(t, filepath.Join(projDir, "state.json"), idx)
+
+	reclaimed := pd.reclaimOrphans(idx)
+	if reclaimed != 0 {
+		t.Errorf("expected 0 reclaimed (orchestrator, not leaf), got %d", reclaimed)
+	}
+}


### PR DESCRIPTION
## Summary

In parallel mode, when a worker is lost (stall kill, daemon restart mid-session), its task stays `in_progress` with no active worker. `fillSlots` can't claim it (requires `not_started`), the navigator returns it ahead of `not_started` tasks, and the daemon moves on. The task is stuck forever until the next full daemon restart triggers self-heal.

`reclaimOrphans` runs each iteration between drain and fill. It scans leaf nodes for `in_progress` tasks with no corresponding entry in `pd.active` and resets them to `not_started` via `RecomputeState`.

Closes #201

## Test plan

- [x] `TestReclaimOrphans_ResetsOrphanedTask`: orphaned task reset to not_started, node state recomputed
- [x] `TestReclaimOrphans_SkipsActiveWorker`: task with active worker left alone
- [x] `TestReclaimOrphans_IgnoresNonInProgressTasks`: complete and not_started tasks ignored
- [x] `TestReclaimOrphans_SkipsOrchestrators`: only leaf nodes scanned
- [x] Full `go test ./...` passes