### PR TITLE
chore: v0.6.0 pre-release audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Wolfcastle is Ralph on steroids. It's what happens when you give an action hero 
 
 - **Language:** Go 1.26+, single module `github.com/dorkusprime/wolfcastle`
 - **Framework:** [Cobra](https://github.com/spf13/cobra) for CLI
-- **Dependencies:** Minimal: Cobra/pflag + chzyer/readline + fsnotify/fsnotify (ADR-048)
+- **Dependencies:** Cobra/pflag, Bubbletea v2 (TUI), chzyer/readline, fsnotify/fsnotify, atotto/clipboard
 - **Build:** `make build` / `go build ./...`
 - **Test:** `make test` / `go test ./...`
 - **Lint:** `make lint` (runs `go vet` + `gofmt`), `golangci-lint run` (full lint suite per ADR-049)
@@ -41,8 +41,8 @@ Entries should be concrete, durable, and non-obvious. "The config loader silentl
 
 ## Design References
 
-- [Architecture Decision Records](docs/decisions/INDEX.md) (100 ADRs) document every major design choice. Consult these before making architectural decisions.
-- [Specifications](docs/specs/) (44 specs) describe the current system in detail. Consult these before modifying behavior.
+- [Architecture Decision Records](docs/decisions/INDEX.md) (101 ADRs) document every major design choice. Consult these before making architectural decisions.
+- [Specifications](docs/specs/) (45 specs) describe the current system in detail. Consult these before modifying behavior.
 - [Full documentation hub](docs/)
 
 ## Critical Rules

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Wolfcastle turns tokens into code. It uses a lot of them. Every planning pass, e
 ## More
 
 - [63 CLI commands](docs/humans/cli.md)
-- [Architecture Decision Records](docs/decisions/INDEX.md) (97 and counting)
+- [Architecture Decision Records](docs/decisions/INDEX.md) (101 and counting)
 - [Specifications](docs/specs/)
 - [Developer guides](docs/agents/)
 - [AGENTS.md](AGENTS.md)

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -22,7 +22,9 @@ wolfcastle/
 │   ├── config/              # Config loading, merging, validation, types
 │   ├── daemon/              # Daemon loop, pipeline execution, marker parsing
 │   ├── errors/              # Typed error categories (ADR-065)
+│   ├── fsutil/              # Atomic file writes (temp + rename)
 │   ├── git/                 # Git operations behind Provider interface
+│   ├── instance/            # Multi-process instance registry and CWD routing (ADR-099, ADR-100)
 │   ├── invoke/              # Model CLI invocation (buffered + streaming)
 │   ├── knowledge/           # Per-namespace codebase knowledge files
 │   ├── logging/             # Per-iteration NDJSON logging
@@ -36,9 +38,10 @@ wolfcastle/
 │   ├── testutil/            # Shared test helpers
 │   ├── tierfs/              # Three-tier file resolution (ADR-063)
 │   ├── tree/                # Tree addressing, slug generation, resolver
+│   ├── tui/                 # Terminal UI (Bubbletea v2, ADR-048)
 │   └── validate/            # Structural validation engine and auto-fix
 ├── docs/
-│   ├── decisions/           # ADRs (001-097)
+│   ├── decisions/           # ADRs (001-101)
 │   ├── specs/               # Implementation specs (timestamped)
 │   └── agents/              # This directory (agent guidance)
 └── Makefile
@@ -96,6 +99,9 @@ Dependencies flow strictly downward. `cmd/` imports `internal/`, but `internal/`
 - `logging` → `output`
 - `invoke` → `config`
 - `tree` → `config`
+- `instance` → (standalone)
+- `fsutil` → (standalone)
+- `tui` → `config`, `output`, `state`, `tree`
 - `knowledge` → (standalone)
 - `logrender` → (standalone)
 - `selfupdate` → (standalone)

--- a/docs/agents/commands.md
+++ b/docs/agents/commands.md
@@ -114,8 +114,8 @@ Registered at root level (not grouped under a parent):
 | Subcommand | Purpose |
 |------------|---------|
 | `show` | Display configuration, optionally filtered by tier or section |
-| `set` | Set a configuration value in the local tier |
-| `unset` | Remove a configuration value from the local tier |
+| `set` | Set a configuration value (default: local tier, supports --tier custom) |
+| `unset` | Remove a configuration value (default: local tier, supports --tier custom) |
 | `append` | Append to a configuration list value |
 | `remove` | Remove an item from a configuration list |
 | `validate` | Validate the configuration files |
@@ -127,6 +127,15 @@ Registered at root level (not grouped under a parent):
 | `add` | Capture an idea or task into the inbox |
 | `list` | Review inbox items |
 | `clear` | Clear inbox items |
+
+### knowledge
+
+| Subcommand | Purpose |
+|------------|---------|
+| `add` | Add a knowledge entry to the codebase knowledge file |
+| `show` | Display codebase knowledge for the current namespace |
+| `edit` | Open the knowledge file in $EDITOR |
+| `prune` | Open the knowledge file for pruning, report token count |
 
 ### orchestrator
 

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -102,3 +102,4 @@
 | 098 | [Per-Worktree Daemon Lock](098-per-worktree-daemon-lock.md) | Accepted | 2026-04-06 |
 | 099 | [File-Per-Instance Registry](099-instance-registry.md) | Accepted | 2026-04-06 |
 | 100 | [CWD-Based Instance Routing](100-cwd-instance-routing.md) | Accepted | 2026-04-06 |
+| 101 | [Vendor All Dependencies](101-vendor-dependencies.md) | Accepted | 2026-04-06 |

--- a/docs/humans/how-it-works.md
+++ b/docs/humans/how-it-works.md
@@ -133,7 +133,7 @@ Stages do not pass output to each other. They read the current state of the worl
 
 ### Execution Protocol
 
-When the execute stage claims a task, the model follows a nine-phase protocol:
+When the execute stage claims a task, the model follows a ten-phase protocol:
 
 1. **Claim** the task.
 2. **Study** the project description, [specs](collaboration.md#specs), [breadcrumbs](audits.md#breadcrumbs), and linked context.
@@ -141,9 +141,10 @@ When the execute stage claims a task, the model follows a nine-phase protocol:
 4. **Validate** by running configured checks (tests, lints, builds).
 5. **Record** [breadcrumbs](audits.md#breadcrumbs) describing what was done and why.
 6. **Document** decisions (ADRs) and contracts (specs).
-7. **Signal** the outcome: COMPLETE, YIELD (needs another iteration), or BLOCKED.
-8. **Pre-block** downstream tasks that cannot succeed, when applicable.
-9. **Create follow-up tasks** based on findings, when applicable.
+7. **Capture** codebase knowledge files for future context.
+8. **Signal** the outcome: COMPLETE, YIELD (needs another iteration), or BLOCKED.
+9. **Pre-block** downstream tasks that cannot succeed, when applicable.
+10. **Create follow-up tasks** based on findings, when applicable.
 
 The model communicates through [script calls](cli.md): `wolfcastle task claim`, `wolfcastle audit breadcrumb`, `wolfcastle task complete`. Every side effect goes through a deterministic command that validates inputs and enforces invariants. The model cannot corrupt the tree. It can only ask the scripts to make valid changes.
 

--- a/internal/daemon/audit_terminal_block_test.go
+++ b/internal/daemon/audit_terminal_block_test.go
@@ -1,0 +1,103 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/dorkusprime/wolfcastle/internal/state"
+)
+
+func TestIsTerminalBlock_BlockedWithSuperseded(t *testing.T) {
+	t.Parallel()
+	task := state.Task{State: state.StatusBlocked, BlockedReason: "Superseded by newer approach"}
+	if !isTerminalBlock(task) {
+		t.Error("expected true for 'superseded' reason")
+	}
+}
+
+func TestIsTerminalBlock_BlockedWithAlreadyDone(t *testing.T) {
+	t.Parallel()
+	task := state.Task{State: state.StatusBlocked, BlockedReason: "Already done in previous iteration"}
+	if !isTerminalBlock(task) {
+		t.Error("expected true for 'already done' reason")
+	}
+}
+
+func TestIsTerminalBlock_BlockedWithAlreadyCompleted(t *testing.T) {
+	t.Parallel()
+	task := state.Task{State: state.StatusBlocked, BlockedReason: "This was already completed by task-0003"}
+	if !isTerminalBlock(task) {
+		t.Error("expected true for 'already completed' reason")
+	}
+}
+
+func TestIsTerminalBlock_BlockedWithNoLongerNeeded(t *testing.T) {
+	t.Parallel()
+	task := state.Task{State: state.StatusBlocked, BlockedReason: "No longer needed after refactor"}
+	if !isTerminalBlock(task) {
+		t.Error("expected true for 'no longer needed' reason")
+	}
+}
+
+func TestIsTerminalBlock_BlockedWithReplacedBy(t *testing.T) {
+	t.Parallel()
+	task := state.Task{State: state.StatusBlocked, BlockedReason: "Replaced by task-0005"}
+	if !isTerminalBlock(task) {
+		t.Error("expected true for 'replaced by' reason")
+	}
+}
+
+func TestIsTerminalBlock_BlockedWithDoneIn(t *testing.T) {
+	t.Parallel()
+	task := state.Task{State: state.StatusBlocked, BlockedReason: "Done in parent node"}
+	if !isTerminalBlock(task) {
+		t.Error("expected true for 'done in' reason")
+	}
+}
+
+func TestIsTerminalBlock_BlockedWithDoneDirectly(t *testing.T) {
+	t.Parallel()
+	task := state.Task{State: state.StatusBlocked, BlockedReason: "Done directly by orchestrator"}
+	if !isTerminalBlock(task) {
+		t.Error("expected true for 'done directly' reason")
+	}
+}
+
+func TestIsTerminalBlock_BlockedWithDecomposedInto(t *testing.T) {
+	t.Parallel()
+	task := state.Task{State: state.StatusBlocked, BlockedReason: "Decomposed into subtasks"}
+	if !isTerminalBlock(task) {
+		t.Error("expected true for 'decomposed into' reason")
+	}
+}
+
+func TestIsTerminalBlock_BlockedWithDecomposition(t *testing.T) {
+	t.Parallel()
+	task := state.Task{State: state.StatusBlocked, BlockedReason: "Blocked due to decomposition of parent"}
+	if !isTerminalBlock(task) {
+		t.Error("expected true for 'decomposition' reason")
+	}
+}
+
+func TestIsTerminalBlock_NotBlocked(t *testing.T) {
+	t.Parallel()
+	task := state.Task{State: state.StatusInProgress, BlockedReason: "superseded"}
+	if isTerminalBlock(task) {
+		t.Error("expected false when state is not blocked")
+	}
+}
+
+func TestIsTerminalBlock_BlockedGenericReason(t *testing.T) {
+	t.Parallel()
+	task := state.Task{State: state.StatusBlocked, BlockedReason: "Waiting for API key"}
+	if isTerminalBlock(task) {
+		t.Error("expected false for a genuine blocking reason")
+	}
+}
+
+func TestIsTerminalBlock_BlockedEmptyReason(t *testing.T) {
+	t.Parallel()
+	task := state.Task{State: state.StatusBlocked, BlockedReason: ""}
+	if isTerminalBlock(task) {
+		t.Error("expected false for empty reason")
+	}
+}

--- a/internal/tui/app/app.go
+++ b/internal/tui/app/app.go
@@ -90,7 +90,8 @@ type TUIModel struct {
 	entryState  EntryState
 	store       *state.Store
 	daemonRepo  *daemon.DaemonRepository
-	worktreeDir string
+	worktreeDir string // tracks the currently-viewed instance's worktree
+	originalCWD string // the directory the TUI was launched from; never mutated
 	version     string
 
 	watcher       *tui.Watcher
@@ -123,6 +124,7 @@ func NewTUIModel(store *state.Store, daemonRepo *daemon.DaemonRepository, worktr
 		store:       store,
 		daemonRepo:  daemonRepo,
 		worktreeDir: worktreeDir,
+		originalCWD: worktreeDir,
 		version:     version,
 		// 256 is enough headroom that a brief render stall (the model
 		// taking a few ms to drain) does not cause the watcher to drop
@@ -251,6 +253,10 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, tui.GlobalKeyMap.Quit):
 			return m, tea.Quit
 
+		case key.Matches(msg, tui.GlobalKeyMap.Dashboard):
+			m.detail.SwitchToDashboard()
+			return m, nil
+
 		case key.Matches(msg, tui.GlobalKeyMap.LogStream):
 			m.activeModal = ModalLog
 			return m, nil
@@ -301,8 +307,9 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				action = "stop"
 			}
 			var pid int
-			var branch, worktree string
+			var branch string
 			var isDraining bool
+			worktree := m.worktreeDir
 			if len(m.instances) > 0 && m.activeInstanceIndex < len(m.instances) {
 				inst := m.instances[m.activeInstanceIndex]
 				pid = inst.PID
@@ -408,6 +415,14 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Data messages: always broadcast regardless of overlay state
 	// ---------------------------------------------------------------
 	case tui.StateUpdatedMsg:
+		// Discard stale reads from in-flight commands that were
+		// dispatched before an instance switch or daemon stop.
+		// Watcher events have empty Worktree and are always current
+		// (the watcher gets replaced on switch).
+		if msg.Worktree != "" && msg.Worktree != m.worktreeDir {
+			return m, nil
+		}
+
 		m.header.SetLoading(false)
 		h, hcmd := m.header.Update(header.StateUpdatedMsg{Index: msg.Index})
 		m.header = h
@@ -434,10 +449,10 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(cmds...)
 
 	case tui.DaemonStatusMsg:
-		// Update instance list on the TUI model.
 		if msg.Instances != nil {
-			m.instances = msg.Instances
-			m.header.SetInstances(m.instances, m.activeInstanceIndex)
+			if cmd := m.reconcileActiveInstance(msg.Instances); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
 		}
 
 		h, hcmd := m.header.Update(header.DaemonStatusMsg{
@@ -465,6 +480,7 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.entryState = StateCold
 		}
+
 		return m, tea.Batch(cmds...)
 
 	case tui.NodeUpdatedMsg:
@@ -518,13 +534,14 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tui.InstancesUpdatedMsg:
-		m.instances = msg.Instances
+		if cmd := m.reconcileActiveInstance(msg.Instances); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 		h, hcmd := m.header.Update(header.InstancesUpdatedMsg{
 			Instances: msg.Instances,
 		})
 		m.header = h
 		cmds = append(cmds, hcmd)
-		m.header.SetInstances(msg.Instances, m.activeInstanceIndex)
 		return m, tea.Batch(cmds...)
 
 	case tui.DaemonConfirmedMsg:
@@ -574,7 +591,27 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.daemonStopping = false
 		m.entryState = StateCold
 		m.header.SetStatusHint("")
-		return m, m.handleRefresh()
+
+		m.worktreeDir = m.originalCWD
+		wolfDir := filepath.Join(m.originalCWD, ".wolfcastle")
+		m.store = storeFromWolfcastleDir(wolfDir)
+		m.daemonRepo = daemon.NewDaemonRepository(wolfDir)
+
+
+		m.tree.Reset()
+		m.detail.Reset()
+		m.detail.SwitchToDashboard()
+		m.prevIndex = nil
+		m.prevNodes = make(map[string]*state.NodeState)
+		m.instances = nil
+		m.activeInstanceIndex = 0
+		m.header.SetInstances(nil, 0)
+
+		m.stopAndDrainWatcher()
+		m.watcher = newWatcherFor(m.store, m.daemonRepo, m.watcherEvents)
+
+		refreshCmd := m.handleRefresh()
+		return m, refreshCmd
 
 	case tui.DaemonStopFailedMsg:
 		m.daemonStopping = false
@@ -623,9 +660,7 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// you inline tui.NewWatcher here you'll silently break the
 		// per-leaf cache freshness because no AddNodeWatch calls
 		// will be made for the new instance's leaves.
-		if m.watcher != nil {
-			m.watcher.Stop()
-		}
+		m.stopAndDrainWatcher()
 		m.watcher = newWatcherFor(m.store, m.daemonRepo, m.watcherEvents)
 
 		// Immediately probe daemon status and inbox so the dashboard
@@ -1175,6 +1210,7 @@ func (m TUIModel) handleRefresh() tea.Cmd {
 
 	if m.store != nil {
 		store := m.store
+		worktree := m.worktreeDir
 		cmds = append(cmds, func() tea.Msg {
 			idx, err := store.ReadIndex()
 			if err != nil {
@@ -1183,7 +1219,7 @@ func (m TUIModel) handleRefresh() tea.Cmd {
 					Message:  "State corruption detected: state.json. Run wolfcastle doctor.",
 				}
 			}
-			return tui.StateUpdatedMsg{Index: idx}
+			return tui.StateUpdatedMsg{Index: idx, Worktree: worktree}
 		})
 	}
 
@@ -1470,6 +1506,26 @@ func (m *TUIModel) startWatcher() tea.Cmd {
 // any user who switched instances during a session. Routing through
 // this helper makes that class of bug structurally impossible: if
 // you forget to call newWatcherFor, you don't get a watcher at all.
+// stopAndDrainWatcher stops the current watcher and drains any stale
+// messages from the events channel. Call this BEFORE constructing the
+// new watcher so the drain doesn't eat the new watcher's eager-prefetch
+// events.
+func (m *TUIModel) stopAndDrainWatcher() {
+	if m.watcher != nil {
+		m.watcher.Stop()
+		m.watcher = nil
+	}
+	// Drain stale messages. The channel is buffered (256), so this is
+	// bounded and non-blocking once the buffer empties.
+	for {
+		select {
+		case <-m.watcherEvents:
+		default:
+			return
+		}
+	}
+}
+
 func newWatcherFor(store *state.Store, repo *daemon.DaemonRepository, events chan tea.Msg) *tui.Watcher {
 	if store == nil {
 		return nil
@@ -1505,6 +1561,7 @@ func (m TUIModel) schedulePollTick() tea.Cmd {
 // TUI in sync with daemon activity.
 func (m TUIModel) pollState() tea.Cmd {
 	store := m.store
+	worktree := m.worktreeDir
 	return func() tea.Msg {
 		if store == nil {
 			return nil
@@ -1513,12 +1570,13 @@ func (m TUIModel) pollState() tea.Cmd {
 		if err != nil {
 			return nil // silent on poll errors; next tick will retry
 		}
-		return tui.StateUpdatedMsg{Index: idx}
+		return tui.StateUpdatedMsg{Index: idx, Worktree: worktree}
 	}
 }
 
 func (m TUIModel) loadInitialState() tea.Cmd {
 	store := m.store
+	worktree := m.worktreeDir
 	return func() tea.Msg {
 		if store == nil {
 			return nil
@@ -1530,7 +1588,7 @@ func (m TUIModel) loadInitialState() tea.Cmd {
 				Message:  "State corruption detected: state.json. Run wolfcastle doctor.",
 			}
 		}
-		return tui.StateUpdatedMsg{Index: idx}
+		return tui.StateUpdatedMsg{Index: idx, Worktree: worktree}
 	}
 }
 

--- a/internal/tui/app/app.go
+++ b/internal/tui/app/app.go
@@ -597,7 +597,6 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.store = storeFromWolfcastleDir(wolfDir)
 		m.daemonRepo = daemon.NewDaemonRepository(wolfDir)
 
-
 		m.tree.Reset()
 		m.detail.Reset()
 		m.detail.SwitchToDashboard()

--- a/internal/tui/app/app_test.go
+++ b/internal/tui/app/app_test.go
@@ -1764,6 +1764,73 @@ func TestPropagateSize_TreeHidden(t *testing.T) {
 	m.propagateSize()
 }
 
+func TestStateUpdatedMsg_DiscardsStale(t *testing.T) {
+	m := newColdModel(t)
+	m.worktreeDir = "/current"
+
+	idx := &state.RootIndex{
+		Root:  []string{"stale"},
+		Nodes: map[string]state.IndexEntry{
+			"stale": {Name: "stale", Type: state.NodeLeaf, State: state.StatusComplete, Address: "stale"},
+		},
+	}
+	result, _ := m.Update(tui.StateUpdatedMsg{Index: idx, Worktree: "/old-instance"})
+	model := toModel(t, result)
+	if model.tree.Index() != nil && len(model.tree.Index().Nodes) > 0 {
+		t.Error("stale StateUpdatedMsg should have been discarded")
+	}
+}
+
+func TestStateUpdatedMsg_AcceptsMatchingWorktree(t *testing.T) {
+	m := newColdModel(t)
+	m.worktreeDir = "/current"
+
+	idx := &state.RootIndex{
+		Root:  []string{"fresh"},
+		Nodes: map[string]state.IndexEntry{
+			"fresh": {Name: "fresh", Type: state.NodeLeaf, State: state.StatusComplete, Address: "fresh"},
+		},
+	}
+	result, _ := m.Update(tui.StateUpdatedMsg{Index: idx, Worktree: "/current"})
+	model := toModel(t, result)
+	if model.tree.Index() == nil || len(model.tree.Index().Nodes) == 0 {
+		t.Error("matching StateUpdatedMsg should have been accepted")
+	}
+}
+
+func TestStateUpdatedMsg_AcceptsEmptyWorktree(t *testing.T) {
+	m := newColdModel(t)
+
+	idx := &state.RootIndex{
+		Root:  []string{"watcher"},
+		Nodes: map[string]state.IndexEntry{
+			"watcher": {Name: "watcher", Type: state.NodeLeaf, State: state.StatusComplete, Address: "watcher"},
+		},
+	}
+	result, _ := m.Update(tui.StateUpdatedMsg{Index: idx, Worktree: ""})
+	model := toModel(t, result)
+	if model.tree.Index() == nil || len(model.tree.Index().Nodes) == 0 {
+		t.Error("empty-worktree StateUpdatedMsg (from watcher) should have been accepted")
+	}
+}
+
+func TestStopAndDrainWatcher(t *testing.T) {
+	m := newColdModel(t)
+	m.watcherEvents <- tui.WatcherMsg{Inner: tui.StateUpdatedMsg{}}
+	m.watcherEvents <- tui.WatcherMsg{Inner: tui.StateUpdatedMsg{}}
+
+	m.stopAndDrainWatcher()
+
+	select {
+	case <-m.watcherEvents:
+		t.Error("channel should be empty after drain")
+	default:
+	}
+	if m.watcher != nil {
+		t.Error("watcher should be nil after stop")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Coverage: Update() routing paths
 // ---------------------------------------------------------------------------

--- a/internal/tui/app/app_test.go
+++ b/internal/tui/app/app_test.go
@@ -1769,7 +1769,7 @@ func TestStateUpdatedMsg_DiscardsStale(t *testing.T) {
 	m.worktreeDir = "/current"
 
 	idx := &state.RootIndex{
-		Root:  []string{"stale"},
+		Root: []string{"stale"},
 		Nodes: map[string]state.IndexEntry{
 			"stale": {Name: "stale", Type: state.NodeLeaf, State: state.StatusComplete, Address: "stale"},
 		},
@@ -1786,7 +1786,7 @@ func TestStateUpdatedMsg_AcceptsMatchingWorktree(t *testing.T) {
 	m.worktreeDir = "/current"
 
 	idx := &state.RootIndex{
-		Root:  []string{"fresh"},
+		Root: []string{"fresh"},
 		Nodes: map[string]state.IndexEntry{
 			"fresh": {Name: "fresh", Type: state.NodeLeaf, State: state.StatusComplete, Address: "fresh"},
 		},
@@ -1802,7 +1802,7 @@ func TestStateUpdatedMsg_AcceptsEmptyWorktree(t *testing.T) {
 	m := newColdModel(t)
 
 	idx := &state.RootIndex{
-		Root:  []string{"watcher"},
+		Root: []string{"watcher"},
 		Nodes: map[string]state.IndexEntry{
 			"watcher": {Name: "watcher", Type: state.NodeLeaf, State: state.StatusComplete, Address: "watcher"},
 		},

--- a/internal/tui/app/instance_reconcile.go
+++ b/internal/tui/app/instance_reconcile.go
@@ -1,0 +1,97 @@
+package app
+
+import (
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/dorkusprime/wolfcastle/internal/daemon"
+	"github.com/dorkusprime/wolfcastle/internal/instance"
+	"github.com/dorkusprime/wolfcastle/internal/state"
+)
+
+// reconcileActiveInstance is the single reconciliation point for all
+// instance-list changes. Every event that modifies m.instances (daemon
+// status discovery, registry watcher updates, daemon start/stop) calls
+// this method instead of doing its own ad-hoc index bookkeeping.
+//
+// It handles three cases:
+//
+//  1. The previously-active instance still exists in the new list but
+//     may have moved to a different index (reordering). Update the
+//     index, no switch needed.
+//
+//  2. The previously-active instance disappeared (stopped, stale entry
+//     pruned). Pick the best replacement: CWD match first, then first
+//     available. Trigger switchInstance to load data.
+//
+//  3. This is the first time we see instances (cold start). Same as
+//     case 2.
+//
+// Returns any tea.Cmd that needs to be batched into the caller's
+// response (typically a switchInstance command, or nil).
+func (m *TUIModel) reconcileActiveInstance(newInstances []instance.Entry) tea.Cmd {
+	// Snapshot what we were looking at.
+	var prevPID int
+	var prevWorktree string
+	if m.activeInstanceIndex < len(m.instances) {
+		prev := m.instances[m.activeInstanceIndex]
+		prevPID = prev.PID
+		prevWorktree = prev.Worktree
+	}
+
+	m.instances = newInstances
+
+	if len(newInstances) == 0 {
+		// All instances gone. Reset to CWD context so the tree shows
+		// the local project rather than stale data from a dead process.
+		// This covers both explicit stops (DaemonStoppedMsg) and
+		// external kills detected by the poll tick.
+		if m.worktreeDir != m.originalCWD {
+			m.worktreeDir = m.originalCWD
+			wolfDir := m.originalCWD + "/.wolfcastle"
+			m.store = storeFromWolfcastleDir(wolfDir)
+			m.daemonRepo = daemon.NewDaemonRepository(wolfDir)
+
+			m.tree.Reset()
+			m.detail.Reset()
+			m.detail.SwitchToDashboard()
+			m.prevIndex = nil
+			m.prevNodes = make(map[string]*state.NodeState)
+
+			m.stopAndDrainWatcher()
+			m.watcher = newWatcherFor(m.store, m.daemonRepo, m.watcherEvents)
+		}
+		m.activeInstanceIndex = 0
+		m.entryState = StateCold
+		m.header.SetInstances(m.instances, 0)
+		return m.handleRefresh()
+	}
+	m.header.SetInstances(m.instances, m.activeInstanceIndex)
+
+	// Case 1: re-locate the active instance by PID+worktree.
+	for i, inst := range newInstances {
+		if inst.PID == prevPID && inst.Worktree == prevWorktree {
+			m.activeInstanceIndex = i
+			m.header.SetInstances(m.instances, m.activeInstanceIndex)
+			return nil
+		}
+	}
+
+	// Case 2/3: active instance gone or first discovery. Pick the best
+	// replacement and switch to it. Use originalCWD for matching since
+	// worktreeDir gets mutated by switchInstance.
+	target := 0
+	for i, inst := range newInstances {
+		if inst.Worktree == m.originalCWD {
+			target = i
+			break
+		}
+	}
+
+	m.activeInstanceIndex = target
+	m.header.SetInstances(m.instances, m.activeInstanceIndex)
+
+	if m.switching {
+		return nil
+	}
+	return m.switchInstance(newInstances[target])
+}

--- a/internal/tui/app/instance_reconcile_test.go
+++ b/internal/tui/app/instance_reconcile_test.go
@@ -1,0 +1,140 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/dorkusprime/wolfcastle/internal/instance"
+)
+
+func TestReconcile_RelocatesAfterReorder(t *testing.T) {
+	m := newColdModel(t)
+	m.instances = []instance.Entry{
+		{PID: 1, Worktree: "/a", Branch: "a"},
+		{PID: 2, Worktree: "/b", Branch: "b"},
+	}
+	m.activeInstanceIndex = 1 // watching /b
+
+	// New list has them swapped.
+	cmd := m.reconcileActiveInstance([]instance.Entry{
+		{PID: 2, Worktree: "/b", Branch: "b"},
+		{PID: 1, Worktree: "/a", Branch: "a"},
+	})
+	if cmd != nil {
+		t.Error("reorder should not trigger a switch")
+	}
+	if m.activeInstanceIndex != 0 {
+		t.Errorf("expected active index 0 after reorder, got %d", m.activeInstanceIndex)
+	}
+}
+
+func TestReconcile_ActiveDisappeared_FallsToCWD(t *testing.T) {
+	m := newColdModel(t)
+	m.originalCWD = "/cwd"
+	m.instances = []instance.Entry{
+		{PID: 1, Worktree: "/other", Branch: "other"},
+	}
+	m.activeInstanceIndex = 0
+
+	// The old instance is gone, a new one matching CWD appeared.
+	cmd := m.reconcileActiveInstance([]instance.Entry{
+		{PID: 99, Worktree: "/somewhere", Branch: "x"},
+		{PID: 100, Worktree: "/cwd", Branch: "main"},
+	})
+	if cmd == nil {
+		t.Error("should trigger switchInstance when active disappeared")
+	}
+	if m.activeInstanceIndex != 1 {
+		t.Errorf("expected CWD match at index 1, got %d", m.activeInstanceIndex)
+	}
+}
+
+func TestReconcile_ActiveDisappeared_FallsToFirst(t *testing.T) {
+	m := newColdModel(t)
+	m.worktreeDir = "/cwd-no-match"
+	m.instances = []instance.Entry{
+		{PID: 1, Worktree: "/old", Branch: "old"},
+	}
+	m.activeInstanceIndex = 0
+
+	cmd := m.reconcileActiveInstance([]instance.Entry{
+		{PID: 50, Worktree: "/alpha", Branch: "alpha"},
+		{PID: 51, Worktree: "/beta", Branch: "beta"},
+	})
+	if cmd == nil {
+		t.Error("should trigger switchInstance")
+	}
+	if m.activeInstanceIndex != 0 {
+		t.Errorf("expected fallback to index 0, got %d", m.activeInstanceIndex)
+	}
+}
+
+func TestReconcile_FirstDiscovery(t *testing.T) {
+	m := newColdModel(t)
+	// No previous instances.
+	m.instances = nil
+	m.activeInstanceIndex = 0
+
+	cmd := m.reconcileActiveInstance([]instance.Entry{
+		{PID: 10, Worktree: "/new", Branch: "feat"},
+	})
+	if cmd == nil {
+		t.Error("first discovery should trigger switchInstance")
+	}
+	if m.activeInstanceIndex != 0 {
+		t.Errorf("expected index 0, got %d", m.activeInstanceIndex)
+	}
+}
+
+func TestReconcile_EmptyList_ResetsToOriginalCWD(t *testing.T) {
+	m := newColdModel(t)
+	m.originalCWD = m.worktreeDir
+	m.instances = []instance.Entry{
+		{PID: 1, Worktree: "/a", Branch: "a"},
+	}
+	m.worktreeDir = "/a" // simulates being switched to instance /a
+	m.activeInstanceIndex = 0
+
+	cmd := m.reconcileActiveInstance(nil)
+	// Should return a handleRefresh cmd to reload CWD data.
+	if cmd == nil {
+		t.Error("empty list should trigger a CWD refresh")
+	}
+	if m.worktreeDir != m.originalCWD {
+		t.Errorf("expected worktreeDir reset to %s, got %s", m.originalCWD, m.worktreeDir)
+	}
+	if m.entryState != StateCold {
+		t.Error("expected StateCold after all instances gone")
+	}
+}
+
+func TestReconcile_EmptyList_AlreadyAtCWD(t *testing.T) {
+	m := newColdModel(t)
+	m.originalCWD = m.worktreeDir
+	// worktreeDir already matches originalCWD; the reset block should be skipped
+	// but handleRefresh should still run.
+	m.instances = []instance.Entry{
+		{PID: 1, Worktree: m.worktreeDir, Branch: "main"},
+	}
+	m.activeInstanceIndex = 0
+
+	cmd := m.reconcileActiveInstance(nil)
+	if cmd == nil {
+		t.Error("should return handleRefresh even when already at CWD")
+	}
+	if m.entryState != StateCold {
+		t.Error("expected StateCold")
+	}
+}
+
+func TestReconcile_SkipsDuringSwitching(t *testing.T) {
+	m := newColdModel(t)
+	m.switching = true
+	m.instances = nil
+
+	cmd := m.reconcileActiveInstance([]instance.Entry{
+		{PID: 1, Worktree: "/a", Branch: "a"},
+	})
+	if cmd != nil {
+		t.Error("should not trigger switch while already switching")
+	}
+}

--- a/internal/tui/app/modal.go
+++ b/internal/tui/app/modal.go
@@ -131,6 +131,11 @@ func (m TUIModel) renderInboxModal(contentHeight int) string {
 	inbox.SetFocused(true)
 
 	content := inbox.View()
+
+	// Add dismiss hint below the inbox content.
+	hint := strings.Repeat(" ", 2) + tui.ModalDimStyle.Render("[Esc] Close")
+	content += "\n" + hint
+
 	box := tui.ModalOverlayStyle.
 		Width(overlayW).
 		Height(overlayH).

--- a/internal/tui/clipboard/osc52.go
+++ b/internal/tui/clipboard/osc52.go
@@ -1,3 +1,5 @@
+// Package clipboard provides clipboard copy via OSC 52 escape sequences
+// with a system-clipboard fallback.
 package clipboard
 
 import (

--- a/internal/tui/detail/coverage_gaps_test.go
+++ b/internal/tui/detail/coverage_gaps_test.go
@@ -1,0 +1,526 @@
+package detail
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dorkusprime/wolfcastle/internal/logrender"
+	"github.com/dorkusprime/wolfcastle/internal/state"
+	"github.com/dorkusprime/wolfcastle/internal/tui"
+)
+
+// ---------------------------------------------------------------------------
+// summarizeForActivity
+// ---------------------------------------------------------------------------
+
+func TestSummarizeForActivity_StageStart_NoNodeTask(t *testing.T) {
+	t.Parallel()
+	rec := logrender.Record{Type: "stage_start", Stage: "intake"}
+	got := summarizeForActivity(rec)
+	if got != "▶ intake" {
+		t.Errorf("expected '▶ intake', got %q", got)
+	}
+}
+
+func TestSummarizeForActivity_StageStart_WithNodeTask(t *testing.T) {
+	t.Parallel()
+	rec := logrender.Record{Type: "stage_start", Stage: "exec", Node: "alpha", Task: "t-001"}
+	got := summarizeForActivity(rec)
+	if got != "▶ exec alpha/t-001" {
+		t.Errorf("expected '▶ exec alpha/t-001', got %q", got)
+	}
+}
+
+func TestSummarizeForActivity_StageComplete_NoNodeTask(t *testing.T) {
+	t.Parallel()
+	exit := 0
+	rec := logrender.Record{Type: "stage_complete", Stage: "plan", ExitCode: &exit}
+	got := summarizeForActivity(rec)
+	if got != "✓ plan (exit=0)" {
+		t.Errorf("expected '✓ plan (exit=0)', got %q", got)
+	}
+}
+
+func TestSummarizeForActivity_StageComplete_WithNodeTask(t *testing.T) {
+	t.Parallel()
+	exit := 1
+	rec := logrender.Record{Type: "stage_complete", Stage: "exec", Node: "beta", Task: "t-002", ExitCode: &exit}
+	got := summarizeForActivity(rec)
+	if got != "✓ exec beta/t-002 (exit=1)" {
+		t.Errorf("expected '✓ exec beta/t-002 (exit=1)', got %q", got)
+	}
+}
+
+func TestSummarizeForActivity_StageComplete_NilExitCode(t *testing.T) {
+	t.Parallel()
+	rec := logrender.Record{Type: "stage_complete", Stage: "plan"}
+	got := summarizeForActivity(rec)
+	if got != "✓ plan" {
+		t.Errorf("expected '✓ plan', got %q", got)
+	}
+}
+
+func TestSummarizeForActivity_StageError(t *testing.T) {
+	t.Parallel()
+	rec := logrender.Record{Type: "stage_error", Stage: "exec", Node: "gamma", Task: "t-003", Error: "timeout"}
+	got := summarizeForActivity(rec)
+	if got != "✗ exec gamma/t-003: timeout" {
+		t.Errorf("expected '✗ exec gamma/t-003: timeout', got %q", got)
+	}
+}
+
+func TestSummarizeForActivity_FailureIncrement(t *testing.T) {
+	t.Parallel()
+	rec := logrender.Record{Type: "failure_increment", Node: "delta", Task: "t-004", Counter: 3}
+	got := summarizeForActivity(rec)
+	if got != "⚠ delta/t-004 failure #3" {
+		t.Errorf("expected '⚠ delta/t-004 failure #3', got %q", got)
+	}
+}
+
+func TestSummarizeForActivity_AutoBlock(t *testing.T) {
+	t.Parallel()
+	rec := logrender.Record{Type: "auto_block", Node: "epsilon", Task: "t-005", Reason: "too many failures"}
+	got := summarizeForActivity(rec)
+	if got != "⛔ blocked epsilon/t-005: too many failures" {
+		t.Errorf("expected auto_block summary, got %q", got)
+	}
+}
+
+func TestSummarizeForActivity_DaemonStart(t *testing.T) {
+	t.Parallel()
+	rec := logrender.Record{Type: "daemon_start"}
+	got := summarizeForActivity(rec)
+	if got != "Daemon started" {
+		t.Errorf("expected 'Daemon started', got %q", got)
+	}
+}
+
+func TestSummarizeForActivity_DaemonLifecycle_WithEvent(t *testing.T) {
+	t.Parallel()
+	rec := logrender.Record{Type: "daemon_lifecycle", Event: "shutdown"}
+	got := summarizeForActivity(rec)
+	if got != "[lifecycle] shutdown" {
+		t.Errorf("expected '[lifecycle] shutdown', got %q", got)
+	}
+}
+
+func TestSummarizeForActivity_DaemonLifecycle_EmptyEvent(t *testing.T) {
+	t.Parallel()
+	rec := logrender.Record{Type: "daemon_lifecycle", Event: ""}
+	got := summarizeForActivity(rec)
+	if got != "" {
+		t.Errorf("expected empty string for empty lifecycle event, got %q", got)
+	}
+}
+
+func TestSummarizeForActivity_Unknown(t *testing.T) {
+	t.Parallel()
+	rec := logrender.Record{Type: "unknown_thing"}
+	got := summarizeForActivity(rec)
+	if got != "" {
+		t.Errorf("expected empty string for unknown type, got %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// renderStatusBlock: lastActivity and currentNode paths
+// ---------------------------------------------------------------------------
+
+func TestView_StatusBlock_WithLastActivity(t *testing.T) {
+	t.Parallel()
+	m := NewDashboardModel()
+	m.nodeCounts[state.StatusInProgress] = 1
+	m.totalNodes = 1
+	m.daemonStatus = "on patrol"
+	m.lastActivity = time.Now().Add(-2 * time.Minute)
+	v := m.View()
+	if !strings.Contains(v, "Last activity:") {
+		t.Errorf("expected Last activity line, got: %s", v)
+	}
+}
+
+func TestView_StatusBlock_WithCurrentNode(t *testing.T) {
+	t.Parallel()
+	m := NewDashboardModel()
+	m.nodeCounts[state.StatusInProgress] = 1
+	m.totalNodes = 1
+	m.currentNode = "auth"
+	v := m.View()
+	if !strings.Contains(v, "Current: auth") {
+		t.Errorf("expected 'Current: auth', got: %s", v)
+	}
+}
+
+func TestView_StatusBlock_WithCurrentNodeAndTask(t *testing.T) {
+	t.Parallel()
+	m := NewDashboardModel()
+	m.nodeCounts[state.StatusInProgress] = 1
+	m.totalNodes = 1
+	m.currentNode = "auth"
+	m.currentTask = "task-0001"
+	v := m.View()
+	if !strings.Contains(v, "Current: auth/task-0001") {
+		t.Errorf("expected 'Current: auth/task-0001', got: %s", v)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// renderInboxSummary
+// ---------------------------------------------------------------------------
+
+func TestView_InboxSummary_CountsCorrectly(t *testing.T) {
+	t.Parallel()
+	m := NewDashboardModel()
+	m.nodeCounts[state.StatusInProgress] = 1
+	m.totalNodes = 1
+	m.inboxItems = []state.InboxItem{
+		{Status: state.InboxNew},
+		{Status: state.InboxNew},
+		{Status: state.InboxFiled},
+		{Status: state.InboxNew},
+	}
+	v := m.View()
+	if !strings.Contains(v, "3 new, 1 filed") {
+		t.Errorf("expected '3 new, 1 filed', got: %s", v)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// extractAssistantContent
+// ---------------------------------------------------------------------------
+
+func TestExtractAssistantContent_PlainText(t *testing.T) {
+	t.Parallel()
+	got := extractAssistantContent("hello world")
+	if got != "hello world" {
+		t.Errorf("expected 'hello world', got %q", got)
+	}
+}
+
+func TestExtractAssistantContent_Empty(t *testing.T) {
+	t.Parallel()
+	got := extractAssistantContent("")
+	if got != "" {
+		t.Errorf("expected empty string, got %q", got)
+	}
+}
+
+func TestExtractAssistantContent_SystemFrame(t *testing.T) {
+	t.Parallel()
+	got := extractAssistantContent(`{"type":"system","subtype":"init","cwd":"/tmp"}`)
+	if got != "" {
+		t.Errorf("expected empty string for system frame, got %q", got)
+	}
+}
+
+func TestExtractAssistantContent_TextBlock(t *testing.T) {
+	t.Parallel()
+	got := extractAssistantContent(`{"type":"assistant","message":{"content":[{"type":"text","text":"Reviewing the code"}]}}`)
+	if got != "Reviewing the code" {
+		t.Errorf("expected 'Reviewing the code', got %q", got)
+	}
+}
+
+func TestExtractAssistantContent_ThinkingBlock(t *testing.T) {
+	t.Parallel()
+	got := extractAssistantContent(`{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"Let me consider this"}]}}`)
+	if !strings.Contains(got, "[thinking]") || !strings.Contains(got, "Let me consider this") {
+		t.Errorf("expected thinking block content, got %q", got)
+	}
+}
+
+func TestExtractAssistantContent_ToolUseBlock(t *testing.T) {
+	t.Parallel()
+	got := extractAssistantContent(`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read"}]}}`)
+	if got != "[tool: Read]" {
+		t.Errorf("expected '[tool: Read]', got %q", got)
+	}
+}
+
+func TestExtractAssistantContent_ToolResultBlock(t *testing.T) {
+	t.Parallel()
+	got := extractAssistantContent(`{"type":"assistant","message":{"content":[{"type":"tool_result"}]}}`)
+	if got != "[tool result]" {
+		t.Errorf("expected '[tool result]', got %q", got)
+	}
+}
+
+func TestExtractAssistantContent_MixedBlocks(t *testing.T) {
+	t.Parallel()
+	got := extractAssistantContent(`{"type":"assistant","message":{"content":[{"type":"text","text":"hello"},{"type":"tool_use","name":"Edit"},{"type":"tool_result"}]}}`)
+	if !strings.Contains(got, "hello") || !strings.Contains(got, "[tool: Edit]") || !strings.Contains(got, "[tool result]") {
+		t.Errorf("expected all block types, got %q", got)
+	}
+	if !strings.Contains(got, " | ") {
+		t.Errorf("expected pipe separator, got %q", got)
+	}
+}
+
+func TestExtractAssistantContent_EmptyContentBlocks(t *testing.T) {
+	t.Parallel()
+	got := extractAssistantContent(`{"type":"assistant","message":{"content":[{"type":"text","text":""},{"type":"thinking","thinking":""},{"type":"tool_use","name":""}]}}`)
+	if got != "" {
+		t.Errorf("expected empty string for empty content blocks, got %q", got)
+	}
+}
+
+func TestExtractAssistantContent_LongPlainText_Truncated(t *testing.T) {
+	t.Parallel()
+	long := strings.Repeat("x", 300)
+	got := extractAssistantContent(long)
+	if len(got) > 250 {
+		t.Errorf("expected truncation, got length %d", len(got))
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("expected ellipsis at end, got %q", got[len(got)-5:])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// truncate (logview)
+// ---------------------------------------------------------------------------
+
+func TestTruncate_Short(t *testing.T) {
+	t.Parallel()
+	got := truncate("hello", 10)
+	if got != "hello" {
+		t.Errorf("expected 'hello', got %q", got)
+	}
+}
+
+func TestTruncate_Long(t *testing.T) {
+	t.Parallel()
+	got := truncate(strings.Repeat("a", 50), 10)
+	// 10 bytes of 'a' + 3 bytes for UTF-8 "…" = 13 bytes
+	if len(got) != 13 {
+		t.Errorf("expected length 13 (10 + 3-byte ellipsis), got %d", len(got))
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("expected trailing ellipsis, got %q", got)
+	}
+}
+
+func TestTruncate_NewlinesReplaced(t *testing.T) {
+	t.Parallel()
+	got := truncate("line1\nline2\nline3", 100)
+	if strings.Contains(got, "\n") {
+		t.Errorf("expected newlines replaced with spaces, got %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// wrapBullet
+// ---------------------------------------------------------------------------
+
+func TestWrapBullet_ShortText(t *testing.T) {
+	t.Parallel()
+	got := wrapBullet("hello world", 80)
+	if !strings.HasPrefix(got, "  \u2022 ") {
+		t.Errorf("expected bullet prefix, got %q", got)
+	}
+	if !strings.Contains(got, "hello world") {
+		t.Errorf("expected text content, got %q", got)
+	}
+}
+
+func TestWrapBullet_LongText_Wraps(t *testing.T) {
+	t.Parallel()
+	long := "This is a very long sentence that should definitely wrap when the width is set to something narrow like forty characters"
+	got := wrapBullet(long, 40)
+	lines := strings.Split(got, "\n")
+	if len(lines) < 2 {
+		t.Errorf("expected wrapping to multiple lines, got %d line(s)", len(lines))
+	}
+	// Continuation lines should use "    " indent, not bullet
+	if len(lines) > 1 && !strings.HasPrefix(lines[1], "    ") {
+		t.Errorf("continuation line should have 4-space indent, got %q", lines[1])
+	}
+}
+
+func TestWrapBullet_Empty(t *testing.T) {
+	t.Parallel()
+	got := wrapBullet("", 80)
+	if got != "  \u2022 " {
+		t.Errorf("expected just bullet prefix for empty text, got %q", got)
+	}
+}
+
+func TestWrapBullet_NarrowWidth(t *testing.T) {
+	t.Parallel()
+	got := wrapBullet("some text", 5)
+	// Width < 20 is clamped to 20
+	if !strings.Contains(got, "some text") {
+		t.Errorf("expected text content even at narrow width, got %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// inboxRelativeTime: hours and days paths
+// ---------------------------------------------------------------------------
+
+func TestInboxRelativeTime_HoursAgo(t *testing.T) {
+	t.Parallel()
+	ts := time.Now().Add(-3 * time.Hour).UTC().Format(time.RFC3339)
+	got := inboxRelativeTime(ts)
+	if got != "3h ago" {
+		t.Errorf("expected '3h ago', got %q", got)
+	}
+}
+
+func TestInboxRelativeTime_DaysAgo(t *testing.T) {
+	t.Parallel()
+	ts := time.Now().Add(-48 * time.Hour).UTC().Format(time.RFC3339)
+	got := inboxRelativeTime(ts)
+	if got != "2d ago" {
+		t.Errorf("expected '2d ago', got %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ensureVisible (scroll adjustment)
+// ---------------------------------------------------------------------------
+
+func TestEnsureVisible_CursorAboveScrollTop(t *testing.T) {
+	t.Parallel()
+	m := NewInboxModel()
+	m.SetSize(80, 24)
+	m.SetItems([]state.InboxItem{
+		{Text: "a"}, {Text: "b"}, {Text: "c"}, {Text: "d"}, {Text: "e"},
+	})
+	m.scrollTop = 3
+	m.cursor = 1
+	m.ensureVisible()
+	if m.scrollTop != 1 {
+		t.Errorf("expected scrollTop=1, got %d", m.scrollTop)
+	}
+}
+
+func TestEnsureVisible_CursorBelowViewport(t *testing.T) {
+	t.Parallel()
+	m := NewInboxModel()
+	m.SetSize(80, 10) // height 10, reserved 4 = 6 visible
+	m.SetItems([]state.InboxItem{
+		{Text: "a"}, {Text: "b"}, {Text: "c"}, {Text: "d"},
+		{Text: "e"}, {Text: "f"}, {Text: "g"}, {Text: "h"},
+		{Text: "i"}, {Text: "j"},
+	})
+	m.scrollTop = 0
+	m.cursor = 8
+	m.ensureVisible()
+	if m.scrollTop <= 0 {
+		t.Errorf("expected scrollTop > 0 when cursor is below viewport, got %d", m.scrollTop)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DetailModel: updateNodeDetail and updateTaskDetail paths
+// ---------------------------------------------------------------------------
+
+func TestUpdate_NodeDetailMode_KeyPress(t *testing.T) {
+	t.Parallel()
+	m := NewDetailModel()
+	m.SetSize(80, 24)
+	m.SetMode(ModeNodeDetail)
+	node := makeOrchestratorNode()
+	m.nodeDetail.Load("root", node, nil, false)
+	m, _ = m.Update(tui.StateUpdatedMsg{Index: &state.RootIndex{
+		Nodes: map[string]state.IndexEntry{"a": {State: state.StatusComplete}},
+	}})
+	// State messages in node detail mode should not panic
+}
+
+func TestUpdate_InboxMsgForwarded_WhenNotInInboxMode(t *testing.T) {
+	t.Parallel()
+	m := NewDetailModel()
+	m.SetSize(80, 24)
+	// In dashboard mode, InboxUpdatedMsg should still reach the inbox sub-model
+	inbox := &state.InboxFile{
+		Items: []state.InboxItem{{Text: "forwarded item", Status: state.InboxNew}},
+	}
+	m, _ = m.Update(tui.InboxUpdatedMsg{Inbox: inbox})
+	if len(m.inbox.items) != 1 {
+		t.Errorf("expected inbox to receive forwarded items, got %d", len(m.inbox.items))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DetailModel.Update: LogLinesMsg forwarding when not in log view mode
+// ---------------------------------------------------------------------------
+
+func TestUpdate_LogLinesMsg_ForwardedToLogView_WhenInDashboard(t *testing.T) {
+	t.Parallel()
+	m := NewDetailModel()
+	m.SetSize(80, 24)
+	// In dashboard mode, LogLinesMsg should still reach the log view sub-model
+	m, _ = m.Update(tui.LogLinesMsg{Lines: []string{
+		`{"type":"stage_start","stage":"exec","node":"alpha","timestamp":"2026-01-01T00:00:00Z","level":"info"}`,
+	}})
+	if len(m.logView.lines) != 1 {
+		t.Errorf("expected log view to receive forwarded lines, got %d", len(m.logView.lines))
+	}
+}
+
+func TestUpdate_NewLogFileMsg_ForwardedToLogView_WhenInDashboard(t *testing.T) {
+	t.Parallel()
+	m := NewDetailModel()
+	m.SetSize(80, 24)
+	// Pre-add a line so the separator has something to follow
+	m.logView.AppendLines([]string{
+		`{"type":"daemon_start","timestamp":"2026-01-01T00:00:00Z","level":"info"}`,
+	})
+	m, _ = m.Update(tui.NewLogFileMsg{Path: "/tmp/0005-exec.jsonl"})
+	if len(m.logView.lines) != 2 {
+		t.Errorf("expected 2 lines after NewLogFileMsg forwarding, got %d", len(m.logView.lines))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// updateNodeDetail: non-key messages are no-ops
+// ---------------------------------------------------------------------------
+
+func TestUpdate_NodeDetailMode_NonKeyMsg_NoOp(t *testing.T) {
+	t.Parallel()
+	m := NewDetailModel()
+	m.SetSize(80, 24)
+	m.SetMode(ModeNodeDetail)
+	type customMsg struct{}
+	_, cmd := m.Update(customMsg{})
+	if cmd != nil {
+		t.Error("expected nil cmd for non-key message in node detail mode")
+	}
+}
+
+func TestUpdate_TaskDetailMode_NonKeyMsg_NoOp(t *testing.T) {
+	t.Parallel()
+	m := NewDetailModel()
+	m.SetSize(80, 24)
+	m.SetMode(ModeTaskDetail)
+	type customMsg struct{}
+	_, cmd := m.Update(customMsg{})
+	if cmd != nil {
+		t.Error("expected nil cmd for non-key message in task detail mode")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// updateInbox: forwarding InboxUpdatedMsg when in inbox mode
+// ---------------------------------------------------------------------------
+
+func TestUpdate_InboxMode_ReceivesInboxMsg(t *testing.T) {
+	t.Parallel()
+	m := NewDetailModel()
+	m.SetSize(80, 24)
+	m.SetMode(ModeInbox)
+	inbox := &state.InboxFile{
+		Items: []state.InboxItem{
+			{Text: "one", Status: state.InboxNew},
+			{Text: "two", Status: state.InboxFiled},
+		},
+	}
+	m, _ = m.Update(tui.InboxUpdatedMsg{Inbox: inbox})
+	if len(m.inbox.items) != 2 {
+		t.Errorf("expected 2 inbox items, got %d", len(m.inbox.items))
+	}
+}

--- a/internal/tui/detail/dashboard.go
+++ b/internal/tui/detail/dashboard.go
@@ -1,3 +1,5 @@
+// Package detail implements the right-pane detail views: dashboard,
+// node detail, task detail, inbox, and the streaming log viewer.
 package detail
 
 import (

--- a/internal/tui/detail/logview.go
+++ b/internal/tui/detail/logview.go
@@ -242,7 +242,7 @@ func (m LogViewModel) View() string {
 	// Error / empty states
 	if m.readErr {
 		body := tui.DashboardBodyStyle.Render(
-			"Transmissions intercepted. Unable to read log file.",
+			"Unable to read log file. Check that the daemon has been started at least once, or run wolfcastle doctor.",
 		)
 		b.WriteString(body)
 		return b.String()

--- a/internal/tui/footer/model.go
+++ b/internal/tui/footer/model.go
@@ -1,3 +1,5 @@
+// Package footer renders the bottom status bar showing context-sensitive
+// key hints and daemon status.
 package footer
 
 import (
@@ -63,6 +65,7 @@ func (m FooterModel) View() string {
 	hints := []hint{
 		{"q", "quit"},
 		{"Tab", "focus"},
+		{"d", "dashboard"},
 	}
 
 	// Mode-specific bindings

--- a/internal/tui/header/model.go
+++ b/internal/tui/header/model.go
@@ -247,8 +247,8 @@ func (m HeaderModel) View() string {
 	left2 := m.renderNodeCounts(barStyle)
 	line2 := composeLine(barStyle, left2, "", innerWidth)
 
-	// Line 3 (optional): instance tab bar when wide enough and multiple instances exist.
-	if m.width > 100 && len(m.instances) > 1 {
+	// Line 3 (optional): instance tab bar when wide enough and at least one instance exists.
+	if m.width > 100 && len(m.instances) > 0 {
 		tabBar := m.renderTabBar(barStyle, boldStyle, innerWidth)
 		return wrap(line1) + "\n" + wrap(line2) + "\n" + wrap(tabBar)
 	}

--- a/internal/tui/header/model_test.go
+++ b/internal/tui/header/model_test.go
@@ -318,11 +318,15 @@ func TestRenderTabBarSingleInstance(t *testing.T) {
 		{PID: 100, Branch: "main"},
 	}, 0)
 
-	// With only 1 instance, View should NOT produce a tab bar line.
+	// Even with 1 instance, the tab bar should be visible so the user
+	// always sees which instance is active.
 	view := m.View()
 	lines := strings.Split(view, "\n")
-	if len(lines) != 2 {
-		t.Errorf("single instance should produce 2 lines (no tab bar), got %d", len(lines))
+	if len(lines) != 3 {
+		t.Errorf("single instance should produce 3 lines (with tab bar), got %d", len(lines))
+	}
+	if !strings.Contains(view, "main") {
+		t.Errorf("tab bar should show the instance branch: %q", view)
 	}
 }
 

--- a/internal/tui/help/model.go
+++ b/internal/tui/help/model.go
@@ -1,3 +1,5 @@
+// Package help renders the full-screen help overlay listing all key
+// bindings grouped by context.
 package help
 
 import (

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -1,10 +1,14 @@
+// Package tui provides shared types, key bindings, messages, styles, and
+// the filesystem watcher used across all TUI components.
 package tui
 
 import "charm.land/bubbles/v2/key"
 
+// GlobalKeys defines key bindings available in every TUI view.
 type GlobalKeys struct {
 	Quit       key.Binding
 	ForceQuit  key.Binding
+	Dashboard  key.Binding
 	LogStream  key.Binding
 	Inbox      key.Binding
 	ToggleTree key.Binding
@@ -15,9 +19,11 @@ type GlobalKeys struct {
 	Copy       key.Binding
 }
 
+// GlobalKeyMap is the default set of global key bindings.
 var GlobalKeyMap = GlobalKeys{
 	Quit:       key.NewBinding(key.WithKeys("q"), key.WithHelp("q", "quit")),
 	ForceQuit:  key.NewBinding(key.WithKeys("ctrl+c"), key.WithHelp("ctrl+c", "quit")),
+	Dashboard:  key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "dashboard")),
 	LogStream:  key.NewBinding(key.WithKeys("L"), key.WithHelp("L", "logs")),
 	Inbox:      key.NewBinding(key.WithKeys("i"), key.WithHelp("i", "inbox")),
 	ToggleTree: key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "tree")),
@@ -28,6 +34,7 @@ var GlobalKeyMap = GlobalKeys{
 	Copy:       key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "copy")),
 }
 
+// TreeKeys defines key bindings for the tree navigation panel.
 type TreeKeys struct {
 	MoveDown key.Binding
 	MoveUp   key.Binding
@@ -37,6 +44,7 @@ type TreeKeys struct {
 	Bottom   key.Binding
 }
 
+// TreeKeyMap is the default set of tree key bindings.
 var TreeKeyMap = TreeKeys{
 	MoveDown: key.NewBinding(key.WithKeys("j", "down"), key.WithHelp("j/↓", "down")),
 	MoveUp:   key.NewBinding(key.WithKeys("k", "up"), key.WithHelp("k/↑", "up")),
@@ -46,6 +54,7 @@ var TreeKeyMap = TreeKeys{
 	Bottom:   key.NewBinding(key.WithKeys("G"), key.WithHelp("G", "bottom")),
 }
 
+// DaemonKeys defines key bindings for daemon start/stop and instance switching.
 type DaemonKeys struct {
 	ToggleDaemon key.Binding
 	StopAll      key.Binding
@@ -53,6 +62,7 @@ type DaemonKeys struct {
 	NextInstance key.Binding
 }
 
+// DaemonKeyMap is the default set of daemon key bindings.
 var DaemonKeyMap = DaemonKeys{
 	ToggleDaemon: key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "start/stop")),
 	StopAll:      key.NewBinding(key.WithKeys("S"), key.WithHelp("S", "stop all")),
@@ -60,6 +70,7 @@ var DaemonKeyMap = DaemonKeys{
 	NextInstance: key.NewBinding(key.WithKeys(">"), key.WithHelp(">", "next instance")),
 }
 
+// SearchKeys defines key bindings for the search overlay.
 type SearchKeys struct {
 	Confirm   key.Binding
 	Cancel    key.Binding
@@ -67,6 +78,7 @@ type SearchKeys struct {
 	PrevMatch key.Binding
 }
 
+// SearchKeyMap is the default set of search key bindings.
 var SearchKeyMap = SearchKeys{
 	Confirm:   key.NewBinding(key.WithKeys("enter"), key.WithHelp("Enter", "confirm")),
 	Cancel:    key.NewBinding(key.WithKeys("esc"), key.WithHelp("Esc", "cancel")),
@@ -74,18 +86,21 @@ var SearchKeyMap = SearchKeys{
 	PrevMatch: key.NewBinding(key.WithKeys("N"), key.WithHelp("N", "prev")),
 }
 
+// HelpKeys defines key bindings for the help overlay.
 type HelpKeys struct {
 	Dismiss    key.Binding
 	ScrollDown key.Binding
 	ScrollUp   key.Binding
 }
 
+// HelpKeyMap is the default set of help key bindings.
 var HelpKeyMap = HelpKeys{
 	Dismiss:    key.NewBinding(key.WithKeys("?", "esc"), key.WithHelp("?/Esc", "close")),
 	ScrollDown: key.NewBinding(key.WithKeys("j", "down"), key.WithHelp("j/↓", "down")),
 	ScrollUp:   key.NewBinding(key.WithKeys("k", "up"), key.WithHelp("k/↑", "up")),
 }
 
+// WelcomeKeys defines key bindings for the welcome/project picker screen.
 type WelcomeKeys struct {
 	MoveDown key.Binding
 	MoveUp   key.Binding
@@ -96,6 +111,7 @@ type WelcomeKeys struct {
 	Quit     key.Binding
 }
 
+// WelcomeKeyMap is the default set of welcome screen key bindings.
 var WelcomeKeyMap = WelcomeKeys{
 	MoveDown: key.NewBinding(key.WithKeys("j", "down"), key.WithHelp("j/↓", "down")),
 	MoveUp:   key.NewBinding(key.WithKeys("k", "up"), key.WithHelp("k/↑", "up")),

--- a/internal/tui/keys_test.go
+++ b/internal/tui/keys_test.go
@@ -12,6 +12,7 @@ func TestGlobalKeyMap_BindingsNonEmpty(t *testing.T) {
 	}{
 		{"Quit", GlobalKeyMap.Quit.Keys()},
 		{"ForceQuit", GlobalKeyMap.ForceQuit.Keys()},
+		{"Dashboard", GlobalKeyMap.Dashboard.Keys()},
 		{"ToggleTree", GlobalKeyMap.ToggleTree.Keys()},
 		{"CycleFocus", GlobalKeyMap.CycleFocus.Keys()},
 		{"Refresh", GlobalKeyMap.Refresh.Keys()},

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -9,17 +9,23 @@ import (
 	"github.com/fsnotify/fsnotify"
 )
 
-// Phase 1 messages
-
+// StateUpdatedMsg signals that the root index has been reloaded from disk.
+// Worktree identifies which instance produced this read; the handler
+// discards messages whose Worktree doesn't match the current worktreeDir
+// to prevent stale in-flight reads from overwriting a freshly-switched
+// context.
 type StateUpdatedMsg struct {
-	Index *state.RootIndex
+	Index    *state.RootIndex
+	Worktree string
 }
 
+// NodeUpdatedMsg signals that a single node's state has changed.
 type NodeUpdatedMsg struct {
 	Address string
 	Node    *state.NodeState
 }
 
+// DaemonStatusMsg carries a snapshot of the daemon's current state.
 type DaemonStatusMsg struct {
 	Status       string
 	Branch       string
@@ -33,10 +39,12 @@ type DaemonStatusMsg struct {
 	CurrentTask  string
 }
 
+// InstancesUpdatedMsg signals that the instance registry has been refreshed.
 type InstancesUpdatedMsg struct {
 	Instances []instance.Entry
 }
 
+// WatcherEventMsg wraps a single filesystem event from the state watcher.
 type WatcherEventMsg struct {
 	Path string
 	Op   fsnotify.Op
@@ -52,102 +60,119 @@ type WatcherMsg struct {
 	Inner tea.Msg
 }
 
+// PollTickMsg triggers a periodic state refresh.
 type PollTickMsg struct{}
 
+// SpinnerTickMsg advances the loading spinner animation.
 type SpinnerTickMsg struct{}
 
+// ErrorMsg reports a file-scoped error to the TUI.
 type ErrorMsg struct {
 	Filename string
 	Message  string
 }
 
+// ErrorClearedMsg signals that a previously reported error has been resolved.
 type ErrorClearedMsg struct {
 	Filename string
 }
 
+// InitStartedMsg signals that project initialization has begun.
 type InitStartedMsg struct{}
 
+// InitCompleteMsg signals that project initialization has finished.
 type InitCompleteMsg struct {
 	Dir string
 	Err error
 }
 
+// ToggleHelpMsg requests the help overlay to toggle visibility.
 type ToggleHelpMsg struct{}
 
+// CopyMsg requests that the given text be copied to the clipboard.
 type CopyMsg struct {
 	Text string
 }
 
+// CopiedMsg confirms that text was successfully copied to the clipboard.
 type CopiedMsg struct{}
 
-// Phase 2 placeholder messages
-
+// LogLinesMsg delivers new log output lines to the log viewer.
 type LogLinesMsg struct {
 	Lines []string // raw JSON strings, one per log line
 }
 
+// NewLogFileMsg signals that the daemon started writing to a new log file.
 type NewLogFileMsg struct {
 	Path string
 }
 
-// Phase 3 messages
-
+// SwitchInstanceMsg requests switching the TUI to a different daemon instance.
 type SwitchInstanceMsg struct {
 	Entry instance.Entry
 }
 
+// InstanceSwitchedMsg confirms that the TUI switched to a new instance.
 type InstanceSwitchedMsg struct {
 	Index *state.RootIndex
 	Entry instance.Entry
 }
 
+// DaemonStartMsg requests starting a new daemon process.
 type DaemonStartMsg struct{}
 
+// DaemonStartedMsg confirms that a daemon process was launched.
 type DaemonStartedMsg struct {
 	Entry instance.Entry
 }
 
+// DaemonStartFailedMsg reports that daemon startup failed.
 type DaemonStartFailedMsg struct {
 	Err    error
 	Stderr string
 }
 
+// DaemonStopMsg requests stopping the current daemon process.
 type DaemonStopMsg struct{}
 
+// DaemonStoppedMsg confirms that the daemon was stopped.
 type DaemonStoppedMsg struct{}
 
+// DaemonStopAllMsg requests stopping all running daemon instances.
 type DaemonStopAllMsg struct{}
 
+// DaemonStopFailedMsg reports that stopping the daemon failed.
 type DaemonStopFailedMsg struct {
 	Err error
 }
 
+// WorktreeGoneMsg signals that the watched worktree no longer exists.
 type WorktreeGoneMsg struct {
 	Entry instance.Entry
 }
 
-// Phase 4: Inbox
-
+// InboxUpdatedMsg signals that the inbox file was reloaded.
 type InboxUpdatedMsg struct {
 	Inbox *state.InboxFile
 }
 
+// InboxItemAddedMsg confirms a new item was added to the inbox.
 type InboxItemAddedMsg struct{}
 
+// InboxAddFailedMsg reports that adding an inbox item failed.
 type InboxAddFailedMsg struct {
 	Err error
 }
 
+// AddInboxItemCmd is a command message that triggers inbox item creation.
 type AddInboxItemCmd struct {
 	Text string
 }
 
-// Modal messages
-
+// DaemonConfirmedMsg signals that the user confirmed a daemon action in the modal.
 type DaemonConfirmedMsg struct{}
 
-// Phase 5 messages
-
+// ToastMsg triggers a timed notification in the TUI.
 type ToastMsg struct {
 	Text string
 }

--- a/internal/tui/notify/coverage_test.go
+++ b/internal/tui/notify/coverage_test.go
@@ -1,0 +1,109 @@
+package notify
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Push truncation paths
+// ---------------------------------------------------------------------------
+
+func TestPush_LongTextWithColon_FrontTruncatesValue(t *testing.T) {
+	t.Parallel()
+	m := NewNotificationModel()
+	// Build a string like "Label: <very long value>"
+	label := "Copied"
+	value := strings.Repeat("x", 100)
+	text := label + ": " + value
+	m.Push(text)
+	if len(m.toasts) != 1 {
+		t.Fatalf("expected 1 toast, got %d", len(m.toasts))
+	}
+	got := m.toasts[0].text
+	if !strings.HasPrefix(got, "Copied: ...") {
+		t.Errorf("expected front-truncated value with '...', got %q", got)
+	}
+	if len(got) > maxWidth {
+		t.Errorf("expected text within maxWidth, got length %d", len(got))
+	}
+}
+
+func TestPush_LongTextWithoutColon_FrontTruncates(t *testing.T) {
+	t.Parallel()
+	m := NewNotificationModel()
+	text := strings.Repeat("y", 100)
+	m.Push(text)
+	got := m.toasts[0].text
+	if !strings.HasPrefix(got, "...") {
+		t.Errorf("expected front-truncation with '...', got %q", got)
+	}
+	// The tail should be preserved
+	if !strings.HasSuffix(got, "yyy") {
+		t.Errorf("expected tail preserved, got %q", got)
+	}
+}
+
+func TestPush_ExactLimitLength_NoTruncation(t *testing.T) {
+	t.Parallel()
+	m := NewNotificationModel()
+	limit := maxWidth - 5
+	text := strings.Repeat("z", limit)
+	m.Push(text)
+	got := m.toasts[0].text
+	if got != text {
+		t.Errorf("text at exact limit should not be truncated, got length %d", len(got))
+	}
+}
+
+func TestPush_ColonNearEnd_FallsBackToPlainTruncation(t *testing.T) {
+	t.Parallel()
+	m := NewNotificationModel()
+	// Colon is beyond the limit, so it won't match the idx < limit check
+	text := strings.Repeat("a", 60) + ": short"
+	m.Push(text)
+	got := m.toasts[0].text
+	if !strings.HasPrefix(got, "...") {
+		t.Errorf("expected fallback truncation, got %q", got)
+	}
+}
+
+func TestUpdate_UnhandledMsg_PassesThrough(t *testing.T) {
+	t.Parallel()
+	m := NewNotificationModel()
+	m.Push("test")
+	type customMsg struct{}
+	m, cmd := m.Update(customMsg{})
+	if cmd != nil {
+		t.Error("expected nil cmd for unhandled message")
+	}
+	if len(m.toasts) != 1 {
+		t.Errorf("toast should be unchanged, got %d", len(m.toasts))
+	}
+}
+
+func TestDismiss_NonExistentID_NoPanic(t *testing.T) {
+	t.Parallel()
+	m := NewNotificationModel()
+	m.Push("test")
+	m, _ = m.Update(ToastDismissMsg{ID: 999})
+	if len(m.toasts) != 1 {
+		t.Errorf("expected toast to remain, got %d", len(m.toasts))
+	}
+}
+
+func TestView_DismissedToasts_Excluded(t *testing.T) {
+	t.Parallel()
+	m := NewNotificationModel()
+	m.Push("first")
+	m.Push("second")
+	// Dismiss the first
+	m.toasts[0].dismissed = true
+	v := m.View()
+	if strings.Contains(v, "first") {
+		t.Error("dismissed toast should not appear in view")
+	}
+	if !strings.Contains(v, "second") {
+		t.Error("active toast should appear in view")
+	}
+}

--- a/internal/tui/notify/model.go
+++ b/internal/tui/notify/model.go
@@ -1,3 +1,5 @@
+// Package notify provides timed toast notifications that appear in the
+// TUI and auto-dismiss after a configurable duration.
 package notify
 
 import (

--- a/internal/tui/search/model.go
+++ b/internal/tui/search/model.go
@@ -1,3 +1,5 @@
+// Package search implements the incremental search overlay that filters
+// the tree view by node and task names.
 package search
 
 import (

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -8,6 +8,7 @@ import (
 	"charm.land/lipgloss/v2"
 
 	"github.com/dorkusprime/wolfcastle/internal/instance"
+	"github.com/dorkusprime/wolfcastle/internal/state"
 )
 
 // Color palette constants
@@ -123,18 +124,20 @@ type StatusGlyph struct {
 	Color color.Color
 }
 
+// NodeStatusGlyphs maps each node lifecycle status to its display glyph and color.
 var NodeStatusGlyphs = map[string]StatusGlyph{
-	"complete":    {Glyph: "●", Color: ColorGreen},
-	"in_progress": {Glyph: "◐", Color: ColorYellow},
-	"not_started": {Glyph: "◯", Color: ColorDimWhite},
-	"blocked":     {Glyph: "☢", Color: ColorRed},
+	string(state.StatusComplete):   {Glyph: "●", Color: ColorGreen},
+	string(state.StatusInProgress): {Glyph: "◐", Color: ColorYellow},
+	string(state.StatusNotStarted): {Glyph: "◯", Color: ColorDimWhite},
+	string(state.StatusBlocked):    {Glyph: "☢", Color: ColorRed},
 }
 
+// AuditStatusGlyphs maps each audit lifecycle status to its display glyph and color.
 var AuditStatusGlyphs = map[string]StatusGlyph{
-	"passed":      {Glyph: "⏸", Color: ColorGreen},
-	"in_progress": {Glyph: "◐", Color: ColorYellow},
-	"pending":     {Glyph: "◯", Color: ColorDimWhite},
-	"failed":      {Glyph: "⊘", Color: ColorRed},
+	string(state.AuditPassed):     {Glyph: "⏸", Color: ColorGreen},
+	string(state.AuditInProgress): {Glyph: "◐", Color: ColorYellow},
+	string(state.AuditPending):    {Glyph: "◯", Color: ColorDimWhite},
+	string(state.AuditFailed):     {Glyph: "⊘", Color: ColorRed},
 }
 
 // GlyphForStatus returns the styled glyph string for a node status.

--- a/internal/tui/tree/coverage_test.go
+++ b/internal/tui/tree/coverage_test.go
@@ -1,0 +1,214 @@
+package tree
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/dorkusprime/wolfcastle/internal/state"
+)
+
+// ---------------------------------------------------------------------------
+// statusGlyphOnBg: all status branches
+// ---------------------------------------------------------------------------
+
+func TestStatusGlyphOnBg_Complete(t *testing.T) {
+	t.Parallel()
+	bg := lipgloss.Color("236")
+	got := statusGlyphOnBg(state.StatusComplete, bg)
+	if !strings.Contains(got, "●") {
+		t.Errorf("expected ● for complete, got %q", got)
+	}
+}
+
+func TestStatusGlyphOnBg_InProgress(t *testing.T) {
+	t.Parallel()
+	bg := lipgloss.Color("236")
+	got := statusGlyphOnBg(state.StatusInProgress, bg)
+	if !strings.Contains(got, "◐") {
+		t.Errorf("expected ◐ for in_progress, got %q", got)
+	}
+}
+
+func TestStatusGlyphOnBg_Blocked(t *testing.T) {
+	t.Parallel()
+	bg := lipgloss.Color("236")
+	got := statusGlyphOnBg(state.StatusBlocked, bg)
+	if !strings.Contains(got, "☢") {
+		t.Errorf("expected ☢ for blocked, got %q", got)
+	}
+}
+
+func TestStatusGlyphOnBg_Default(t *testing.T) {
+	t.Parallel()
+	bg := lipgloss.Color("236")
+	got := statusGlyphOnBg(state.StatusNotStarted, bg)
+	if !strings.Contains(got, "◯") {
+		t.Errorf("expected ◯ for not_started, got %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// taskStatusGlyphOnBg: non-InProgress branches
+// ---------------------------------------------------------------------------
+
+func TestTaskStatusGlyphOnBg_Complete(t *testing.T) {
+	t.Parallel()
+	bg := lipgloss.Color("236")
+	got := taskStatusGlyphOnBg(state.StatusComplete, bg)
+	if !strings.Contains(got, "●") {
+		t.Errorf("expected ● for complete task, got %q", got)
+	}
+}
+
+func TestTaskStatusGlyphOnBg_Blocked(t *testing.T) {
+	t.Parallel()
+	bg := lipgloss.Color("236")
+	got := taskStatusGlyphOnBg(state.StatusBlocked, bg)
+	if !strings.Contains(got, "☢") {
+		t.Errorf("expected ☢ for blocked task, got %q", got)
+	}
+}
+
+func TestTaskStatusGlyphOnBg_NotStarted(t *testing.T) {
+	t.Parallel()
+	bg := lipgloss.Color("236")
+	got := taskStatusGlyphOnBg(state.StatusNotStarted, bg)
+	if !strings.Contains(got, "◯") {
+		t.Errorf("expected ◯ for not_started task, got %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// renderTaskRow: ancestor hit path
+// ---------------------------------------------------------------------------
+
+func TestRenderTaskRow_AncestorHit(t *testing.T) {
+	t.Parallel()
+	row := TreeRow{
+		Addr:   "node/t-001",
+		Name:   "A Task",
+		Depth:  1,
+		Status: state.StatusComplete,
+		IsTask: true,
+	}
+	normal := RenderRow(row, 60, false, false)
+	ancestor := RenderRow(row, 60, false, false, false, true)
+	if normal == ancestor {
+		t.Error("ancestor hit task row should differ from normal task row")
+	}
+}
+
+func TestRenderNodeRow_AncestorHit(t *testing.T) {
+	t.Parallel()
+	row := TreeRow{
+		Addr:       "a",
+		Name:       "Node",
+		Depth:      0,
+		NodeType:   state.NodeOrchestrator,
+		Status:     state.StatusInProgress,
+		Expandable: true,
+	}
+	normal := RenderRow(row, 60, false, false)
+	ancestor := RenderRow(row, 60, false, false, false, true)
+	if normal == ancestor {
+		t.Error("ancestor hit node row should differ from normal node row")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// renderTaskRow: selected path coverage
+// ---------------------------------------------------------------------------
+
+func TestRenderTaskRow_Selected_Complete(t *testing.T) {
+	t.Parallel()
+	row := TreeRow{
+		Addr:   "node/t-002",
+		Name:   "Complete task",
+		Depth:  1,
+		Status: state.StatusComplete,
+		IsTask: true,
+	}
+	got := RenderRow(row, 60, true, false)
+	if !strings.Contains(got, "t-002") {
+		t.Error("selected task row should contain task ID")
+	}
+}
+
+func TestRenderTaskRow_Selected_Blocked(t *testing.T) {
+	t.Parallel()
+	row := TreeRow{
+		Addr:   "node/t-003",
+		Name:   "Blocked task",
+		Depth:  1,
+		Status: state.StatusBlocked,
+		IsTask: true,
+	}
+	got := RenderRow(row, 60, true, false)
+	if !strings.Contains(got, "t-003") {
+		t.Error("selected blocked task row should contain task ID")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// taskHint rendering in tree rows
+// ---------------------------------------------------------------------------
+
+func TestRenderNodeRow_WithTaskHint(t *testing.T) {
+	t.Parallel()
+	row := TreeRow{
+		Addr:       "alpha",
+		Name:       "Alpha Node",
+		Depth:      0,
+		NodeType:   state.NodeLeaf,
+		Status:     state.StatusInProgress,
+		Expandable: true,
+		TaskHint:   "2/5 tasks",
+	}
+	got := RenderRow(row, 80, false, false)
+	if !strings.Contains(got, "2/5 tasks") {
+		t.Errorf("expected task hint in output, got %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// taskHint: all branches
+// ---------------------------------------------------------------------------
+
+func TestTaskHint_NoTasks(t *testing.T) {
+	t.Parallel()
+	ns := &state.NodeState{}
+	got := taskHint(ns)
+	if got != "" {
+		t.Errorf("expected empty string for no tasks, got %q", got)
+	}
+}
+
+func TestTaskHint_TasksNoFailures(t *testing.T) {
+	t.Parallel()
+	ns := &state.NodeState{
+		Tasks: []state.Task{
+			{ID: "t1"}, {ID: "t2"}, {ID: "t3"},
+		},
+	}
+	got := taskHint(ns)
+	if got != "(3 tasks)" {
+		t.Errorf("expected '(3 tasks)', got %q", got)
+	}
+}
+
+func TestTaskHint_TasksWithFailures(t *testing.T) {
+	t.Parallel()
+	ns := &state.NodeState{
+		Tasks: []state.Task{
+			{ID: "t1", FailureCount: 2},
+			{ID: "t2", FailureCount: 0},
+			{ID: "t3", FailureCount: 1},
+		},
+	}
+	got := taskHint(ns)
+	if got != "(3 tasks, 3 failures)" {
+		t.Errorf("expected '(3 tasks, 3 failures)', got %q", got)
+	}
+}

--- a/internal/tui/tree/model.go
+++ b/internal/tui/tree/model.go
@@ -1,3 +1,5 @@
+// Package tree implements the left-pane tree view that displays the
+// project node hierarchy with expandable sections and cursor navigation.
 package tree
 
 import (


### PR DESCRIPTION
## Summary

Full 13-section audit for v0.6.0 release. All findings fixed in this PR.

- **Sections 1, 3, 4, 5** (correctness, error handling, security, architecture): clean
- **Section 2** (Go practices): 8 packages + 47 exports missing doc comments
- **Section 6** (documentation): stale counts, missing ADR index entry, missing commands
- **Section 7** (SSOT): glyph maps used raw string keys instead of typed constants
- **Section 8** (voice): "nine-phase" should be "ten-phase"
- **Sections 9-11** (testing, CI, cross-platform): clean
- **Section 12** (coverage): new test files, 91%+ overall
- **Section 13** (usability): unwired `d` binding, missing modal hints, vague error message

Instance management refactor (found during smoke testing):
- `reconcileActiveInstance` centralizes all instance-list changes
- `originalCWD` tracks launch directory (survives instance switches)
- `StateUpdatedMsg.Worktree` discards stale in-flight reads
- `stopAndDrainWatcher` prevents buffered messages from overwriting context
- Tab bar visible with single instance
- CWD fallback when all instances disappear (including external kills)

## Test plan

- [x] Full test suite green (`go test ./...`)
- [x] All 5 cross-compile targets pass
- [x] `go vet`, `gofmt` clean
- [x] Manual smoke: start TUI from external dir, switch instances, stop all, verify CWD fallback
- [x] Debug logging verified stale message discard and channel drain