### PR TITLE
Log propagation errors, add Getting Started to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,16 @@ Wolfcastle is a Go CLI with 20 internal packages. Here's the map:
 
 The `cmd/` directory mirrors the CLI surface: `cmd/daemon/` (start, stop, log, status), `cmd/task/` (add, claim, complete, block, unblock, deliverable, scope), `cmd/audit/` (breadcrumb, gap, scope, summary, etc.), `cmd/config/` (show, set, unset, append, remove, validate), `cmd/orchestrator/`, `cmd/inbox/`, `cmd/project/`, `cmd/knowledge/` (add, show, edit, prune). Shared command utilities live in `cmd/cmdutil/`.
 
+## Getting Started
+
+```
+git clone https://github.com/dorkusprime/wolfcastle.git
+cd wolfcastle
+make test
+```
+
+All 3,000+ tests should pass. If they do, you're ready to contribute.
+
 ## Adding a CLI Command
 
 1. Create a file in the appropriate `cmd/` subdirectory (e.g., `cmd/task/newcmd.go`)

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -3,6 +3,7 @@ package state
 import (
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -143,7 +144,9 @@ func (s *Store) MutateNode(addr string, fn func(*NodeState) error) error {
 		}
 
 		if err := Propagate(addr, ns.State, idx, loadNode, saveNode); err != nil {
-			// Propagation failure is non-fatal for the mutation itself.
+			// Propagation failure is non-fatal for the mutation itself,
+			// but log it so operators can diagnose stale parent state.
+			log.Printf("wolfcastle: propagation error for %s: %v", addr, err)
 			return nil
 		}
 		return SaveRootIndex(s.indexPath(), idx)


### PR DESCRIPTION
## Summary

From the eval report (eval-report-2026-04-05T1316.md):

- **Propagation error logging**: `MutateNode` in `internal/state/store.go` was silently returning nil when propagation failed after a successful mutation. Now logs the error via `log.Printf` before returning nil. The mutation still succeeds (propagation is non-fatal), but the error is no longer invisible.

- **CONTRIBUTING.md**: Added a "Getting Started" section with clone + `make test` instructions. One paragraph, closes the gap between "I cloned the repo" and "I'm ready to contribute."

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] All MutateNode and propagation tests pass
- [x] No behavior change (propagation errors were already non-fatal; now they're logged)