### PR TITLE
fix: watcher new-leaf subscriptions, log rendering, stall timeout

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,7 +86,7 @@ func Defaults() *Config {
 			MaxIterations:              -1,
 			MaxTurnsPerInvocation:      200,
 			InvocationTimeoutSeconds:   3600,
-			StallTimeoutSeconds:        120,
+			StallTimeoutSeconds:        600,
 			MaxRestarts:                3,
 			RestartDelaySeconds:        2,
 			LogLevel:                   "info",

--- a/internal/tui/app/wiring_smoke_test.go
+++ b/internal/tui/app/wiring_smoke_test.go
@@ -536,13 +536,16 @@ func TestWiring_LogViewShowsExistingContent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Stage a real .jsonl file with one valid record. The exact
-	// schema doesn't matter for this test — only that the log view
-	// has SOMETHING to render.
+	// Stage a real .jsonl file with one valid record. Use a recognized
+	// record type so the renderer produces a non-empty line; the
+	// log view filters out empty-rendered records (e.g., assistant
+	// envelopes with no human-readable content).
 	rec := map[string]any{
-		"ts":    "2026-04-08T07:30:00Z",
-		"level": "info",
-		"msg":   "wiring smoke test record",
+		"timestamp": "2026-04-08T07:30:00Z",
+		"level":     "info",
+		"type":      "stage_start",
+		"stage":     "exec",
+		"node":      "wiring-smoke",
 	}
 	data, _ := json.Marshal(rec)
 	logFile := filepath.Join(logDir, "0001-exec-20260408T07-30Z.jsonl")

--- a/internal/tui/detail/dashboard.go
+++ b/internal/tui/detail/dashboard.go
@@ -9,6 +9,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
+	"github.com/dorkusprime/wolfcastle/internal/logrender"
 	"github.com/dorkusprime/wolfcastle/internal/state"
 	"github.com/dorkusprime/wolfcastle/internal/tui"
 )
