### PR TITLE
Clear stale parallel-status.json on serial mode startup

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -533,6 +533,10 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// and before the main loop begins dispatching work.
 	if d.Config.Daemon.Parallel.Enabled {
 		d.dispatcher = NewParallelDispatcher(d, d.Config.Daemon.Parallel.MaxWorkers)
+	} else {
+		// Remove stale parallel status from a previous session so
+		// `wolfcastle status` doesn't show misleading worker counts.
+		_ = os.Remove(parallelStatusPath(d.WolfcastleDir))
 	}
 
 	// Start the parallel inbox processing goroutine (ADR-064).

--- a/internal/daemon/parallel_coverage_test.go
+++ b/internal/daemon/parallel_coverage_test.go
@@ -99,3 +99,28 @@ func TestRemoveStatusFile_NoFile(t *testing.T) {
 	// Should not panic when file doesn't exist.
 	dispatcher.removeStatusFile()
 }
+
+func TestSerialMode_CleansStaleParallelStatus(t *testing.T) {
+	t.Parallel()
+	d := testDaemon(t)
+	d.Config.Daemon.Parallel.Enabled = false
+
+	// Plant a stale parallel-status.json from a previous session.
+	statusPath := parallelStatusPath(d.WolfcastleDir)
+	_ = os.MkdirAll(filepath.Dir(statusPath), 0755)
+	_ = os.WriteFile(statusPath, []byte(`{"max_workers":3}`), 0644)
+
+	if _, err := os.Stat(statusPath); os.IsNotExist(err) {
+		t.Fatal("precondition: stale status file should exist")
+	}
+
+	// Drop a stop file so the daemon exits after startup cleanup.
+	stopPath := filepath.Join(d.WolfcastleDir, "system", "stop")
+	_ = os.WriteFile(stopPath, nil, 0644)
+
+	_ = d.Run(t.Context())
+
+	if _, err := os.Stat(statusPath); !os.IsNotExist(err) {
+		t.Error("stale parallel-status.json should be removed in serial mode")
+	}
+}


### PR DESCRIPTION
## Summary
- On serial mode startup, remove leftover `parallel-status.json` from previous parallel sessions
- Prevents `wolfcastle status` from showing misleading "0/N workers active" when running serially

Closes #212

## Test plan
- [ ] `go test -race ./...` passes
- [ ] New test `TestSerialMode_CleansStaleParallelStatus` verifies the cleanup