### PR TITLE
Add cross-sibling verification to orchestrator completion review

### DIFF
--- a/internal/project/templates/prompts/stages/plan-review.md
+++ b/internal/project/templates/prompts/stages/plan-review.md
@@ -27,6 +27,18 @@ Check the codebase:
 - Are there gaps between what was planned and what was delivered?
 - Were ADRs and specs created where needed?
 
+#### Cross-sibling verification
+If any child modified a schema, endpoint, response model, shared interface, or public API, identify all test files that exercise those contracts in other siblings. Run those tests. A passing leaf audit does not guarantee cross-leaf compatibility. Schema changes in one child can break assertions in another child's tests without either leaf audit catching it.
+
+#### Behavioral regression check
+For refactoring tasks (extract helper, unify components, rename), compare observable behavior before and after. If an endpoint previously returned a specific response shape, verify it still does. If a function previously handled an edge case with graceful degradation, verify that path is preserved. Uniform extraction of patterns that had intentional per-site variation is a common regression source.
+
+#### Multi-tool verification
+Run ALL verification tools the project uses, not just the test suite. This includes type checkers (`tsc --noEmit`, `pyright`, `mypy`), linters (`ruff`, `eslint`, `go vet`), formatters, and build checks. A test suite that passes does not guarantee type safety or lint cleanliness. Check the project's CI configuration or Makefile for the full list of verification commands.
+
+#### Inbox item completeness
+When the orchestrator was created from an inbox item containing a numbered list of sub-items, verify each sub-item was addressed by at least one child's deliverables. Explicitly check off each sub-item. Flag any that were missed as gaps.
+
 ### D. Decide
 If all success criteria are met, no unaddressed action items remain, and no gaps exist, this orchestrator's work is done.
 


### PR DESCRIPTION
## Summary
- Adds four verification checks to the orchestrator completion review prompt (`plan-review.md` Phase C) to catch integration failures that pass individual leaf audits
- Cross-sibling test verification for shared schemas/APIs
- Behavioral regression checks for refactoring tasks
- Multi-tool verification (type checkers, linters, build)
- Inbox item completeness against original sub-items

Evidence from 38+ hours of monitored builds documented in #207.

Closes #207

## Test plan
- [ ] Build passes (`go build ./...`)
- [ ] Template tests pass (`go test ./internal/project/... ./internal/pipeline/...`)
- [ ] Prompt content review: verify new sections are clear and actionable