@@ -83,8 +84,16 @@ func (m DashboardModel) Update(msg tea.Msg) (DashboardModel, tea.Cmd) {
 		m.currentNode = msg.CurrentNode
 		m.currentTask = msg.CurrentTask
 	case tui.LogLinesMsg:
-		for _, s := range msg.Lines {
-			m.pushActivity(s)
+		for _, raw := range msg.Lines {
+			rec, err := logrender.ParseRecord(raw)
+			if err != nil {
+				continue
+			}
+			summary := summarizeForActivity(rec)
+			if summary == "" {
+				continue
+			}
+			m.pushActivity(summary)
 		}
 	}
 	return m, nil
@@ -113,6 +122,48 @@ func (m *DashboardModel) recomputeFromIndex(idx *state.RootIndex) {
 	m.auditCounts = auditCounts
 	m.openGaps = gaps
 	m.openEscalations = escalations
+}
+
+// summarizeForActivity converts a parsed log record into a one-line summary
+// suitable for the Recent Activity feed, or returns "" for records that are
+// too noisy or low-signal to surface (assistant chatter, debug frames,
+// unknown types). The dashboard wants milestones, not a full transcript.
+func summarizeForActivity(rec logrender.Record) string {
+	nodeTask := rec.Node
+	if rec.Task != "" {
+		nodeTask += "/" + rec.Task
+	}
+	switch rec.Type {
+	case "stage_start":
+		if nodeTask == "" {
+			return fmt.Sprintf("▶ %s", rec.Stage)
+		}
+		return fmt.Sprintf("▶ %s %s", rec.Stage, nodeTask)
+	case "stage_complete":
+		exit := ""
+		if rec.ExitCode != nil {
+			exit = fmt.Sprintf(" (exit=%d)", *rec.ExitCode)
+		}
+		if nodeTask == "" {
+			return fmt.Sprintf("✓ %s%s", rec.Stage, exit)
+		}
+		return fmt.Sprintf("✓ %s %s%s", rec.Stage, nodeTask, exit)
+	case "stage_error":
+		return fmt.Sprintf("✗ %s %s: %s", rec.Stage, nodeTask, rec.Error)
+	case "failure_increment":
+		return fmt.Sprintf("⚠ %s failure #%d", nodeTask, rec.Counter)
+	case "auto_block":
+		return fmt.Sprintf("⛔ blocked %s: %s", nodeTask, rec.Reason)
+	case "daemon_start":
+		return "Daemon started"
+	case "daemon_lifecycle":
+		if rec.Event == "" {
+			return ""
+		}
+		return fmt.Sprintf("[lifecycle] %s", rec.Event)
+	default:
+		return ""
+	}
 }
 
 func (m *DashboardModel) pushActivity(text string) {
@@ -293,7 +344,7 @@ func (m DashboardModel) renderActivity() string {
 	}
 
 	for _, entry := range m.recentActivity {
-		ts := entry.timestamp.Format("15:04")
+		ts := entry.timestamp.Local().Format("15:04")
 		b.WriteByte('\n')
 		b.WriteString(body.Render(fmt.Sprintf("  %s  %s", ts, entry.text)))
 	}

--- a/internal/tui/detail/dashboard_test.go
+++ b/internal/tui/detail/dashboard_test.go
@@ -101,12 +101,18 @@ func TestDaemonStatusMsg_UpdatesFields(t *testing.T) {
 func TestLogLinesMsg_PushesActivity(t *testing.T) {
 	t.Parallel()
 	m := NewDashboardModel()
-	m, _ = m.Update(tui.LogLinesMsg{Lines: []string{"line one", "line two"}})
+	m, _ = m.Update(tui.LogLinesMsg{Lines: []string{
+		`{"type":"stage_start","stage":"intake","node":"alpha"}`,
+		`{"type":"stage_complete","stage":"exec","node":"alpha","task":"task-0001","exit_code":0}`,
+	}})
 	if len(m.recentActivity) != 2 {
-		t.Errorf("expected 2 activity entries, got %d", len(m.recentActivity))
+		t.Fatalf("expected 2 activity entries, got %d", len(m.recentActivity))
 	}
-	if m.recentActivity[0].text != "line one" {
-		t.Errorf("expected 'line one', got %q", m.recentActivity[0].text)
+	if !strings.Contains(m.recentActivity[0].text, "intake") {
+		t.Errorf("expected first entry to mention intake stage, got %q", m.recentActivity[0].text)
+	}
+	if !strings.Contains(m.recentActivity[1].text, "exit=0") {
+		t.Errorf("expected second entry to include exit code, got %q", m.recentActivity[1].text)
 	}
 }
 
@@ -115,7 +121,7 @@ func TestLogLinesMsg_CappedAtMax(t *testing.T) {
 	m := NewDashboardModel()
 	lines := make([]string, 15)
 	for i := range lines {
-		lines[i] = "line"
+		lines[i] = `{"type":"stage_start","stage":"exec","node":"alpha"}`
 	}
 	m, _ = m.Update(tui.LogLinesMsg{Lines: lines})
 	if len(m.recentActivity) != maxActivity {
@@ -123,12 +129,17 @@ func TestLogLinesMsg_CappedAtMax(t *testing.T) {
 	}
 }
 
-func TestLogLinesMsg_AllStringsAccepted(t *testing.T) {
+func TestLogLinesMsg_SkipsNoiseAndUnparseable(t *testing.T) {
 	t.Parallel()
 	m := NewDashboardModel()
-	m, _ = m.Update(tui.LogLinesMsg{Lines: []string{"alpha", "bravo", "charlie"}})
-	if len(m.recentActivity) != 3 {
-		t.Errorf("expected 3 activity entries, got %d", len(m.recentActivity))
+	m, _ = m.Update(tui.LogLinesMsg{Lines: []string{
+		"alpha",                                       // not JSON, dropped
+		`{"type":"assistant","text":"yammering"}`,     // assistant chatter, dropped
+		`{"type":"stage_start","stage":"intake"}`,     // kept
+		`{"type":"unknown_thing","field":"whatever"}`, // unknown type, dropped
+	}})
+	if len(m.recentActivity) != 1 {
+		t.Errorf("expected 1 activity entry (only the stage_start should survive), got %d", len(m.recentActivity))
 	}
 }
 
@@ -461,12 +472,14 @@ func TestView_ActivityWithTimestamps(t *testing.T) {
 	m.nodeCounts[state.StatusInProgress] = 1
 	m.totalNodes = 1
 	m.daemonRunning = true
+	ts := time.Date(2026, 1, 1, 14, 30, 0, 0, time.UTC)
 	m.recentActivity = []activityEntry{
-		{timestamp: time.Date(2026, 1, 1, 14, 30, 0, 0, time.UTC), text: "task completed"},
+		{timestamp: ts, text: "task completed"},
 	}
 	v := m.View()
-	if !strings.Contains(v, "14:30") {
-		t.Errorf("expected timestamp in activity, got: %s", v)
+	localHHMM := ts.Local().Format("15:04")
+	if !strings.Contains(v, localHHMM) {
+		t.Errorf("expected local timestamp %s in activity, got: %s", localHHMM, v)
 	}
 	if !strings.Contains(v, "task completed") {
 		t.Errorf("expected activity text, got: %s", v)

--- a/internal/tui/detail/dashboard_test.go
+++ b/internal/tui/detail/dashboard_test.go
@@ -133,7 +133,7 @@ func TestLogLinesMsg_SkipsNoiseAndUnparseable(t *testing.T) {
 	t.Parallel()
 	m := NewDashboardModel()
 	m, _ = m.Update(tui.LogLinesMsg{Lines: []string{
-		"alpha",                                       // not JSON, dropped
+		"alpha", // not JSON, dropped
 		`{"type":"assistant","text":"yammering"}`,     // assistant chatter, dropped
 		`{"type":"stage_start","stage":"intake"}`,     // kept
 		`{"type":"unknown_thing","field":"whatever"}`, // unknown type, dropped

--- a/internal/tui/detail/logview.go
+++ b/internal/tui/detail/logview.go
@@ -148,9 +148,13 @@ func (m *LogViewModel) AppendLines(rawLines []string) {
 		if err != nil {
 			continue
 		}
+		rendered := m.renderLine(rec)
+		if rendered == "" {
+			continue
+		}
 		m.lines = append(m.lines, logLine{
 			record:   rec,
-			rendered: m.renderLine(rec),
+			rendered: rendered,
 			rawJSON:  raw,
 		})
 	}
@@ -291,12 +295,20 @@ func (m LogViewModel) followIndicator() string {
 	return lipgloss.NewStyle().Foreground(tui.ColorYellow).Render("[paused]")
 }
 
-// renderLine produces a single styled line from a parsed record.
+// renderLine produces a single styled line from a parsed record. Returns the
+// empty string when the record has no human-readable content (e.g., an
+// assistant envelope that contains only tool-use plumbing); callers should
+// skip empty results rather than emit blank lines.
 func (m LogViewModel) renderLine(rec logrender.Record) string {
+	content := renderContent(rec)
+	if content == "" {
+		return ""
+	}
+
 	var b strings.Builder
 
 	// Timestamp
-	ts := rec.Timestamp.Format("15:04:05")
+	ts := rec.Timestamp.Local().Format("15:04:05")
 	b.WriteString(lipgloss.NewStyle().Foreground(tui.ColorDimWhite).Render(ts))
 	b.WriteByte(' ')
 
@@ -308,8 +320,6 @@ func (m LogViewModel) renderLine(rec logrender.Record) string {
 		b.WriteByte(' ')
 	}
 
-	// Content varies by record type
-	content := renderContent(rec)
 	b.WriteString(content)
 
 	// Apply level-based tint to the whole line
@@ -344,7 +354,11 @@ func renderContent(rec logrender.Record) string {
 			fmt.Sprintf("[%s] Error: %s", rec.Stage, rec.Error),
 		)
 	case "assistant":
-		return lipgloss.NewStyle().Foreground(tui.ColorWhite).Render(rec.Text)
+		text := extractAssistantContent(rec.Text)
+		if text == "" {
+			return ""
+		}
+		return lipgloss.NewStyle().Foreground(tui.ColorWhite).Render(text)
 	case "failure_increment":
 		return lipgloss.NewStyle().Foreground(tui.ColorYellow).Render(
 			fmt.Sprintf("[failure] %s failure #%d", nodeTask, rec.Counter),
@@ -362,11 +376,76 @@ func renderContent(rec logrender.Record) string {
 			fmt.Sprintf("[lifecycle] %s", rec.Event),
 		)
 	default:
-		rawBytes, _ := json.Marshal(rec.Raw)
+		// Unknown record type. Render a compact tag rather than dumping the
+		// raw JSON envelope, which would otherwise flood the viewport.
+		if rec.Type == "" {
+			return ""
+		}
 		return lipgloss.NewStyle().Foreground(tui.ColorDimWhite).Render(
-			fmt.Sprintf("[%s] %s", rec.Type, string(rawBytes)),
+			fmt.Sprintf("[%s]", rec.Type),
 		)
 	}
+}
+
+// extractAssistantContent pulls a one-line summary from a Claude API JSON
+// envelope embedded in an assistant record's `text` field. It joins text
+// content blocks, abbreviates thinking blocks, and tags tool_use blocks by
+// name. Plain (non-JSON) input passes through unchanged. Returns the empty
+// string only when there is genuinely nothing human-readable to show.
+func extractAssistantContent(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	var envelope struct {
+		Type    string `json:"type"`
+		Subtype string `json:"subtype"`
+		Message struct {
+			Content []struct {
+				Type     string `json:"type"`
+				Text     string `json:"text"`
+				Thinking string `json:"thinking"`
+				Name     string `json:"name"`
+			} `json:"content"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal([]byte(raw), &envelope); err != nil {
+		// Not JSON; treat as plain text and pass through (truncated).
+		return truncate(raw, 240)
+	}
+
+	// System frames (init, etc.) carry no operator-facing content.
+	if envelope.Type == "system" {
+		return ""
+	}
+
+	var parts []string
+	for _, c := range envelope.Message.Content {
+		switch c.Type {
+		case "text":
+			if c.Text != "" {
+				parts = append(parts, truncate(c.Text, 240))
+			}
+		case "thinking":
+			if c.Thinking != "" {
+				parts = append(parts, "[thinking] "+truncate(c.Thinking, 200))
+			}
+		case "tool_use":
+			if c.Name != "" {
+				parts = append(parts, "[tool: "+c.Name+"]")
+			}
+		case "tool_result":
+			parts = append(parts, "[tool result]")
+		}
+	}
+	return strings.Join(parts, " | ")
+}
+
+func truncate(s string, max int) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…"
 }
 
 func applyLevelTint(level, s string) string {
@@ -486,9 +565,13 @@ func (m *LogViewModel) LoadFromFile(path string, lastN int) error {
 		if err != nil {
 			continue
 		}
+		rendered := m.renderLine(rec)
+		if rendered == "" {
+			continue
+		}
 		m.lines = append(m.lines, logLine{
 			record:   rec,
-			rendered: m.renderLine(rec),
+			rendered: rendered,
 			rawJSON:  raw,
 		})
 	}

--- a/internal/tui/detail/logview_test.go
+++ b/internal/tui/detail/logview_test.go
@@ -471,6 +471,46 @@ func TestRenderLine_Assistant(t *testing.T) {
 	}
 }
 
+// TestRenderLine_AssistantWithClaudeEnvelope verifies that an assistant record
+// whose text field carries a Claude API JSON envelope is rendered as a
+// readable summary instead of being dumped raw into the viewport.
+func TestRenderLine_AssistantWithClaudeEnvelope(t *testing.T) {
+	t.Parallel()
+	m := NewLogViewModel()
+	envelope := `{"type":"assistant","message":{"content":[{"type":"text","text":"Reviewing the diff now"},{"type":"tool_use","name":"Read"}]}}`
+	line := makeLogJSON(map[string]any{"type": "assistant", "text": envelope})
+	m.AppendLines([]string{line})
+
+	if len(m.lines) != 1 {
+		t.Fatalf("expected 1 rendered line, got %d", len(m.lines))
+	}
+	rendered := m.lines[0].rendered
+	if !strings.Contains(rendered, "Reviewing the diff now") {
+		t.Errorf("expected text content to be extracted, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "[tool: Read]") {
+		t.Errorf("expected tool_use to be tagged, got %q", rendered)
+	}
+	if strings.Contains(rendered, `"content"`) {
+		t.Errorf("rendered line should not contain raw JSON, got %q", rendered)
+	}
+}
+
+// TestRenderLine_AssistantSystemFrameSkipped verifies that system init frames
+// (Claude Code's session bootstrap) produce no entry rather than a noisy raw
+// dump.
+func TestRenderLine_AssistantSystemFrameSkipped(t *testing.T) {
+	t.Parallel()
+	m := NewLogViewModel()
+	envelope := `{"type":"system","subtype":"init","cwd":"/tmp"}`
+	line := makeLogJSON(map[string]any{"type": "assistant", "text": envelope})
+	m.AppendLines([]string{line})
+
+	if len(m.lines) != 0 {
+		t.Errorf("expected system init frames to be skipped, got %d lines", len(m.lines))
+	}
+}
+
 func TestRenderLine_FailureIncrement(t *testing.T) {
 	t.Parallel()
 	m := NewLogViewModel()

--- a/internal/tui/detail/model_test.go
+++ b/internal/tui/detail/model_test.go
@@ -118,7 +118,10 @@ func TestUpdate_ForwardsDaemonStatusMsg(t *testing.T) {
 func TestUpdate_ForwardsLogLinesMsg(t *testing.T) {
 	t.Parallel()
 	m := NewDetailModel()
-	m, _ = m.Update(tui.LogLinesMsg{Lines: []string{"hello", "world"}})
+	m, _ = m.Update(tui.LogLinesMsg{Lines: []string{
+		`{"type":"stage_start","stage":"intake","node":"alpha"}`,
+		`{"type":"stage_complete","stage":"exec","node":"alpha","exit_code":0}`,
+	}})
 	if len(m.dashboard.recentActivity) != 2 {
 		t.Errorf("expected 2 activity entries, got %d", len(m.dashboard.recentActivity))
 	}

--- a/internal/tui/detail/nodedetail.go
+++ b/internal/tui/detail/nodedetail.go
@@ -190,7 +190,7 @@ func (m *NodeDetailModel) rebuildContent() {
 			b.WriteString(body.Render(fmt.Sprintf("  Breadcrumbs: %d", len(audit.Breadcrumbs))))
 			b.WriteByte('\n')
 			for _, bc := range audit.Breadcrumbs {
-				b.WriteString(body.Render(fmt.Sprintf("    [%s] %s: %s", bc.Timestamp.Format("15:04:05"), bc.Task, bc.Text)))
+				b.WriteString(body.Render(fmt.Sprintf("    [%s] %s: %s", bc.Timestamp.Local().Format("15:04:05"), bc.Task, bc.Text)))
 				b.WriteByte('\n')
 			}
 		}
@@ -253,14 +253,14 @@ func relativeTime(t time.Time) string {
 		return fmt.Sprintf("%dm ago", m)
 	case d < 24*time.Hour:
 		h := int(d.Hours())
-		exact := t.Format("15:04:05")
+		exact := t.Local().Format("15:04:05")
 		if h == 1 {
 			return fmt.Sprintf("1h ago (%s)", exact)
 		}
 		return fmt.Sprintf("%dh ago (%s)", h, exact)
 	default:
 		days := int(d.Hours()) / 24
-		exact := t.Format("15:04:05")
+		exact := t.Local().Format("15:04:05")
 		if days == 1 {
 			return fmt.Sprintf("1d ago (%s)", exact)
 		}

--- a/internal/tui/watcher.go
+++ b/internal/tui/watcher.go
@@ -41,6 +41,16 @@ type Watcher struct {
 	mu          sync.Mutex
 	useFsnotify bool
 
+	// subscribed tracks which leaf addresses already have an
+	// fsnotify subscription via AddNodeWatch + an initial cache
+	// load via NodeUpdatedMsg. EagerPrefetchAndSubscribe consults
+	// this set so it can be called repeatedly without re-emitting
+	// load events for already-subscribed leaves. The set is what
+	// makes the function idempotent and lets the watcher pick up
+	// leaves that the daemon adds to the index after startup
+	// (decomposition, planning passes, etc).
+	subscribed map[string]bool
+
 	// polling state
 	indexMtime    time.Time
 	instanceMtime time.Time
@@ -61,6 +71,7 @@ func NewWatcher(store *state.Store, logDir, instanceDir string, events chan<- te
 		pending:     make(map[string]bool),
 		done:        make(chan struct{}),
 		useFsnotify: true,
+		subscribed:  make(map[string]bool),
 	}
 }
 
@@ -285,6 +296,14 @@ func (w *Watcher) flush(paths map[string]bool) {
 					})
 				} else {
 					w.emit(StateUpdatedMsg{Index: idx})
+					// The index just changed. The daemon may have
+					// added new leaves via decomposition; subscribe
+					// to any that don't already have an fsnotify
+					// watch and load their initial state into the
+					// model's cache. EagerPrefetchAndSubscribe is
+					// idempotent (consults w.subscribed), so this
+					// is safe to call after every index update.
+					_ = w.EagerPrefetchAndSubscribe()
 				}
 			}
 
@@ -497,6 +516,16 @@ func (w *Watcher) AddNodeWatch(addr string) {
 // in-flight state.json is logged-and-skipped, and the next watcher
 // event will retry on its own.
 //
+// **Idempotent.** The function consults w.subscribed and skips any
+// address that already has a subscription, so it's safe to call
+// repeatedly. The flush handler invokes it after every index update
+// so leaves added by daemon decomposition (which appear in the
+// index after watcher startup) get subscribed and cached the moment
+// they show up. Without this re-call, eager prefetch would only
+// cover leaves that existed at TUI launch — newly-decomposed leaves
+// would have no fsnotify subscription and their tasks would never
+// reach the cache.
+//
 // Safe to call before or after Start/StartPolling. When called
 // before fsnotify init, the AddNodeWatch calls become no-ops and
 // only the eager-load half runs; when called after, both halves
@@ -516,15 +545,25 @@ func (w *Watcher) EagerPrefetchAndSubscribe() error {
 		if entry.Type != state.NodeLeaf {
 			continue
 		}
+		w.mu.Lock()
+		alreadySubscribed := w.subscribed[addr]
+		w.mu.Unlock()
+		if alreadySubscribed {
+			continue
+		}
 		node, err := w.store.ReadNode(addr)
 		if err != nil {
 			// Skip leaves whose state files are missing or corrupt.
 			// The next fsnotify event will retry on its own once
-			// the daemon writes a clean version.
+			// the daemon writes a clean version. Don't mark as
+			// subscribed yet so a retry happens.
 			continue
 		}
 		w.emit(NodeUpdatedMsg{Address: addr, Node: node})
 		w.AddNodeWatch(addr)
+		w.mu.Lock()
+		w.subscribed[addr] = true
+		w.mu.Unlock()
 	}
 	return nil
 }

--- a/internal/tui/watcher_test.go
+++ b/internal/tui/watcher_test.go
@@ -1111,6 +1111,7 @@ func TestEagerPrefetchAndSubscribe_PicksUpLeavesAddedAfterStartup(t *testing.T) 
 	}
 
 	betaSeen := false
+drain:
 	for i := 0; i < 4; i++ {
 		select {
 		case msg := <-events:
@@ -1130,12 +1131,10 @@ func TestEagerPrefetchAndSubscribe_PicksUpLeavesAddedAfterStartup(t *testing.T) 
 				if nu.Node == nil || len(nu.Node.Tasks) == 0 || nu.Node.Tasks[0].Title != "beta brand-new task" {
 					t.Errorf("beta event did not carry the freshly-written task content; node = %+v", nu.Node)
 				}
+				break drain
 			}
 		case <-time.After(50 * time.Millisecond):
-			break
-		}
-		if betaSeen {
-			break
+			break drain
 		}
 	}
 	if !betaSeen {

--- a/internal/tui/watcher_test.go
+++ b/internal/tui/watcher_test.go
@@ -994,6 +994,155 @@ func TestEagerPrefetchAndSubscribe_AddsFsnotifySubscriptions(t *testing.T) {
 	}
 }
 
+// TestEagerPrefetchAndSubscribe_IsIdempotent verifies that calling
+// the function repeatedly with no index changes does not re-emit
+// NodeUpdatedMsg events for already-subscribed leaves. The
+// idempotence is what makes it safe to call after every index
+// update without spamming the channel with redundant events.
+func TestEagerPrefetchAndSubscribe_IsIdempotent(t *testing.T) {
+	tmp := t.TempDir()
+	store := newPopulatedStoreForTest(t, tmp, map[string][]testTask{
+		"alpha": {{ID: "task-0001", Title: "first", State: state.StatusComplete}},
+	})
+
+	events, next := drainEvents(t)
+	w := NewWatcher(store, "", "", events)
+	if err := w.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer w.Stop()
+
+	// First call should emit one NodeUpdatedMsg.
+	if err := w.EagerPrefetchAndSubscribe(); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	first := next()
+	if env, ok := first.(WatcherMsg); !ok {
+		t.Fatalf("first call did not produce a WatcherMsg, got %T", first)
+	} else if _, ok := env.Inner.(NodeUpdatedMsg); !ok {
+		t.Fatalf("first call envelope did not contain NodeUpdatedMsg, got %T", env.Inner)
+	}
+
+	// Second call with no index changes should produce no events.
+	if err := w.EagerPrefetchAndSubscribe(); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	select {
+	case msg := <-events:
+		if env, ok := msg.(WatcherMsg); ok {
+			if _, ok := env.Inner.(NodeUpdatedMsg); ok {
+				t.Errorf("second call should be a no-op for already-subscribed leaves, but emitted a NodeUpdatedMsg")
+			}
+		}
+	case <-time.After(50 * time.Millisecond):
+		// Expected: no events.
+	}
+}
+
+// TestEagerPrefetchAndSubscribe_PicksUpLeavesAddedAfterStartup is
+// the regression test for the new-leaves-after-startup gap. The
+// daemon decomposes nodes during a session, adding new leaves to
+// the index. Without this fix, those leaves never got an fsnotify
+// subscription or an initial cache load, so their per-task glyphs
+// went stale forever even though the leaf glyph (which comes from
+// the index) updated correctly.
+//
+// This test simulates the flow:
+//  1. Watcher starts with one leaf in the index
+//  2. EagerPrefetchAndSubscribe runs, subscribes to it
+//  3. The user/daemon adds a new leaf to the index AND writes its
+//     state.json
+//  4. EagerPrefetchAndSubscribe runs again (in production this
+//     happens automatically inside the flush handler after a
+//     StateUpdatedMsg is emitted)
+//  5. The new leaf must produce a NodeUpdatedMsg
+func TestEagerPrefetchAndSubscribe_PicksUpLeavesAddedAfterStartup(t *testing.T) {
+	tmp := t.TempDir()
+	store := newPopulatedStoreForTest(t, tmp, map[string][]testTask{
+		"alpha": {{ID: "task-0001", Title: "alpha task", State: state.StatusInProgress}},
+	})
+
+	events, next := drainEvents(t)
+	w := NewWatcher(store, "", "", events)
+	if err := w.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer w.Stop()
+
+	if err := w.EagerPrefetchAndSubscribe(); err != nil {
+		t.Fatalf("initial prefetch: %v", err)
+	}
+	// Drain alpha's initial event.
+	_ = next()
+
+	// Now simulate decomposition: add a new leaf "beta" to the
+	// index and write its state.json. This is what happens when
+	// the daemon decomposes an orchestrator into new leaves.
+	if err := store.MutateIndex(func(idx *state.RootIndex) error {
+		idx.Root = append(idx.Root, "beta")
+		idx.Nodes["beta"] = state.IndexEntry{
+			Name:    "beta",
+			Type:    state.NodeLeaf,
+			State:   state.StatusInProgress,
+			Address: "beta",
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	betaPath, err := store.NodePath("beta")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(betaPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeLeafState(t, betaPath, []testTask{
+		{ID: "task-0001", Title: "beta brand-new task", State: state.StatusInProgress},
+	})
+
+	// Re-run EagerPrefetchAndSubscribe (in production this happens
+	// automatically inside the flush handler after the index
+	// update is detected). The new beta leaf should produce a
+	// NodeUpdatedMsg, while the already-subscribed alpha leaf
+	// should NOT.
+	if err := w.EagerPrefetchAndSubscribe(); err != nil {
+		t.Fatalf("re-prefetch: %v", err)
+	}
+
+	betaSeen := false
+	for i := 0; i < 4; i++ {
+		select {
+		case msg := <-events:
+			env, ok := msg.(WatcherMsg)
+			if !ok {
+				continue
+			}
+			nu, ok := env.Inner.(NodeUpdatedMsg)
+			if !ok {
+				continue
+			}
+			if nu.Address == "alpha" {
+				t.Errorf("alpha should not be re-emitted (already subscribed); idempotence check failed")
+			}
+			if nu.Address == "beta" {
+				betaSeen = true
+				if nu.Node == nil || len(nu.Node.Tasks) == 0 || nu.Node.Tasks[0].Title != "beta brand-new task" {
+					t.Errorf("beta event did not carry the freshly-written task content; node = %+v", nu.Node)
+				}
+			}
+		case <-time.After(50 * time.Millisecond):
+			break
+		}
+		if betaSeen {
+			break
+		}
+	}
+	if !betaSeen {
+		t.Error("EagerPrefetchAndSubscribe did not emit a NodeUpdatedMsg for the newly-added beta leaf; daemon decomposition will silently break per-leaf cache freshness")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Test helpers for the eager-prefetch tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **New-leaf subscriptions**: `EagerPrefetchAndSubscribe` is now idempotent and re-called after every index update. Leaves added by daemon decomposition mid-session get fsnotify watches and initial cache loads immediately, fixing stale per-task glyphs for dynamically-created leaves.
- **Log and activity rendering**: Logs extract human-readable content from Claude API JSON envelopes (text, thinking, tool tags) instead of dumping raw JSON. System init frames are skipped. Recent Activity filters to milestones only (stage transitions, failures, blocks). All displayed timestamps converted to local time.
- **Stall timeout**: Default raised from 120s to 600s. The previous value was killing Opus sessions that were thinking on large contexts, not genuinely stalled. The timeout is a catastrophic-failure backstop, not a pacing mechanism.

## Test plan

- [x] `TestEagerPrefetchAndSubscribe_IsIdempotent` - repeated calls don't re-emit
- [x] `TestEagerPrefetchAndSubscribe_PicksUpLeavesAddedAfterStartup` - new leaves get subscribed
- [x] `TestRenderLine_AssistantWithClaudeEnvelope` - JSON envelopes rendered as summaries
- [x] `TestRenderLine_AssistantSystemFrameSkipped` - init frames produce no output
- [x] `TestLogLinesMsg_SkipsNoiseAndUnparseable` - activity feed filters noise
- [x] `TestView_ActivityWithTimestamps` - local timezone rendering
- [x] Full TUI suite green, vet clean
- [x] Manual smoke: live daemon with decomposition, log view, activity feed