### PR TITLE
fix(tui): instance-switch watcher restart was missing eager prefetch

### DIFF
--- a/internal/tui/app/app.go
+++ b/internal/tui/app/app.go
@@ -586,23 +586,15 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.daemonRepo = daemon.NewDaemonRepository(wolfDir)
 		m.worktreeDir = msg.Entry.Worktree
 
-		// Restart watcher: stop old, create and start new.
+		// Restart watcher: stop old, create+start+eager-prefetch new.
+		// MUST go through newWatcherFor so eager prefetch happens; if
+		// you inline tui.NewWatcher here you'll silently break the
+		// per-leaf cache freshness because no AddNodeWatch calls
+		// will be made for the new instance's leaves.
 		if m.watcher != nil {
 			m.watcher.Stop()
 		}
-		logDir := ""
-		if m.daemonRepo != nil {
-			logDir = m.daemonRepo.LogDir()
-		}
-		instanceDir := ""
-		if dir, err := instanceRegistryDir(); err == nil {
-			instanceDir = dir
-		}
-		w := tui.NewWatcher(m.store, logDir, instanceDir, m.watcherEvents)
-		if err := w.Start(); err != nil {
-			w.StartPolling()
-		}
-		m.watcher = w
+		m.watcher = newWatcherFor(m.store, m.daemonRepo, m.watcherEvents)
 
 		// Immediately probe daemon status and inbox so the dashboard
 		// populates without waiting for the next poll tick.
@@ -1416,31 +1408,51 @@ func (m *TUIModel) startWatcher() tea.Cmd {
 		if store == nil {
 			return nil
 		}
-		logDir := ""
-		instanceDir := ""
-		if repo != nil {
-			logDir = repo.LogDir()
-		}
-		if dir, err := instanceRegistryDir(); err == nil {
-			instanceDir = dir
-		}
-		w := tui.NewWatcher(store, logDir, instanceDir, events)
-		// Prefer fsnotify when available; fall back to mtime polling
-		// if the OS watcher cannot be initialized. Either path drives
-		// the same WatcherMsg envelope back through the model.
-		if err := w.Start(); err != nil {
-			w.StartPolling()
-		}
-		// Eagerly walk the index, populate the per-leaf cache, and
-		// add an fsnotify subscription for each leaf so the cache
-		// stays fresh as the daemon writes state.json updates.
-		// Without this, the per-task glyphs in the tree go stale
-		// the moment the daemon transitions a task, and search
-		// can't find tasks in unexpanded leaves.
-		_ = w.EagerPrefetchAndSubscribe()
-		m.watcher = w
+		m.watcher = newWatcherFor(store, repo, events)
 		return nil
 	}
+}
+
+// newWatcherFor is the single canonical entrypoint for constructing
+// and starting a Watcher. EVERY caller that touches m.watcher must
+// route through this helper, never call tui.NewWatcher directly.
+//
+// The helper does four things in order:
+//
+//  1. Resolve logDir and instanceDir from the daemon repo and the
+//     instance registry override.
+//  2. Construct the Watcher with the events channel.
+//  3. Start fsnotify (with polling fallback if fsnotify init fails).
+//  4. Walk the index and call EagerPrefetchAndSubscribe so the
+//     per-leaf cache is populated AND every leaf gets an fsnotify
+//     subscription. Without step 4 the leaf-level glyph in the tree
+//     stays in sync with the index file (which is watched), but the
+//     per-task glyphs go stale because no per-leaf state.json
+//     subscriptions exist.
+//
+// The instance-switch handler used to inline these four steps but
+// skip step 4, which silently broke task-level cache freshness for
+// any user who switched instances during a session. Routing through
+// this helper makes that class of bug structurally impossible: if
+// you forget to call newWatcherFor, you don't get a watcher at all.
+func newWatcherFor(store *state.Store, repo *daemon.DaemonRepository, events chan tea.Msg) *tui.Watcher {
+	if store == nil {
+		return nil
+	}
+	logDir := ""
+	if repo != nil {
+		logDir = repo.LogDir()
+	}
+	instanceDir := ""
+	if dir, err := instanceRegistryDir(); err == nil {
+		instanceDir = dir
+	}
+	w := tui.NewWatcher(store, logDir, instanceDir, events)
+	if err := w.Start(); err != nil {
+		w.StartPolling()
+	}
+	_ = w.EagerPrefetchAndSubscribe()
+	return w
 }
 
 func (m TUIModel) startPoller() tea.Cmd {

--- a/internal/tui/app/wiring_smoke_test.go
+++ b/internal/tui/app/wiring_smoke_test.go
@@ -27,8 +27,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/dorkusprime/wolfcastle/internal/daemon"
+	"github.com/dorkusprime/wolfcastle/internal/instance"
 	"github.com/dorkusprime/wolfcastle/internal/logging"
 	"github.com/dorkusprime/wolfcastle/internal/state"
 	"github.com/dorkusprime/wolfcastle/internal/tui"
@@ -372,6 +374,142 @@ drainLoop:
 	}
 	if !found {
 		t.Error("startWatcher did not trigger eager prefetch; no NodeUpdatedMsg for alpha arrived in the events channel")
+	}
+}
+
+// TestWiring_InstanceSwitchTriggersEagerPrefetch is the regression
+// test for the dead-wiring bug found in the debug log: the
+// InstanceSwitchedMsg handler used to inline tui.NewWatcher calls
+// without calling EagerPrefetchAndSubscribe, so users who switched
+// instances mid-session lost per-leaf cache freshness for the new
+// worktree. The fix routes both call sites through newWatcherFor;
+// this test exercises the InstanceSwitchedMsg path end-to-end so
+// any future regression that re-introduces an inline construction
+// is caught immediately.
+func TestWiring_InstanceSwitchTriggersEagerPrefetch(t *testing.T) {
+	// Set up a target worktree with a real config (so
+	// storeFromWolfcastleDir resolves an identity), a real index,
+	// and one leaf so the eager prefetch has something to find.
+	tmp := t.TempDir()
+	wcDir := filepath.Join(tmp, ".wolfcastle")
+
+	// Local-tier config provides an identity, which makes
+	// storeFromWolfcastleDir return a non-nil store. Without this,
+	// the InstanceSwitchedMsg handler silently fails to construct
+	// a watcher and the test doesn't actually exercise the code
+	// path under test.
+	if err := os.MkdirAll(filepath.Join(wcDir, "system", "local"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfgJSON := `{"identity": {"user": "tester", "machine": "box"}}`
+	if err := os.WriteFile(filepath.Join(wcDir, "system", "local", "config.json"), []byte(cfgJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stage the index and leaf state under the namespace dir that
+	// id.ProjectsDir() will derive from the identity above:
+	// <wcDir>/system/projects/<user>-<machine>
+	storeDir := filepath.Join(wcDir, "system", "projects", "tester-box")
+	if err := os.MkdirAll(storeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rootIndex := map[string]any{
+		"version": 1,
+		"root":    []string{"target"},
+		"nodes": map[string]any{
+			"target": map[string]any{
+				"name":    "target",
+				"type":    "leaf",
+				"state":   "in_progress",
+				"address": "target",
+			},
+		},
+	}
+	rootData, _ := json.Marshal(rootIndex)
+	if err := os.WriteFile(filepath.Join(storeDir, "state.json"), rootData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	leafDir := filepath.Join(storeDir, "target")
+	if err := os.MkdirAll(leafDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	leafState := map[string]any{
+		"version": 1,
+		"id":      "target",
+		"name":    "target",
+		"type":    "leaf",
+		"state":   "in_progress",
+		"tasks": []map[string]any{
+			{"id": "task-0001", "title": "switched", "description": "switched", "state": "in_progress", "failure_count": 0},
+		},
+	}
+	leafData, _ := json.Marshal(leafState)
+	if err := os.WriteFile(filepath.Join(leafDir, "state.json"), leafData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Build a model that's already in StateLive with a (different)
+	// store, then feed an InstanceSwitchedMsg pointing at the
+	// staged target. This is exactly what happens when a user
+	// presses < or > or a digit key to switch instances.
+	m := newColdModel(t)
+	m.entryState = StateLive
+
+	// Drain anything left in the events channel from newColdModel
+	// setup so we can assert against a fresh state below.
+	for {
+		select {
+		case <-m.watcherEvents:
+		default:
+			goto drained
+		}
+	}
+drained:
+
+	freshStore := state.NewStore(storeDir, 0)
+	freshIdx, err := freshStore.ReadIndex()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = freshStore // only used for the index read above
+	switchMsg := tui.InstanceSwitchedMsg{
+		Index: freshIdx,
+		Entry: instance.Entry{
+			Worktree:  tmp,
+			PID:       os.Getpid(),
+			Branch:    "main",
+			StartedAt: time.Now(),
+		},
+	}
+	result, _ := m.Update(switchMsg)
+	m = toModel(t, result)
+
+	// After the handler runs, the events channel should contain a
+	// WatcherMsg{NodeUpdatedMsg} for the target leaf because the
+	// new watcher's eager prefetch fired during construction.
+	found := false
+drainSwitchLoop:
+	for i := 0; i < 8; i++ {
+		select {
+		case msg := <-m.watcherEvents:
+			envelope, ok := msg.(tui.WatcherMsg)
+			if !ok {
+				continue
+			}
+			nu, ok := envelope.Inner.(tui.NodeUpdatedMsg)
+			if !ok {
+				continue
+			}
+			if nu.Address == "target" && nu.Node != nil && len(nu.Node.Tasks) == 1 {
+				found = true
+				break drainSwitchLoop
+			}
+		default:
+			break drainSwitchLoop
+		}
+	}
+	if !found {
+		t.Error("InstanceSwitchedMsg handler constructed a watcher without triggering eager prefetch; no NodeUpdatedMsg for target arrived in the events channel. The handler must route through newWatcherFor.")
 	}
 }
 


### PR DESCRIPTION
## Summary
**Found via runtime debug logging on a real session.** You launched the TUI in one worktree, then switched to another (via the welcome screen's running-instances panel, or via \`<\` / \`>\` / digit keys). After the switch, the per-task glyphs in the new worktree's tree never updated and the daemon was operating on tasks the TUI didn't even show. The debug log proved that fsnotify was completely silent on per-leaf state.json files for the second instance, and zero \`AddNodeWatch\` calls had been made for it.

## Root cause
The \`InstanceSwitchedMsg\` handler at app.go:560 inlined the watcher construction:

\`\`\`go
m.watcher = tui.NewWatcher(m.store, logDir, instanceDir, m.watcherEvents)
if err := w.Start(); err != nil { w.StartPolling() }
\`\`\`

It correctly subscribed fsnotify to the new worktree's index dir, instance registry, and log dir, but **it skipped the \`EagerPrefetchAndSubscribe\` call** that the \`startWatcher\` cmd does. So no \`AddNodeWatch\` calls were made for any per-leaf state.json file in the new worktree, which meant fsnotify was completely silent on per-task changes for the rest of the session.

Same dead-wiring shape as #240 (Watcher.Start dead code) and the previous PR (AddNodeWatch dead code): a function exists, the renderer downstream of it is correct, but one of the call sites that should invoke it doesn't. Per-layer unit tests can't catch this — only an integration test that drives the specific message-routing path can.

## Fix
Extract a canonical \`newWatcherFor\` helper that does construct + Start + EagerPrefetchAndSubscribe in one shot. Both call sites (\`startWatcher\` cmd and \`InstanceSwitchedMsg\` handler) route through it. **There is now exactly one \`tui.NewWatcher\` call in production app.go and it lives inside \`newWatcherFor\`** — you can no longer construct a watcher without eager prefetch even if you try.

\`\`\`go
// newWatcherFor is the single canonical entrypoint for constructing
// and starting a Watcher. EVERY caller that touches m.watcher must
// route through this helper, never call tui.NewWatcher directly.
func newWatcherFor(store *state.Store, repo *daemon.DaemonRepository, events chan tea.Msg) *tui.Watcher
\`\`\`

## Test coverage
- **\`TestWiring_InstanceSwitchTriggersEagerPrefetch\`** sets up a real target worktree with config, identity, index, and one leaf state.json, then sends an \`InstanceSwitchedMsg\` to a model that was previously pointed at a different worktree, and asserts a \`NodeUpdatedMsg\` for the target leaf arrives in the events channel. Without this test, anyone re-introducing an inline \`tui.NewWatcher\` in the \`InstanceSwitchedMsg\` handler would silently break per-leaf cache freshness for instance-switching users and the existing tests would all still pass.
- The existing \`TestStartWatcher_TriggersEagerPrefetch\` keeps covering the \`startWatcher\` cmd path. **Both call sites are now exercised end-to-end.**

## Test plan
- [x] \`go test ./internal/tui/... -count=1\` (full suite green)
- [x] \`golangci-lint run ./internal/tui/...\` clean
- [x] \`TestWiring_InstanceSwitchTriggersEagerPrefetch\` fails against the unfixed code, passes after the refactor
- [ ] Manual: launch TUI in a worktree, switch instances via \`>\` or digit key, verify task glyphs in the new worktree's leaves stay in sync with the daemon's writes

## How this slipped through PR #241
\`TestStartWatcher_TriggersEagerPrefetch\` only tested the \`startWatcher\` cmd path. The \`InstanceSwitchedMsg\` handler had a separate inline construction that was never tested. **The lesson going forward: every \`m.watcher = ...\` assignment in production needs a wiring smoke test for whichever message handler triggers it.** The \`newWatcherFor\` refactor enforces this structurally — there's now only one assignment site to test, plus the caller invocation.