### PR TITLE
docs: TUI-first documentation rewrite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Wolfcastle is Ralph on steroids. It's what happens when you give an action hero 
 
 - **Language:** Go 1.26+, single module `github.com/dorkusprime/wolfcastle`
 - **Framework:** [Cobra](https://github.com/spf13/cobra) for CLI
-- **Dependencies:** Minimal: Cobra/pflag + chzyer/readline + fsnotify/fsnotify (ADR-048)
+- **Dependencies:** Cobra/pflag + chzyer/readline + fsnotify/fsnotify + Bubbletea v2/Lipgloss v2/Bubbles v2 + atotto/clipboard (ADR-048, ADR-101)
 - **Build:** `make build` / `go build ./...`
 - **Test:** `make test` / `go test ./...`
 - **Lint:** `make lint` (runs `go vet` + `gofmt`), `golangci-lint run` (full lint suite per ADR-049)
@@ -41,8 +41,8 @@ Entries should be concrete, durable, and non-obvious. "The config loader silentl
 
 ## Design References
 
-- [Architecture Decision Records](docs/decisions/INDEX.md) (100 ADRs) document every major design choice. Consult these before making architectural decisions.
-- [Specifications](docs/specs/) (44 specs) describe the current system in detail. Consult these before modifying behavior.
+- [Architecture Decision Records](docs/decisions/INDEX.md) (101 ADRs) document every major design choice. Consult these before making architectural decisions.
+- [Specifications](docs/specs/) (45 specs) describe the current system in detail. Consult these before modifying behavior.
 - [Full documentation hub](docs/)
 
 ## Critical Rules

--- a/README.md
+++ b/README.md
@@ -22,12 +22,21 @@ Pre-release. Probably broken. Then fixed. Then broken again. On repeat until rel
 ```bash
 brew install dorkusprime/tap/wolfcastle
 cd your-repo
+wolfcastle
+```
 
+This opens the [TUI](docs/humans/the-tui.md). Press `I` to initialize the project, `i` then `a` to add work to the inbox, `s` to start the daemon. The dashboard shows progress in real time: tree state, audit results, log stream, everything. The TUI is the primary interface.
+
+![Wolfcastle TUI](assets/screenshots/tui-full-layout.png)
+
+### Headless / CI
+
+You can also run Wolfcastle without the TUI, from the command line or in a headless environment:
+
+```bash
 wolfcastle init                                            # scaffold .wolfcastle/
 wolfcastle inbox add "Build a website for my donut stand"  # queue up work
 wolfcastle start                                           # the daemon wakes up
-
-# in another terminal, same directory:
 wolfcastle status -w                                       # watch it work
 ```
 
@@ -38,20 +47,14 @@ wolfcastle status -w                                       # watch it work
 You can also run Wolfcastle in the background and just let it go. Give it work as you find work for it to do. No LLM calls are made if there's no work to be done:
 
 ```bash
-brew install dorkusprime/tap/wolfcastle
-cd your-repo
-
-wolfcastle init                                            # scaffold .wolfcastle/
 wolfcastle start -d                                        # the daemon wakes up
 
-# Whenever you get to it
+# Whenever you get to it:
+# press i then a in the TUI, or from the command line:
 wolfcastle inbox add "Build a website for my donut stand"  # queue up work
-
-# in another terminal, same directory:
-wolfcastle status -w                                       # watch it work
 ```
 
-Feed it work through the [CLI](docs/humans/cli.md) or chat with your coding agent to hammer out the details and have it inject the work directly with a markdown file path. A detailed spec or PRD gets the most predictable results, but Wolfcastle takes vague directions too without getting lost in the wrong state like a second lieutenant. "Make the API faster" becomes specs, task trees, and acceptance criteria before any code gets written. The [daemon](docs/humans/how-it-works.md#the-daemon) takes it from there: triage, planning, execution, audit, commit. Depth-first through the [tree](docs/humans/how-it-works.md#the-project-tree) until it's conquered or something insurmountable gets in the way.
+Feed it work through the [TUI inbox](docs/humans/the-tui.md#the-inbox), the [CLI](docs/humans/cli.md), or chat with your coding agent to hammer out the details and have it inject the work directly with a markdown file path. A detailed spec or PRD gets the most predictable results, but Wolfcastle takes vague directions too without getting lost in the wrong state like a second lieutenant. "Make the API faster" becomes specs, task trees, and acceptance criteria before any code gets written. The [daemon](docs/humans/how-it-works.md#the-daemon) takes it from there: triage, planning, execution, audit, commit. Depth-first through the [tree](docs/humans/how-it-works.md#the-project-tree) until it's conquered or something insurmountable gets in the way.
 
 By default, the daemon works one task at a time. With [parallel execution](docs/humans/parallel-execution.md) enabled, independent siblings under the same orchestrator run concurrently. Each agent declares which files it intends to touch via [scope locks](docs/humans/cli/task-scope-add.md); the daemon enforces disjoint scopes and serializes git commits. Three agents writing three packages simultaneously, no collisions, no coordination overhead. The tree structure, the audits, the state machine: all identical. The only difference is how many agents are swinging at once.
 
@@ -81,7 +84,7 @@ Wolfcastle [audits](docs/humans/audits.md#the-audit-system) every piece of work 
 
 Most agent workflows assume someone is always watching: approving plans, reviewing code, deciding what to do next. The agent is capable, but the process treats it like an intern. Scale hits the human's availability long before it hits the agent's throughput.
 
-Wolfcastle runs the full lifecycle without waiting for a human: [intake](docs/humans/how-it-works.md#getting-work-in), [planning](docs/humans/how-it-works.md#the-pipeline), [execution](docs/humans/how-it-works.md#execution-protocol), [audit](docs/humans/audits.md#the-audit-system), [remediation](docs/humans/audits.md#gap-escalation), commit. With parallel execution, throughput scales with the work: three independent packages build simultaneously instead of sequentially. Your role is to check [`wolfcastle status`](docs/humans/cli/status.md), adjust priorities, and [unblock](docs/humans/failure-and-recovery.md#the-unblock-workflow) the rare task that genuinely needs judgment. The system does the volume. You do the thinking.
+Wolfcastle runs the full lifecycle without waiting for a human: [intake](docs/humans/how-it-works.md#getting-work-in), [planning](docs/humans/how-it-works.md#the-pipeline), [execution](docs/humans/how-it-works.md#execution-protocol), [audit](docs/humans/audits.md#the-audit-system), [remediation](docs/humans/audits.md#gap-escalation), commit. With parallel execution, throughput scales with the work: three independent packages build simultaneously instead of sequentially. Your role is to check the [TUI dashboard](docs/humans/the-tui.md#the-dashboard), adjust priorities, and [unblock](docs/humans/failure-and-recovery.md#the-unblock-workflow) the rare task that genuinely needs judgment. The system does the volume. You do the thinking.
 
 ## Standing on the Shoulders of . . . Ralph Wiggum
 
@@ -97,7 +100,7 @@ Ralph is the insight. Wolfcastle is the infrastructure.
 
 ## How It Works
 
-Wolfcastle organizes code changes into a [project tree](docs/humans/how-it-works.md#the-project-tree). Orchestrators represent features, modules, or milestones. Leaves are where the actual coding tasks live. Every node ends with an automatic [audit](docs/humans/audits.md#the-audit-system) and, if gaps are found, [remediation](docs/humans/audits.md#gap-escalation). Nodes have [four states](docs/humans/how-it-works.md#four-states): `not_started`, `in_progress`, `complete`, `blocked`. State [propagates upward](docs/humans/how-it-works.md#state-propagation) deterministically: when a task completes, its leaf recomputes, then its parent, all the way to the root. No node decides its own fate. Insubordination is not a valid state.
+Wolfcastle organizes code changes into a [project tree](docs/humans/how-it-works.md#the-project-tree), visible in the [TUI tree pane](docs/humans/the-tui.md#the-tree). Orchestrators represent features, modules, or milestones. Leaves are where the actual coding tasks live. Every node ends with an automatic [audit](docs/humans/audits.md#the-audit-system) and, if gaps are found, [remediation](docs/humans/audits.md#gap-escalation). Nodes have [four states](docs/humans/how-it-works.md#four-states): `not_started`, `in_progress`, `complete`, `blocked`. State [propagates upward](docs/humans/how-it-works.md#state-propagation) deterministically: when a task completes, its leaf recomputes, then its parent, all the way to the root. No node decides its own fate. Insubordination is not a valid state.
 
 The daemon hunts down the next task and eliminates it, running a [pipeline of stages](docs/humans/how-it-works.md#the-pipeline): intake triages inbox items into projects, planning agents decompose projects into specs and task trees, execution claims tasks and points agents at code, audits verify the results from a separate invocation with fresh context. In [parallel mode](docs/humans/parallel-execution.md), the daemon dispatches up to `max_workers` tasks simultaneously, each with its own agent and file scope. Each stage is a separate model call with a specific role. Stages are [configured as a dictionary](docs/humans/configuration.md#pipeline-stages), and each one can be overridden individually across [config tiers](docs/humans/configuration.md#three-tier-directory-structure) (base, custom, local) without replacing the entire pipeline.
 
@@ -127,8 +130,9 @@ Wolfcastle turns tokens into code. It uses a lot of them. Every planning pass, e
 
 ## More
 
+- [TUI Guide](docs/humans/the-tui.md)
 - [63 CLI commands](docs/humans/cli.md)
-- [Architecture Decision Records](docs/decisions/INDEX.md) (97 and counting)
+- [Architecture Decision Records](docs/decisions/INDEX.md) (101 and counting)
 - [Specifications](docs/specs/)
 - [Developer guides](docs/agents/)
 - [AGENTS.md](AGENTS.md)

--- a/cmd/cmdutil/app.go
+++ b/cmd/cmdutil/app.go
@@ -30,7 +30,7 @@ type App struct {
 	Identity *config.Identity // nil if identity not configured
 	Prompts  *pipeline.PromptRepository
 	Classes  *pipeline.ClassRepository
-	Daemon   *daemon.DaemonRepository
+	Daemon   *daemon.Repository
 	State    *state.Store // nil if identity not configured
 	Git      git.Provider
 
@@ -126,7 +126,7 @@ func (a *App) initFromRoot(root string) error {
 	// Create repositories.
 	a.Config = config.NewRepository(root)
 	a.Prompts = pipeline.NewPromptRepository(root)
-	a.Daemon = daemon.NewDaemonRepository(root)
+	a.Daemon = daemon.NewRepository(root)
 	a.Git = git.NewService(filepath.Dir(root))
 	a.Classes = pipeline.NewClassRepository(a.Prompts)
 
@@ -167,7 +167,7 @@ func (a *App) InitFromDir(dir string) error {
 
 	a.Config = config.NewRepository(candidate)
 	a.Prompts = pipeline.NewPromptRepository(candidate)
-	a.Daemon = daemon.NewDaemonRepository(candidate)
+	a.Daemon = daemon.NewRepository(candidate)
 	a.Git = git.NewService(dir)
 	a.Classes = pipeline.NewClassRepository(a.Prompts)
 

--- a/cmd/daemon/daemon_test.go
+++ b/cmd/daemon/daemon_test.go
@@ -76,7 +76,7 @@ func TestGetDaemonStatus_NoInstance(t *testing.T) {
 	instance.RegistryDirOverride = regDir
 	defer func() { instance.RegistryDirOverride = "" }()
 
-	repo := dmn.NewDaemonRepository(tmp)
+	repo := dmn.NewRepository(tmp)
 	status := getDaemonStatus(repo, "")
 	if status != "stopped" {
 		t.Errorf("expected 'stopped', got %q", status)
@@ -96,7 +96,7 @@ func TestGetDaemonStatus_Running(t *testing.T) {
 	entryJSON := fmt.Sprintf(`{"pid":%d,"worktree":%q,"branch":"main","started_at":"2026-01-01T00:00:00Z"}`, os.Getpid(), cwd)
 	_ = os.WriteFile(filepath.Join(regDir, slug+".json"), []byte(entryJSON), 0644)
 
-	repo := dmn.NewDaemonRepository(tmp)
+	repo := dmn.NewRepository(tmp)
 	status := getDaemonStatus(repo, "")
 	if !strings.Contains(status, "running") {
 		t.Errorf("expected 'running' status, got %q", status)
@@ -117,7 +117,7 @@ func TestGetDaemonStatus_Draining(t *testing.T) {
 
 	// Create the system dir + drain file so HasDrainFile returns true.
 	_ = os.MkdirAll(filepath.Join(tmp, "system"), 0755)
-	repo := dmn.NewDaemonRepository(tmp)
+	repo := dmn.NewRepository(tmp)
 	if err := repo.WriteDrainFile(); err != nil {
 		t.Fatalf("writing drain file: %v", err)
 	}
@@ -478,7 +478,7 @@ func TestGetDaemonStatus_RunningProcess(t *testing.T) {
 	entryJSON := fmt.Sprintf(`{"pid":%d,"worktree":%q,"branch":"test","started_at":"2026-01-01T00:00:00Z"}`, pid, cwd)
 	_ = os.WriteFile(filepath.Join(regDir, slug+".json"), []byte(entryJSON), 0644)
 
-	repo := dmn.NewDaemonRepository(tmp)
+	repo := dmn.NewRepository(tmp)
 	status := getDaemonStatus(repo, "")
 	if status == "stopped" {
 		t.Error("expected running status for own PID")

--- a/cmd/daemon/multiprocess_test.go
+++ b/cmd/daemon/multiprocess_test.go
@@ -394,7 +394,7 @@ func TestGetDaemonStatus_ExplicitRepoDir(t *testing.T) {
 		StartedAt: time.Now().UTC(),
 	})
 
-	repoObj := dmn.NewDaemonRepository(filepath.Join(repo, ".wolfcastle"))
+	repoObj := dmn.NewRepository(filepath.Join(repo, ".wolfcastle"))
 	status := getDaemonStatus(repoObj, repo)
 	if !strings.HasPrefix(status, "running") {
 		t.Errorf("expected status to start with 'running', got %q", status)
@@ -407,7 +407,7 @@ func TestGetDaemonStatus_ExplicitRepoDir(t *testing.T) {
 // registry has nothing matching the test's actual CWD.
 func TestGetDaemonStatus_EmptyRepoDirFallsBackToCWD(t *testing.T) {
 	_ = setupRegistry(t) // empty registry
-	repo := dmn.NewDaemonRepository(t.TempDir())
+	repo := dmn.NewRepository(t.TempDir())
 	status := getDaemonStatus(repo, "")
 	if status != "stopped" {
 		t.Errorf("expected 'stopped' for an empty registry, got %q", status)

--- a/cmd/daemon/start.go
+++ b/cmd/daemon/start.go
@@ -162,7 +162,7 @@ Examples:
 
 			// Startup validation gate: block on error-severity issues
 			if idxErr == nil {
-				engine := validate.NewEngine(app.State.Dir(), validate.DefaultNodeLoader(app.State.Dir()), dmn.NewDaemonRepository(app.Config.Root()))
+				engine := validate.NewEngine(app.State.Dir(), validate.DefaultNodeLoader(app.State.Dir()), dmn.NewRepository(app.Config.Root()))
 				report := engine.ValidateStartup(idx)
 				if report.HasErrors() {
 					output.PrintHuman("Startup blocked. %d error(s):", report.Errors)

--- a/cmd/daemon/start_test.go
+++ b/cmd/daemon/start_test.go
@@ -238,7 +238,7 @@ func TestGetDaemonStatus_CurrentProcessJSON(t *testing.T) {
 	entryJSON := fmt.Sprintf(`{"pid":%d,"worktree":%q,"branch":"test","started_at":"2026-01-01T00:00:00Z"}`, pid, cwd)
 	_ = os.WriteFile(filepath.Join(regDir, slug+".json"), []byte(entryJSON), 0644)
 
-	repo := dmn.NewDaemonRepository(tmp)
+	repo := dmn.NewRepository(tmp)
 	status := getDaemonStatus(repo, "")
 	expected := fmt.Sprintf("running (PID %d)", pid)
 	if status != expected {

--- a/cmd/daemon/status.go
+++ b/cmd/daemon/status.go
@@ -671,7 +671,7 @@ func taskGlyph(s state.NodeStatus) string {
 // back to the current working directory; the prior variadic shape
 // existed only for backward compat with old call sites and has been
 // retired in favor of an explicit, single signature.
-func getDaemonStatus(repo *dmn.DaemonRepository, repoDir string) string {
+func getDaemonStatus(repo *dmn.Repository, repoDir string) string {
 	dir := repoDir
 	if dir == "" {
 		var err error

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -59,7 +59,7 @@ Examples:
 		nodeLoader := validate.RecoveringNodeLoader(projectsDir, func(addr string, report *validate.RecoveryReport) {
 			recoveredNodes = append(recoveredNodes, validate.RecoveredNode{Address: addr, Report: report})
 		})
-		engine := validate.NewEngine(projectsDir, nodeLoader, daemon.NewDaemonRepository(root))
+		engine := validate.NewEngine(projectsDir, nodeLoader, daemon.NewRepository(root))
 		report := engine.ValidateAll(idx)
 
 		// Inject MALFORMED_JSON issues for any nodes that required recovery.
@@ -91,7 +91,7 @@ Examples:
 		}
 
 		// Apply deterministic fixes
-		fixes, postFixWarnings, fixErr := validate.ApplyDeterministicFixes(idx, report.Issues, projectsDir, indexPath, daemon.NewDaemonRepository(root))
+		fixes, postFixWarnings, fixErr := validate.ApplyDeterministicFixes(idx, report.Issues, projectsDir, indexPath, daemon.NewRepository(root))
 
 		if !app.JSON {
 			if len(fixes) == 0 {

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/dorkusprime/wolfcastle/internal/output"
 	"github.com/dorkusprime/wolfcastle/internal/tierfs"
@@ -128,10 +127,6 @@ All commands support ` + "`--json`" + ` for structured output.
 		}
 	}
 	return nil
-}
-
-func canSymlink() bool {
-	return runtime.GOOS != "windows"
 }
 
 func copyDir(src, dst string) error {

--- a/cmd/install_symlink_unix.go
+++ b/cmd/install_symlink_unix.go
@@ -1,0 +1,5 @@
+//go:build !windows
+
+package cmd
+
+func canSymlink() bool { return true }

--- a/cmd/install_symlink_windows.go
+++ b/cmd/install_symlink_windows.go
@@ -1,0 +1,5 @@
+//go:build windows
+
+package cmd
+
+func canSymlink() bool { return false }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,7 +84,7 @@ func init() {
 func launchTUI() error {
 	var (
 		store       *state.Store
-		daemonRepo  *wcDaemon.DaemonRepository
+		daemonRepo  *wcDaemon.Repository
 		worktreeDir string
 	)
 
@@ -122,7 +122,7 @@ func launchTUI() error {
 	if worktreeDir != "" {
 		wolfcastleDir := filepath.Join(worktreeDir, ".wolfcastle")
 		if info, statErr := os.Stat(wolfcastleDir); statErr == nil && info.IsDir() {
-			daemonRepo = wcDaemon.NewDaemonRepository(wolfcastleDir)
+			daemonRepo = wcDaemon.NewRepository(wolfcastleDir)
 
 			// Try full app init for Store access. Failure is non-fatal;
 			// the TUI runs in cold-start mode without node data.

--- a/cmd/unblock.go
+++ b/cmd/unblock.go
@@ -170,7 +170,7 @@ func runInteractiveUnblockWith(ctx context.Context, taskAddr, diagnostic string,
 		return fmt.Errorf("unblock model %q not found in config. Add it to the models section of your config or set unblock.model to an existing model name (see 'wolfcastle config show models')", cfg.Unblock.Model)
 	}
 
-	invokeFn := invoke.InvokeSimple
+	invokeFn := invoke.Simple
 	var rlStdin io.ReadCloser
 	var rlStdout io.Writer
 	if opts != nil {

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,8 +16,8 @@ Start here if you want to modify Wolfcastle.
 
 ## [Architecture Decisions](decisions/)
 
-100 ADRs documenting every major design choice. Each records the context, decision, and consequences so future contributors understand why the system is built the way it is. ADRs are the authoritative source; specs defer to them on conflict.
+101 ADRs documenting every major design choice. Each records the context, decision, and consequences so future contributors understand why the system is built the way it is. ADRs are the authoritative source; specs defer to them on conflict.
 
 ## [Specifications](specs/)
 
-44 living specs that describe the current system in detail: state machine, config schema, tree addressing, pipeline contracts, audit propagation, archive format, CLI commands, validation engine, CI/CD, testing, and more. Specs track implementation, not aspirations.
+45 living specs that describe the current system in detail: state machine, config schema, tree addressing, pipeline contracts, audit propagation, archive format, CLI commands, validation engine, CI/CD, testing, and more. Specs track implementation, not aspirations.

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -15,14 +15,17 @@ wolfcastle/
 │   ├── knowledge/           # add, show, edit, prune
 │   ├── project/             # create
 │   ├── orchestrator/        # criteria (planning pipeline support)
-│   └── task/                # add, amend, claim, complete, block, unblock, deliverable
+│   ├── task/                # add, amend, claim, complete, block, unblock, deliverable
+│   └── tui/                 # TUI launch command
 ├── internal/                # Core logic (not importable outside the module)
 │   ├── archive/             # Archive entry rollup (Markdown generation)
 │   ├── clock/               # Time abstraction for deterministic testing (ADR-052)
 │   ├── config/              # Config loading, merging, validation, types
 │   ├── daemon/              # Daemon loop, pipeline execution, marker parsing
 │   ├── errors/              # Typed error categories (ADR-065)
+│   ├── fsutil/              # Filesystem helpers (atomic writes, path resolution)
 │   ├── git/                 # Git operations behind Provider interface
+│   ├── instance/            # Per-worktree instance registry and routing (ADR-099, ADR-100)
 │   ├── invoke/              # Model CLI invocation (buffered + streaming)
 │   ├── knowledge/           # Per-namespace codebase knowledge files
 │   ├── logging/             # Per-iteration NDJSON logging
@@ -36,9 +39,10 @@ wolfcastle/
 │   ├── testutil/            # Shared test helpers
 │   ├── tierfs/              # Three-tier file resolution (ADR-063)
 │   ├── tree/                # Tree addressing, slug generation, resolver
+│   ├── tui/                 # TUI application (Bubbletea v2 models and views)
 │   └── validate/            # Structural validation engine and auto-fix
 ├── docs/
-│   ├── decisions/           # ADRs (001-097)
+│   ├── decisions/           # ADRs (001-101)
 │   ├── specs/               # Implementation specs (timestamped)
 │   └── agents/              # This directory (agent guidance)
 └── Makefile
@@ -86,7 +90,8 @@ User input → cmd/ → internal/ → filesystem (.wolfcastle/)
 
 Dependencies flow strictly downward. `cmd/` imports `internal/`, but `internal/` packages never import `cmd/`. Within `internal/`, the dependency graph is:
 
-- `daemon` → `archive`, `clock`, `config`, `errors`, `git`, `invoke`, `knowledge`, `logging`, `output`, `pipeline`, `signals`, `state`, `tree`
+- `tui` → `config`, `daemon`, `instance`, `logging`, `logrender`, `output`, `state`, `tree`
+- `daemon` → `archive`, `clock`, `config`, `errors`, `git`, `instance`, `invoke`, `knowledge`, `logging`, `output`, `pipeline`, `signals`, `state`, `tree`
 - `validate` → `config`, `invoke`, `pipeline`, `state`, `tree`
 - `pipeline` → `config`, `invoke`, `knowledge`, `state`, `tierfs`
 - `archive` → `clock`, `config`, `state`
@@ -104,4 +109,6 @@ Dependencies flow strictly downward. `cmd/` imports `internal/`, but `internal/`
 - `tierfs` → (standalone)
 - `signals` → (standalone)
 - `output` → (standalone)
+- `instance` → `config` (ADR-099, ADR-100)
+- `fsutil` → (standalone)
 - `errors` → (standalone)

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -16,7 +16,6 @@ wolfcastle/
 │   ├── project/             # create
 │   ├── orchestrator/        # criteria (planning pipeline support)
 │   ├── task/                # add, amend, claim, complete, block, unblock, deliverable
-│   └── tui/                 # TUI launch command
 ├── internal/                # Core logic (not importable outside the module)
 │   ├── archive/             # Archive entry rollup (Markdown generation)
 │   ├── clock/               # Time abstraction for deterministic testing (ADR-052)
@@ -90,7 +89,7 @@ User input → cmd/ → internal/ → filesystem (.wolfcastle/)
 
 Dependencies flow strictly downward. `cmd/` imports `internal/`, but `internal/` packages never import `cmd/`. Within `internal/`, the dependency graph is:
 
-- `tui` → `config`, `daemon`, `instance`, `logging`, `logrender`, `output`, `state`, `tree`
+- `tui` → `config`, `daemon`, `instance`, `logging`, `logrender`, `pipeline`, `project`, `state`
 - `daemon` → `archive`, `clock`, `config`, `errors`, `git`, `instance`, `invoke`, `knowledge`, `logging`, `output`, `pipeline`, `signals`, `state`, `tree`
 - `validate` → `config`, `invoke`, `pipeline`, `state`, `tree`
 - `pipeline` → `config`, `invoke`, `knowledge`, `state`, `tierfs`

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -102,3 +102,4 @@
 | 098 | [Per-Worktree Daemon Lock](098-per-worktree-daemon-lock.md) | Accepted | 2026-04-06 |
 | 099 | [File-Per-Instance Registry](099-instance-registry.md) | Accepted | 2026-04-06 |
 | 100 | [CWD-Based Instance Routing](100-cwd-instance-routing.md) | Accepted | 2026-04-06 |
+| 101 | [Vendor All Dependencies](101-vendor-dependencies.md) | Accepted | 2026-04-06 |

--- a/docs/humans/README.md
+++ b/docs/humans/README.md
@@ -2,11 +2,15 @@
 
 The field manual. Everything you need to operate the weapon.
 
-Start with [How It Works](how-it-works.md) if you want the full picture. Start with the [CLI Reference](cli.md) if you want to hit things.
+Start with the [TUI Guide](the-tui.md) to learn the interface. Start with [How It Works](how-it-works.md) if you want the full picture.
+
+## [TUI Guide](the-tui.md)
+
+The primary interface. Launching, navigation, keybindings, and every screen explained. Bare `wolfcastle` opens the TUI; everything the daemon does is visible here in real time.
 
 ## [How It Works](how-it-works.md)
 
-The core of the machine. Work enters through your coding agent, the inbox, or direct CLI commands. It lands in a project tree built from orchestrator nodes (containers) and leaf nodes (where tasks live). A daemon runs a pipeline of stages in a loop, each invoking a model with a specific role. When a model executes a task, it follows a ten-phase protocol and communicates only through deterministic script calls. State is JSON on disk, propagates upward from children to parents, and every mutation is atomic.
+The core of the machine. Work enters through your coding agent, the inbox, or direct CLI commands. It lands in a project tree built from orchestrator nodes (containers) and leaf nodes (where tasks live). A daemon runs a pipeline of stages in a loop, each invoking a model with a specific role. When a model executes a task, it follows a nine-phase protocol and communicates only through deterministic script calls. State is JSON on disk, propagates upward from children to parents, and every mutation is atomic.
 
 ## [Configuration Quickstart](config-quickstart.md)
 
@@ -34,7 +38,7 @@ Every leaf gets verified by an automatic audit task that reviews breadcrumbs aga
 
 ## [Parallel Execution](parallel-execution.md)
 
-Run multiple tasks concurrently with file-level scope locks. Configure the worker pool, monitor active workers and scope conflicts through `wolfcastle status`, and diagnose contention when tasks keep yielding on the same files.
+Run multiple tasks concurrently with file-level scope locks. Configure the worker pool, monitor active workers and scope conflicts through the TUI dashboard or `wolfcastle status`, and diagnose contention when tasks keep yielding on the same files.
 
 ## [Collaboration](collaboration.md)
 
@@ -42,4 +46,4 @@ Each engineer gets their own namespace under `.wolfcastle/system/projects/`. No 
 
 ## [CLI Reference](cli.md)
 
-63 commands across lifecycle, task management, auditing, diagnostics, and documentation. Every command accepts `--json` and `--node` for tree addressing. Covers the inbox, installation channels, project directory layout, and new engineer setup.
+63 commands for scripting, automation, and agent integration. Every command accepts `--json` and `--node` for tree addressing. Covers the inbox, installation channels, project directory layout, and new engineer setup.

--- a/docs/humans/audits.md
+++ b/docs/humans/audits.md
@@ -4,6 +4,8 @@
 
 Every [leaf](how-it-works.md#the-project-tree) ends with an audit task. Auto-created. Cannot be moved. Cannot be deleted. Runs last, after every other task in the leaf has completed. Its job: verify that the work actually happened and actually works.
 
+Audit state is visible in the [TUI](the-tui.md) node detail view: press `Enter` on any node in the tree to see its audit status glyph, breadcrumb count, gap and escalation counts, and result summary when the audit is finished. The [dashboard](the-tui.md#the-dashboard) also shows an aggregate audit summary across the entire project.
+
 ### Breadcrumbs
 
 As tasks execute, they write timestamped breadcrumbs via `wolfcastle audit breadcrumb` (during the [record phase](how-it-works.md#execution-protocol) of execution). Each breadcrumb describes what was done, why, and what changed. These are not terse commit messages. They are rich, explanatory records: the raw material for verification.

--- a/docs/humans/collaboration.md
+++ b/docs/humans/collaboration.md
@@ -13,7 +13,7 @@ Multiple engineers work on the same repo simultaneously. No merge conflicts. No 
 
 Each engineer reads and writes only their own namespace. Everyone can see everyone else's work (the `projects/` directory is committed), but nobody steps on anyone else's [state](how-it-works.md#distributed-state).
 
-[`wolfcastle status`](cli.md#commands) shows your tree. `wolfcastle status --all` aggregates across all engineers at runtime. No shared index file. No merge conflicts.
+The [TUI](the-tui.md) header shows all running instances as tabs. Press `<` or `>` to switch between them, or `1`-`9` to jump directly. The [welcome screen](the-tui.md#the-welcome-screen) lists all active sessions across your machine, letting you reconnect to any of them. From the command line, [`wolfcastle status`](cli.md#commands) shows your tree and `wolfcastle status --all` aggregates across all engineers at runtime. No shared index file. No merge conflicts.
 
 ### Overlap Advisory
 

--- a/docs/humans/configuration.md
+++ b/docs/humans/configuration.md
@@ -52,7 +52,11 @@ Each tier has the same internal layout. The resolution order, from lowest to hig
 
 **custom/** is where your team puts shared configuration: model definitions, pipeline tweaks, validation commands, custom class prompts. Because it's committed, everyone on the team gets the same settings. Code review applies here just as it does to application code.
 
-**local/** is yours alone. Identity (username and machine) lives here automatically after `init`. Personal model overrides, experimental prompt tweaks, looser permissions for your own workflow, anything you wouldn't commit but need for your environment.
+**local/** is yours alone. Personal model overrides, experimental prompt tweaks, looser permissions for your own workflow, anything you wouldn't commit but need for your environment.
+
+### Identity
+
+Identity (username and machine) lives in `local/config.json` automatically after `wolfcastle init`. The identity fields tell the daemon which engineer namespace to use and which machine name to stamp on commits and logs. These are set once during init and rarely touched afterward.
 
 ### Prompt and Rule Resolution
 

--- a/docs/humans/failure-and-recovery.md
+++ b/docs/humans/failure-and-recovery.md
@@ -4,6 +4,8 @@
 
 Tasks fail. Wolfcastle does not take it personally. It takes it systematically.
 
+In the [TUI](the-tui.md), blocked tasks show the `☢` glyph in the tree. Toast notifications announce auto-blocks as they happen. Press `Enter` on a blocked task to see the block reason, failure count, and last failure type in the [task detail](the-tui.md#task-detail) view.
+
 Each task tracks a failure counter. All thresholds are [configurable](config-reference.md#failure):
 
 | Failures | Depth OK | Action |

--- a/docs/humans/how-it-works.md
+++ b/docs/humans/how-it-works.md
@@ -4,9 +4,11 @@
 
 The most common path: you tell your coding agent what you want done. "Add OAuth2 PKCE support to the auth service." You go back and forth with the agent, refining scope, adding constraints, clarifying how you want things structured, until the plan feels right. Then the agent uses Wolfcastle's [CLI](cli.md) to inject the work, decompose it into tasks, and start [the daemon](#the-daemon). Wolfcastle handles the orchestration from there.
 
+The quickest path for humans at a keyboard: open the [TUI](the-tui.md) inbox (`i`), press `a`, and type your idea. The daemon's intake stage picks it up from there.
+
 When you want direct control, the CLI has you covered:
 
-**The inbox** is for quick capture. `wolfcastle inbox add "support OAuth2 PKCE"` drops an item into a queue. The daemon's [intake stage](#the-pipeline) picks it up in a background goroutine, uses a model to create projects and tasks directly in the tree. You throw an idea at Wolfcastle. It figures out the rest. ([More on the inbox.](cli.md#the-inbox))
+**The inbox** is for quick capture. In the TUI, press `i` to open the inbox modal, then `a` to add an item. From the command line, `wolfcastle inbox add "support OAuth2 PKCE"` drops an item into a queue. The daemon's [intake stage](#the-pipeline) picks it up in a background goroutine, uses a model to create projects and tasks directly in the tree. You throw an idea at Wolfcastle. It figures out the rest. ([More on the inbox.](cli.md#the-inbox))
 
 **Project creation** is for structured planning. `wolfcastle project create --node backend/auth` creates an orchestrator or leaf node at a specific point in the tree. You define the shape of the work; the daemon fills in the tasks, or you add them manually.
 
@@ -105,7 +107,7 @@ When a root-level project completes, the daemon can automatically archive it. Au
 
 ## The Daemon
 
-`wolfcastle start` launches the daemon. It owns the pipeline loop.
+Press `s` in the [TUI](the-tui.md) to start the daemon, or launch it from the command line:
 
 ```
 wolfcastle start                          # foreground
@@ -113,6 +115,8 @@ wolfcastle start -d                       # background
 wolfcastle start --node backend/auth      # scoped to a subtree
 wolfcastle start --worktree feature/auth  # isolated git worktree
 ```
+
+The TUI dashboard shows daemon status, current target, and progress in real time. `wolfcastle status` provides the same information from the command line.
 
 Each iteration walks the [configured pipeline stages](configuration.md#pipeline-stages), invokes [models](configuration.md#model-configuration), and advances the tree. Between iterations, it checks for stop signals. On SIGTERM or SIGINT, it finishes the current stage, cleans up child processes, and shuts down. It does not leave a mess.
 

--- a/docs/humans/parallel-execution.md
+++ b/docs/humans/parallel-execution.md
@@ -37,7 +37,7 @@ A yielded task is reset to `not_started` and becomes eligible for re-dispatch on
 
 ## Worker Status
 
-Run `wolfcastle status` to see the worker pool while the daemon is running. The parallel section appears below the daemon line and shows active workers, their scope locks, and any yielded tasks waiting on scope. See [status](cli/status.md) for the full output format.
+The [TUI dashboard](the-tui.md#the-dashboard) shows the current target and progress for all active workers in real time. From the command line, run `wolfcastle status` to see the worker pool while the daemon is running. The parallel section appears below the daemon line and shows active workers, their scope locks, and any yielded tasks waiting on scope. See [status](cli/status.md) for the full output format.
 
 ## Failure Handling
 
@@ -51,4 +51,4 @@ On daemon startup, `selfHeal` cleans up stale scope locks left by a previous cra
 
 Parallel mode is most effective when your project tree has multiple independent leaf nodes with non-overlapping scope. A project with three modules that each touch different directories will see near-linear speedup at `max_workers: 3`.
 
-It is less useful when tasks frequently overlap in scope, since the yield-and-retry overhead can approach serial execution time. The yield tracking in `wolfcastle status` helps you diagnose this: if you see the same tasks yielding repeatedly, consider restructuring the task tree to reduce file contention.
+It is less useful when tasks frequently overlap in scope, since the yield-and-retry overhead can approach serial execution time. The yield tracking in the TUI dashboard and `wolfcastle status` helps you diagnose this: if you see the same tasks yielding repeatedly, consider restructuring the task tree to reduce file contention.

--- a/docs/humans/task-classes.md
+++ b/docs/humans/task-classes.md
@@ -2,7 +2,7 @@
 
 Task classes are behavioral prompts that shape how the execution agent approaches work. A Go coding task calls for different instincts than a security review or a research pass, and classes encode that difference. When a task carries a class, the agent receives a class-specific prompt that tells it how to think about the problem: what idioms to follow, what tools to reach for, what quality standards to enforce.
 
-Classes do not restrict capabilities. A `coding/go` task can still search the web. A `research` task can still write files. The prompt shapes the agent's priorities and judgment; it does not gate its toolbox. Terminal markers, deliverable verification, and state transitions all work identically regardless of class.
+Classes do not restrict capabilities. A `coding/go` task can still search the web. A `research` task can still write files. The prompt shapes the agent's priorities and judgment; it does not gate its toolbox. Terminal markers, deliverable verification, and state transitions all work identically regardless of class. A task's class is visible in the [TUI task detail](the-tui.md#task-detail) view (press `Enter` on a task in the tree).
 
 Every task receives two layers of guidance:
 

--- a/docs/humans/the-tui.md
+++ b/docs/humans/the-tui.md
@@ -32,7 +32,7 @@ The welcome screen is a launcher. Once you select a session or navigate into an 
 |-----|--------|
 | `j` / `↓` | Move down |
 | `k` / `↑` | Move up |
-| `Enter` / `l` | Select session or navigate into directory |
+| `Enter` / `l` / `→` | Select session or navigate into directory |
 | `h` / `←` / `Backspace` | Go up one directory |
 | `g` | Jump to top |
 | `G` | Jump to bottom |
@@ -367,7 +367,7 @@ The complete set, organized by context. Press `?` to see this in the TUI itself.
 |-----|--------|
 | `j` / `↓` | Move down |
 | `k` / `↑` | Move up |
-| `Enter` / `l` | Select / navigate into |
+| `Enter` / `l` / `→` | Select / navigate into |
 | `h` / `←` / `Backspace` | Go up one level |
 | `g` | Jump to top |
 | `G` | Jump to bottom |

--- a/docs/humans/the-tui.md
+++ b/docs/humans/the-tui.md
@@ -1,0 +1,376 @@
+# The TUI
+
+Bare `wolfcastle` launches the terminal interface. No subcommands, no flags. The TUI is the primary way to operate Wolfcastle: watching work unfold, feeding the inbox, starting and stopping daemons, navigating the project tree. Everything the daemon does is visible here in real time.
+
+The [CLI](cli.md) remains available for scripting, automation, and agent integration. Anything you can see in the TUI, you can query from the command line. The TUI is for humans at a keyboard.
+
+![Wolfcastle TUI](../assets/screenshots/tui-full-layout.png)
+
+## Launching
+
+The TUI opens in one of three states depending on the project directory:
+
+| State | Condition | What you see |
+|-------|-----------|--------------|
+| **Live** | `.wolfcastle/` exists, daemon running | Tree pane, dashboard, live updates |
+| **Cold** | `.wolfcastle/` exists, no daemon | Tree pane, dashboard (static), daemon controls |
+| **Welcome** | No `.wolfcastle/` directory | Session browser and directory navigator |
+
+If you run `wolfcastle` inside an initialized project with a running daemon, you land in the live view immediately. If the daemon isn't running, you get the same layout but static, with the option to start one. Outside any project, the welcome screen helps you find or create one.
+
+## The Welcome Screen
+
+![Welcome screen](../assets/screenshots/tui-welcome-sessions.png)
+
+Two panels, side by side. The left panel lists running Wolfcastle sessions across your machine: any daemon that's alive shows up here with its branch and directory. The right panel is a directory browser rooted at your current location.
+
+`Tab` switches focus between panels. `j`/`k` move the cursor within whichever panel is focused. In the directory browser, `Enter` or `l` navigates into a directory, `h` goes up a level. If the selected directory contains a `.wolfcastle/` project, pressing `Enter` connects to it. `I` initializes a new project in the current directory.
+
+The welcome screen is a launcher. Once you select a session or navigate into an initialized project, the TUI transitions to the live or cold state and the welcome screen disappears.
+
+| Key | Action |
+|-----|--------|
+| `j` / `↓` | Move down |
+| `k` / `↑` | Move up |
+| `Enter` / `l` | Select session or navigate into directory |
+| `h` / `←` / `Backspace` | Go up one directory |
+| `g` | Jump to top |
+| `G` | Jump to bottom |
+| `Tab` | Switch panel focus |
+| `I` | Initialize project in current directory |
+| `q` | Quit |
+
+## Layout
+
+The main interface is a four-part layout:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Header: version │ daemon status │ node counts │ tabs    │
+├──────────────┬──────────────────────────────────────────┤
+│              │                                          │
+│  Tree pane   │            Detail pane                   │
+│              │                                          │
+│              │  (dashboard, node detail, task detail,   │
+│              │   inbox modal, log modal)                │
+│              │                                          │
+├──────────────┴──────────────────────────────────────────┤
+│ Footer: key hints                                       │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Header** shows the Wolfcastle version, daemon status (running/stopped, branch, uptime), node counts by state, audit summary, and instance tabs when multiple daemons are active. A braille spinner animates while the daemon is running.
+
+**Tree pane** on the left displays the project tree. Orchestrators and leaves, expandable and collapsible, with status glyphs showing progress at a glance.
+
+**Detail pane** on the right shows context for whatever is selected: the dashboard when nothing specific is focused, node or task detail when you drill in.
+
+**Footer** is a single line of key hints that updates based on the current focus and mode.
+
+`Tab` cycles focus between the tree pane and detail pane. `t` toggles the tree pane's visibility entirely, giving the detail pane the full width.
+
+## The Tree
+
+![Tree pane](../assets/screenshots/tui-tree-expanded.png)
+
+The tree pane renders the project hierarchy with status glyphs, expand/collapse indicators, and a cursor.
+
+### Status Glyphs
+
+| Glyph | Color | Meaning |
+|-------|-------|---------|
+| `●` | Green | Complete |
+| `◐` | Yellow | In progress |
+| `◯` | Dim | Not started |
+| `☢` | Red | Blocked |
+
+Tasks that are in progress show `→` (yellow arrow) instead of `◐`, matching the daemon's status output.
+
+### Visual Indicators
+
+- `▾` before a node name means it's expanded (children visible)
+- `▸` means collapsed (children hidden)
+- `▶` (bright yellow) marks the current target: the task the daemon is actively working on
+- Selected rows get a dark red background
+- Ancestor nodes of search matches get a muted olive background
+
+### Navigation
+
+| Key | Action |
+|-----|--------|
+| `j` / `↓` | Move down |
+| `k` / `↑` | Move up |
+| `Enter` / `l` / `→` | Expand node, or view detail if already expanded |
+| `Esc` / `h` / `←` | Collapse node, or go back to parent |
+| `g` | Jump to top |
+| `G` | Jump to bottom |
+
+`Enter` on an orchestrator expands it to show children. `Enter` on an expanded orchestrator or a leaf opens its detail view in the right pane. `Esc` reverses the last expansion or, if viewing a detail, returns to the dashboard.
+
+## The Dashboard
+
+![Dashboard](../assets/screenshots/tui-dashboard-active.png)
+
+Press `d` from anywhere to return to the dashboard. It's the default detail view, the mission briefing.
+
+The dashboard shows:
+
+- **Daemon status**: running or stopped, current branch, uptime
+- **Current target**: the node address the daemon is actively working on
+- **Progress bars**: per-status counts (complete, in progress, not started, blocked) rendered as a horizontal bar with numeric labels
+- **Inbox summary**: count of new and filed items
+- **Recent activity**: the last 10 milestone events with timestamps (task completions, audit results, blocks, decompositions)
+- **Audit summary**: passed/in-progress/pending counts, gap counts, escalation counts
+
+Two terminal states replace the normal dashboard content:
+
+- **"All targets eliminated"** when every node in the tree is complete
+- **"Blocked on all fronts. Human intervention required."** when every remaining node is blocked
+
+![All complete](../assets/screenshots/tui-all-complete.png)
+![All blocked](../assets/screenshots/tui-all-blocked.png)
+
+## Node Detail
+
+![Node detail](../assets/screenshots/tui-node-detail.png)
+
+Press `Enter` on a tree node to open its detail view. The header shows the node name with its status glyph, node type (orchestrator or leaf), and address.
+
+The detail includes:
+
+- **Scope**: the files and directories this node covers
+- **Success criteria**: what "done" means for this node
+- **Children** (orchestrators): a list of child nodes with their states
+- **Tasks** (leaves): the task list with per-task status glyphs
+- **Audit section**: audit status glyph, started/completed timestamps, breadcrumb count, gap count, escalation count, and a result summary when the audit is finished
+- **Specs**: linked specification files
+
+The view scrolls if the content exceeds the terminal height.
+
+## Task Detail
+
+![Task detail](../assets/screenshots/tui-task-detail.png)
+
+Press `Enter` on a task row within a node detail to see the full task. The header shows the task ID with its status glyph.
+
+Fields displayed:
+
+- **Title** and **description**
+- **Body**: the full task specification
+- **Class**: the [task class](task-classes.md) (e.g., `coding/go`, `research`)
+- **Type**: the task type
+- **Deliverables**: what the task should produce
+- **Acceptance criteria**: how completion is verified
+- **Constraints**: any limitations on the approach
+- **References**: linked files, ADRs, specs
+
+When the task is blocked:
+
+- **Block reason**: why the task cannot proceed
+- **Failure count**: how many times execution has failed
+- **Last failure type**: the most recent failure classification
+- **Needs decomposition**: whether the task has hit the decomposition threshold
+- **Is audit**: whether this is an audit task
+
+![Blocked task](../assets/screenshots/tui-task-blocked.png)
+
+## The Inbox
+
+![Inbox modal](../assets/screenshots/tui-inbox-modal.png)
+
+Press `i` to open the inbox modal. The inbox is a list of items you've submitted for the daemon to triage. Each item shows a glyph (`○` for new, `●` for filed), a status label, and a relative timestamp.
+
+`j`/`k` navigate the list. Press `a` to add a new item: a text input appears at the bottom of the modal. Type your idea and press `Enter` to submit it. `Esc` cancels the input if you change your mind, or closes the modal entirely if no input is active.
+
+![Inbox input](../assets/screenshots/tui-inbox-input.png)
+
+The inbox is the fastest path from thought to task. Type a sentence, hit Enter, and the daemon's intake stage picks it up, decomposes it into projects and tasks, and files them into the tree. You can also add items from the CLI with `wolfcastle inbox add`.
+
+| Key | Action |
+|-----|--------|
+| `i` | Open inbox |
+| `j` / `↓` | Move down |
+| `k` / `↑` | Move up |
+| `a` | Add new item (opens text input) |
+| `Enter` | Submit new item |
+| `Esc` | Cancel input, or close modal |
+
+## The Log Stream
+
+![Log stream](../assets/screenshots/tui-log-modal.png)
+
+Press `L` (capital) to open the log stream modal. This is a live, scrollable, filterable view of the daemon's log output.
+
+The header bar shows three indicators:
+
+- **Level filter**: which log levels are visible (all, debug, info, warn, error)
+- **Trace filter**: which traces are visible (all, exec, intake)
+- **Follow indicator**: `[following]` (green) when auto-scrolling to new output, `[paused]` (yellow) when you've scrolled up manually
+
+The log stream maintains a circular buffer of up to 10,000 lines. When log files rotate between daemon iterations, a visual separator (`── iteration N ──`) appears in the stream so you can see where one run ends and the next begins.
+
+![Filtered logs](../assets/screenshots/tui-log-filtered.png)
+
+| Key | Action |
+|-----|--------|
+| `L` | Open log stream / cycle level filter (all → debug → info → warn → error) |
+| `T` | Cycle trace filter (all → exec → intake) |
+| `f` | Toggle follow mode |
+| `j` / `↓` | Scroll down |
+| `k` / `↑` | Scroll up |
+| `g` | Jump to top |
+| `G` | Jump to bottom |
+| `Ctrl+D` | Half page down |
+| `Ctrl+U` | Half page up |
+| `Esc` | Close modal |
+
+Scrolling manually pauses follow mode. Press `f` to re-enable it, or `G` to jump to the bottom (which also re-enables follow).
+
+## Daemon Control
+
+![Start daemon](../assets/screenshots/tui-daemon-start.png)
+
+Press `s` to open the daemon control modal. If no daemon is running, the modal offers to start one. If a daemon is running, it offers to stop it. The modal shows contextual information: current branch, worktree path, and (when stopping) the daemon's PID and whether it's draining.
+
+`Enter` confirms the action. `Esc` cancels without doing anything.
+
+`S` (capital) stops all running daemons across all instances. Use this when you want a clean shutdown of everything.
+
+![Stop daemon](../assets/screenshots/tui-daemon-stop.png)
+
+| Key | Action |
+|-----|--------|
+| `s` | Start/stop daemon (opens confirmation modal) |
+| `S` | Stop all daemons |
+| `Enter` | Confirm |
+| `Esc` | Cancel |
+
+## Instance Switching
+
+![Multiple instances](../assets/screenshots/tui-multi-instance.png)
+
+When multiple Wolfcastle daemons are running (different branches, different worktrees), the header bar shows each as a tab. The active instance is highlighted.
+
+`<` and `>` cycle through instances. `1` through `9` jump directly to an instance by position. The tree pane, dashboard, and all detail views update to reflect the selected instance.
+
+| Key | Action |
+|-----|--------|
+| `<` | Previous instance |
+| `>` | Next instance |
+| `1`-`9` | Select instance by index |
+
+## Search
+
+![Search](../assets/screenshots/tui-search-active.png)
+
+Press `/` to activate the search bar at the bottom of the screen. Type a query and press `Enter` to search the tree. `Esc` dismisses the search bar without searching.
+
+Matches highlight in yellow. Ancestor nodes of matching nodes (nodes that contain a match deeper in the tree) get a muted olive background, so you can trace the path from root to match. These highlights are address-keyed: they survive expand and collapse operations.
+
+`n` moves to the next match, `N` moves to the previous match. The cursor jumps to each match in the tree.
+
+| Key | Action |
+|-----|--------|
+| `/` | Open search bar |
+| `Enter` | Confirm search |
+| `Esc` | Cancel search |
+| `n` | Next match |
+| `N` | Previous match |
+
+## Notifications
+
+![Toast notification](../assets/screenshots/tui-toast.png)
+
+Toast notifications appear in the upper right corner of the terminal. They announce events: task completions, blocks, audit results, daemon state changes. Each toast auto-dismisses after 3 seconds. Up to 5 toasts can stack. Long text is front-truncated to keep the meaningful part visible, with a maximum width of 60 characters.
+
+Notifications are informational. They don't require interaction and won't block your workflow.
+
+## Keybinding Reference
+
+The complete set, organized by context. Press `?` to see this in the TUI itself.
+
+![Help overlay](../assets/screenshots/tui-help-overlay.png)
+
+### Global
+
+| Key | Action |
+|-----|--------|
+| `q` | Quit |
+| `Ctrl+C` | Quit |
+| `d` | Dashboard |
+| `L` | Log stream (modal) |
+| `i` | Inbox (modal) |
+| `t` | Toggle tree |
+| `Tab` | Cycle focus |
+| `R` | Refresh |
+| `?` | Help |
+| `/` | Search |
+| `y` | Copy address |
+
+### Tree Navigation
+
+| Key | Action |
+|-----|--------|
+| `j` / `↓` | Move down |
+| `k` / `↑` | Move up |
+| `Enter` / `l` / `→` | Expand / view detail |
+| `Esc` / `h` / `←` | Collapse / back |
+| `g` | Jump to top |
+| `G` | Jump to bottom |
+
+### Daemon Control
+
+| Key | Action |
+|-----|--------|
+| `s` | Start/stop daemon (modal) |
+| `S` | Stop all daemons |
+| `<` `>` | Switch instance |
+| `1`-`9` | Select instance |
+
+### Inbox
+
+| Key | Action |
+|-----|--------|
+| `i` | Open inbox |
+| `a` | Add item |
+| `Enter` | Submit |
+| `Esc` | Cancel |
+
+### Log Stream
+
+| Key | Action |
+|-----|--------|
+| `L` | Open log stream |
+| `j` / `↓` | Scroll down |
+| `k` / `↑` | Scroll up |
+| `g` | Jump to top |
+| `G` | Jump to bottom |
+| `f` | Toggle follow |
+| `L` | Cycle level filter (all → debug → info → warn → error) |
+| `T` | Cycle trace filter (all → exec → intake) |
+| `Ctrl+D` | Half page down |
+| `Ctrl+U` | Half page up |
+
+### Search
+
+| Key | Action |
+|-----|--------|
+| `/` | Start search |
+| `Enter` | Confirm search |
+| `Esc` | Cancel search |
+| `n` | Next match |
+| `N` | Previous match |
+
+### Welcome Screen
+
+| Key | Action |
+|-----|--------|
+| `j` / `↓` | Move down |
+| `k` / `↑` | Move up |
+| `Enter` / `l` | Select / navigate into |
+| `h` / `←` / `Backspace` | Go up one level |
+| `g` | Jump to top |
+| `G` | Jump to bottom |
+| `Tab` | Switch panel focus |
+| `I` | Initialize project |
+| `q` | Quit |

--- a/docs/specs/2026-04-06T01-00Z-tui-v01.md
+++ b/docs/specs/2026-04-06T01-00Z-tui-v01.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft
+Accepted
 
 ## Supersedes
 

--- a/internal/daemon/activity.go
+++ b/internal/daemon/activity.go
@@ -47,7 +47,7 @@ func (d *Daemon) removeActivityFile() {
 
 // activityPath returns the path to the daemon activity snapshot file.
 func activityPath(wolfcastleDir string) string {
-	return filepath.Join(NewDaemonRepository(wolfcastleDir).systemDir, "daemon-activity.json")
+	return filepath.Join(NewRepository(wolfcastleDir).systemDir, "daemon-activity.json")
 }
 
 // LoadDaemonActivity reads the daemon activity snapshot from disk.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -105,9 +105,9 @@ func (d *Daemon) logInbox(record map[string]any) {
 	}
 }
 
-// repo returns a DaemonRepository for the daemon's wolfcastle directory.
-func (d *Daemon) repo() *DaemonRepository {
-	return NewDaemonRepository(d.WolfcastleDir)
+// repo returns a Repository for the daemon's wolfcastle directory.
+func (d *Daemon) repo() *Repository {
+	return NewRepository(d.WolfcastleDir)
 }
 
 // namespace derives the engineer namespace from the daemon's config identity.
@@ -122,7 +122,7 @@ func (d *Daemon) namespace() string {
 
 // New creates a new daemon.
 func New(cfg *config.Config, wolfcastleDir string, store *state.Store, scopeNode string, repoDir string) (*Daemon, error) {
-	logDir := NewDaemonRepository(wolfcastleDir).LogDir()
+	logDir := NewRepository(wolfcastleDir).LogDir()
 	logger, err := logging.NewLogger(logDir)
 	if err != nil {
 		return nil, err

--- a/internal/daemon/drain_test.go
+++ b/internal/daemon/drain_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // ═══════════════════════════════════════════════════════════════════════════
-// DaemonRepository drain file operations
+// Repository drain file operations
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestDrainFile_WriteHasRemove(t *testing.T) {

--- a/internal/daemon/parallel.go
+++ b/internal/daemon/parallel.go
@@ -669,7 +669,7 @@ func (pd *ParallelDispatcher) removeStatusFile() {
 
 // parallelStatusPath returns the path to the parallel status snapshot file.
 func parallelStatusPath(wolfcastleDir string) string {
-	return filepath.Join(NewDaemonRepository(wolfcastleDir).systemDir, "parallel-status.json")
+	return filepath.Join(NewRepository(wolfcastleDir).systemDir, "parallel-status.json")
 }
 
 // LoadParallelStatus reads the parallel status snapshot from disk.

--- a/internal/daemon/repository.go
+++ b/internal/daemon/repository.go
@@ -9,39 +9,39 @@ import (
 	"github.com/dorkusprime/wolfcastle/internal/tierfs"
 )
 
-// DaemonRepository consolidates all filesystem operations the daemon
+// Repository consolidates all filesystem operations the daemon
 // performs against its system directory. Every path the daemon touches
 // (PID file, stop file, log directory) flows through this struct,
 // eliminating scattered filepath.Join constructions.
-type DaemonRepository struct {
+type Repository struct {
 	systemDir string
 }
 
-// NewDaemonRepository creates a DaemonRepository rooted at the given
+// NewRepository creates a Repository rooted at the given
 // wolfcastle directory. All paths are derived from wolfcastleRoot/system.
-func NewDaemonRepository(wolfcastleRoot string) *DaemonRepository {
-	return &DaemonRepository{
+func NewRepository(wolfcastleRoot string) *Repository {
+	return &Repository{
 		systemDir: filepath.Join(wolfcastleRoot, tierfs.SystemPrefix),
 	}
 }
 
-func (r *DaemonRepository) stopPath() string {
+func (r *Repository) stopPath() string {
 	return filepath.Join(r.systemDir, "stop")
 }
 
 // HasStopFile reports whether the stop file exists.
-func (r *DaemonRepository) HasStopFile() bool {
+func (r *Repository) HasStopFile() bool {
 	_, err := os.Stat(r.stopPath())
 	return err == nil
 }
 
 // WriteStopFile creates the stop file (empty, 0644).
-func (r *DaemonRepository) WriteStopFile() error {
+func (r *Repository) WriteStopFile() error {
 	return os.WriteFile(r.stopPath(), nil, 0644)
 }
 
 // RemoveStopFile removes the stop file. Returns nil if the file does not exist.
-func (r *DaemonRepository) RemoveStopFile() error {
+func (r *Repository) RemoveStopFile() error {
 	err := os.Remove(r.stopPath())
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
@@ -50,14 +50,14 @@ func (r *DaemonRepository) RemoveStopFile() error {
 }
 
 // StopFileExists reports whether the stop file exists on disk.
-func (r *DaemonRepository) StopFileExists() bool {
+func (r *Repository) StopFileExists() bool {
 	_, err := os.Stat(r.stopPath())
 	return err == nil
 }
 
 // IsAlive checks the instance registry for a running daemon whose
 // worktree matches this repository's root directory (parent of systemDir).
-func (r *DaemonRepository) IsAlive() bool {
+func (r *Repository) IsAlive() bool {
 	repoDir := filepath.Dir(r.systemDir)
 	entry, err := instance.Resolve(repoDir)
 	if err != nil {
@@ -67,18 +67,18 @@ func (r *DaemonRepository) IsAlive() bool {
 }
 
 // HasDrainFile reports whether the drain file exists.
-func (r *DaemonRepository) HasDrainFile() bool {
+func (r *Repository) HasDrainFile() bool {
 	_, err := os.Stat(r.drainPath())
 	return err == nil
 }
 
 // WriteDrainFile creates the drain file (empty, 0644).
-func (r *DaemonRepository) WriteDrainFile() error {
+func (r *Repository) WriteDrainFile() error {
 	return os.WriteFile(r.drainPath(), nil, 0644)
 }
 
 // RemoveDrainFile removes the drain file. Returns nil if the file does not exist.
-func (r *DaemonRepository) RemoveDrainFile() error {
+func (r *Repository) RemoveDrainFile() error {
 	err := os.Remove(r.drainPath())
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
@@ -86,7 +86,7 @@ func (r *DaemonRepository) RemoveDrainFile() error {
 	return err
 }
 
-func (r *DaemonRepository) drainPath() string {
+func (r *Repository) drainPath() string {
 	return filepath.Join(r.systemDir, "drain")
 }
 
@@ -94,6 +94,6 @@ func (r *DaemonRepository) drainPath() string {
 // intentional escape hatch: the Logger manages its own file handles,
 // rotation, and compression, so it needs the directory path rather
 // than a repository method for each log operation.
-func (r *DaemonRepository) LogDir() string {
+func (r *Repository) LogDir() string {
 	return filepath.Join(r.systemDir, "logs")
 }

--- a/internal/daemon/repository_audit_test.go
+++ b/internal/daemon/repository_audit_test.go
@@ -12,7 +12,7 @@ import (
 func TestStopFileExists_NoFile(t *testing.T) {
 	t.Parallel()
 	env := testutil.NewEnvironment(t)
-	repo := daemon.NewDaemonRepository(env.Root)
+	repo := daemon.NewRepository(env.Root)
 
 	if repo.StopFileExists() {
 		t.Error("StopFileExists: expected false when no stop file exists")
@@ -22,7 +22,7 @@ func TestStopFileExists_NoFile(t *testing.T) {
 func TestStopFileExists_WithFile(t *testing.T) {
 	t.Parallel()
 	env := testutil.NewEnvironment(t)
-	repo := daemon.NewDaemonRepository(env.Root)
+	repo := daemon.NewRepository(env.Root)
 
 	if err := repo.WriteStopFile(); err != nil {
 		t.Fatalf("WriteStopFile: %v", err)
@@ -41,7 +41,7 @@ func TestIsAlive_NoRegistration(t *testing.T) {
 	instance.RegistryDirOverride = regDir
 	defer func() { instance.RegistryDirOverride = old }()
 
-	repo := daemon.NewDaemonRepository(env.Root)
+	repo := daemon.NewRepository(env.Root)
 
 	if repo.IsAlive() {
 		t.Error("IsAlive: expected false when no instance is registered")
@@ -65,7 +65,7 @@ func TestIsAlive_CurrentProcess(t *testing.T) {
 	}
 	defer func() { _ = instance.Deregister(env.Root) }()
 
-	repo := daemon.NewDaemonRepository(env.Root)
+	repo := daemon.NewRepository(env.Root)
 	if !repo.IsAlive() {
 		t.Error("IsAlive: expected true for current process PID")
 	}

--- a/internal/daemon/repository_test.go
+++ b/internal/daemon/repository_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/dorkusprime/wolfcastle/internal/testutil"
 )
 
-func TestDaemonRepository_StopFile(t *testing.T) {
+func TestRepository_StopFile(t *testing.T) {
 	t.Parallel()
 	env := testutil.NewEnvironment(t)
-	repo := daemon.NewDaemonRepository(env.Root)
+	repo := daemon.NewRepository(env.Root)
 
 	if repo.HasStopFile() {
 		t.Error("HasStopFile: expected false before write")
@@ -34,10 +34,10 @@ func TestDaemonRepository_StopFile(t *testing.T) {
 	}
 }
 
-func TestDaemonRepository_LogDir(t *testing.T) {
+func TestRepository_LogDir(t *testing.T) {
 	t.Parallel()
 	env := testutil.NewEnvironment(t)
-	repo := daemon.NewDaemonRepository(env.Root)
+	repo := daemon.NewRepository(env.Root)
 
 	want := filepath.Join(env.Root, "system", "logs")
 	if got := repo.LogDir(); got != want {
@@ -45,10 +45,10 @@ func TestDaemonRepository_LogDir(t *testing.T) {
 	}
 }
 
-func TestDaemonRepository_RemoveStopFile_Idempotent(t *testing.T) {
+func TestRepository_RemoveStopFile_Idempotent(t *testing.T) {
 	t.Parallel()
 	env := testutil.NewEnvironment(t)
-	repo := daemon.NewDaemonRepository(env.Root)
+	repo := daemon.NewRepository(env.Root)
 
 	// No stop file exists; RemoveStopFile should succeed silently.
 	if err := repo.RemoveStopFile(); err != nil {

--- a/internal/invoke/invoker.go
+++ b/internal/invoke/invoker.go
@@ -362,10 +362,10 @@ func detectLineMarker(line string, result *Result) {
 
 // --- Legacy API for backward compatibility ---
 
-// InvokeSimple runs a model CLI command with the given prompt piped to stdin.
+// Simple runs a model CLI command with the given prompt piped to stdin.
 // It captures all output and returns it when the command finishes.
 // This is a convenience wrapper around ProcessInvoker for callers that
 // do not need streaming or line callbacks.
-func InvokeSimple(ctx context.Context, model config.ModelDef, prompt string, workDir string) (*Result, error) {
+func Simple(ctx context.Context, model config.ModelDef, prompt string, workDir string) (*Result, error) {
 	return NewProcessInvoker().Invoke(ctx, model, prompt, workDir, nil, nil)
 }

--- a/internal/invoke/invoker_test.go
+++ b/internal/invoke/invoker_test.go
@@ -30,8 +30,8 @@ func shModel(script string) config.ModelDef {
 	return config.ModelDef{Command: "sh", Args: []string{"-c", script}}
 }
 
-func TestInvokeSimple_BasicOutput_Echo(t *testing.T) {
-	result, err := InvokeSimple(context.Background(), echoModel("hello", "world"), "", ".")
+func TestSimple_BasicOutput_Echo(t *testing.T) {
+	result, err := Simple(context.Background(), echoModel("hello", "world"), "", ".")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -44,8 +44,8 @@ func TestInvokeSimple_BasicOutput_Echo(t *testing.T) {
 	}
 }
 
-func TestInvokeSimple_StdinPiped(t *testing.T) {
-	result, err := InvokeSimple(context.Background(), catModel(), "prompt text here", ".")
+func TestSimple_StdinPiped(t *testing.T) {
+	result, err := Simple(context.Background(), catModel(), "prompt text here", ".")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -55,8 +55,8 @@ func TestInvokeSimple_StdinPiped(t *testing.T) {
 	}
 }
 
-func TestInvokeSimple_NonZeroExitCode(t *testing.T) {
-	result, err := InvokeSimple(context.Background(), shModel("exit 42"), "", ".")
+func TestSimple_NonZeroExitCode(t *testing.T) {
+	result, err := Simple(context.Background(), shModel("exit 42"), "", ".")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -65,8 +65,8 @@ func TestInvokeSimple_NonZeroExitCode(t *testing.T) {
 	}
 }
 
-func TestInvokeSimple_StderrCaptured(t *testing.T) {
-	result, err := InvokeSimple(context.Background(), shModel("echo error-text >&2"), "", ".")
+func TestSimple_StderrCaptured(t *testing.T) {
+	result, err := Simple(context.Background(), shModel("echo error-text >&2"), "", ".")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -75,8 +75,8 @@ func TestInvokeSimple_StderrCaptured(t *testing.T) {
 	}
 }
 
-func TestInvokeSimple_CommandNotFound(t *testing.T) {
-	_, err := InvokeSimple(context.Background(), config.ModelDef{Command: "nonexistent-command-xyz"}, "", ".")
+func TestSimple_CommandNotFound(t *testing.T) {
+	_, err := Simple(context.Background(), config.ModelDef{Command: "nonexistent-command-xyz"}, "", ".")
 	if err == nil {
 		t.Fatal("expected error for missing command")
 	}
@@ -85,9 +85,9 @@ func TestInvokeSimple_CommandNotFound(t *testing.T) {
 	}
 }
 
-func TestInvokeSimple_WorkingDirectory(t *testing.T) {
+func TestSimple_WorkingDirectory(t *testing.T) {
 	dir := t.TempDir()
-	result, err := InvokeSimple(context.Background(), shModel("pwd"), "", dir)
+	result, err := Simple(context.Background(), shModel("pwd"), "", dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -100,10 +100,10 @@ func TestInvokeSimple_WorkingDirectory(t *testing.T) {
 	}
 }
 
-func TestInvokeSimple_ContextCancelled(t *testing.T) {
+func TestSimple_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately
-	_, err := InvokeSimple(ctx, shModel("sleep 10"), "", ".")
+	_, err := Simple(ctx, shModel("sleep 10"), "", ".")
 	if err == nil {
 		t.Fatal("expected error for cancelled context")
 	}
@@ -181,7 +181,7 @@ func TestProcessInvoker_Streaming_StderrCaptured(t *testing.T) {
 // --- Marker detection tests ---
 
 func TestMarkerDetection_Complete(t *testing.T) {
-	result, err := InvokeSimple(context.Background(), echoModel("WOLFCASTLE_COMPLETE"), "", ".")
+	result, err := Simple(context.Background(), echoModel("WOLFCASTLE_COMPLETE"), "", ".")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -191,7 +191,7 @@ func TestMarkerDetection_Complete(t *testing.T) {
 }
 
 func TestMarkerDetection_Yield(t *testing.T) {
-	result, err := InvokeSimple(context.Background(), echoModel("WOLFCASTLE_YIELD"), "", ".")
+	result, err := Simple(context.Background(), echoModel("WOLFCASTLE_YIELD"), "", ".")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -201,7 +201,7 @@ func TestMarkerDetection_Yield(t *testing.T) {
 }
 
 func TestMarkerDetection_Blocked(t *testing.T) {
-	result, err := InvokeSimple(context.Background(), shModel("echo 'WOLFCASTLE_BLOCKED: missing dependency'"), "", ".")
+	result, err := Simple(context.Background(), shModel("echo 'WOLFCASTLE_BLOCKED: missing dependency'"), "", ".")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -211,7 +211,7 @@ func TestMarkerDetection_Blocked(t *testing.T) {
 }
 
 func TestMarkerDetection_Summary(t *testing.T) {
-	result, err := InvokeSimple(context.Background(), shModel("echo 'WOLFCASTLE_SUMMARY: Implemented the feature'"), "", ".")
+	result, err := Simple(context.Background(), shModel("echo 'WOLFCASTLE_SUMMARY: Implemented the feature'"), "", ".")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -223,7 +223,7 @@ func TestMarkerDetection_Summary(t *testing.T) {
 func TestMarkerDetection_SummaryWithComplete(t *testing.T) {
 	script := `echo "WOLFCASTLE_SUMMARY: Task done successfully"
 echo "WOLFCASTLE_COMPLETE"`
-	result, err := InvokeSimple(context.Background(), shModel(script), "", ".")
+	result, err := Simple(context.Background(), shModel(script), "", ".")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -238,7 +238,7 @@ echo "WOLFCASTLE_COMPLETE"`
 func TestMarkerDetection_FirstTerminalMarkerWins(t *testing.T) {
 	script := `echo "WOLFCASTLE_YIELD"
 echo "WOLFCASTLE_COMPLETE"`
-	result, err := InvokeSimple(context.Background(), shModel(script), "", ".")
+	result, err := Simple(context.Background(), shModel(script), "", ".")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -248,7 +248,7 @@ echo "WOLFCASTLE_COMPLETE"`
 }
 
 func TestMarkerDetection_Skip(t *testing.T) {
-	result, err := InvokeSimple(context.Background(), echoModel("WOLFCASTLE_SKIP reason here"), "", ".")
+	result, err := Simple(context.Background(), echoModel("WOLFCASTLE_SKIP reason here"), "", ".")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -258,7 +258,7 @@ func TestMarkerDetection_Skip(t *testing.T) {
 }
 
 func TestMarkerDetection_Continue(t *testing.T) {
-	result, err := InvokeSimple(context.Background(), echoModel("WOLFCASTLE_CONTINUE"), "", ".")
+	result, err := Simple(context.Background(), echoModel("WOLFCASTLE_CONTINUE"), "", ".")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -268,7 +268,7 @@ func TestMarkerDetection_Continue(t *testing.T) {
 }
 
 func TestMarkerDetection_NoMarker(t *testing.T) {
-	result, err := InvokeSimple(context.Background(), echoModel("just some output"), "", ".")
+	result, err := Simple(context.Background(), echoModel("just some output"), "", ".")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -278,7 +278,7 @@ func TestMarkerDetection_NoMarker(t *testing.T) {
 }
 
 func TestMarkerDetection_EmptySummaryIgnored(t *testing.T) {
-	result, err := InvokeSimple(context.Background(), shModel("echo 'WOLFCASTLE_SUMMARY:'"), "", ".")
+	result, err := Simple(context.Background(), shModel("echo 'WOLFCASTLE_SUMMARY:'"), "", ".")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -381,10 +381,10 @@ func TestProcessInvoker_StreamingCommandNotFound(t *testing.T) {
 	}
 }
 
-// --- InvokeSimple tests ---
+// --- Simple tests ---
 
-func TestInvokeSimple_BasicOutput(t *testing.T) {
-	result, err := InvokeSimple(context.Background(), echoModel("simple"), "", ".")
+func TestSimple_BasicOutput(t *testing.T) {
+	result, err := Simple(context.Background(), echoModel("simple"), "", ".")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -460,8 +460,8 @@ echo "WOLFCASTLE_COMPLETE"
 
 // --- Empty output test ---
 
-func TestInvokeSimple_EmptyOutput(t *testing.T) {
-	result, err := InvokeSimple(context.Background(), shModel("true"), "", ".")
+func TestSimple_EmptyOutput(t *testing.T) {
+	result, err := Simple(context.Background(), shModel("true"), "", ".")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/project/migration_service.go
+++ b/internal/project/migration_service.go
@@ -51,6 +51,9 @@ func (m *MigrationService) MigrateDirectoryLayout() error {
 		}
 	}
 
+	// Legacy filenames from the pre-v0.3 flat layout. These are intentionally
+	// hardcoded because they describe the old on-disk format being migrated
+	// away from, not the current system's naming conventions.
 	filesToMove := []string{"wolfcastle.pid", "stop", "daemon.log", "daemon.meta.json"}
 	for _, f := range filesToMove {
 		src := filepath.Join(m.root, f)

--- a/internal/project/scaffold_service.go
+++ b/internal/project/scaffold_service.go
@@ -37,7 +37,7 @@ var scaffoldFiles = map[string]string{
 type ScaffoldService struct {
 	config  *config.Repository
 	prompts promptWriter
-	daemon  any    // *daemon.DaemonRepository; stored for future use, typed as any to avoid import cycle
+	daemon  any    // *daemon.Repository; stored for future use, typed as any to avoid import cycle
 	root    string // path to .wolfcastle/
 }
 

--- a/internal/testutil/environment.go
+++ b/internal/testutil/environment.go
@@ -49,7 +49,7 @@ type AppFields struct {
 	Identity *config.Identity
 	Prompts  *pipeline.PromptRepository
 	Classes  *pipeline.ClassRepository
-	Daemon   *daemon.DaemonRepository
+	Daemon   *daemon.Repository
 	State    *state.Store
 	Git      git.Provider
 }
@@ -77,7 +77,7 @@ type Environment struct {
 	Classes *pipeline.ClassRepository
 
 	// Daemon provides access to daemon filesystem operations (PID, stop file, logs).
-	Daemon *daemon.DaemonRepository
+	Daemon *daemon.Repository
 
 	// Identity holds the resolved user+machine identity extracted from config.
 	Identity *config.Identity
@@ -192,7 +192,7 @@ func NewEnvironment(t *testing.T) *Environment {
 		Config:    cfgRepo,
 		Prompts:   prompts,
 		Classes:   pipeline.NewClassRepository(prompts),
-		Daemon:    daemon.NewDaemonRepository(wolfcastleDir),
+		Daemon:    daemon.NewRepository(wolfcastleDir),
 		Identity:  identity,
 		t:         t,
 		namespace: namespace,

--- a/internal/tui/app/app.go
+++ b/internal/tui/app/app.go
@@ -69,7 +69,7 @@ type TUIModel struct {
 	lastFocused FocusedPane
 
 	header  header.HeaderModel
-	tree    tree.TreeModel
+	tree    tree.Model
 	detail  detail.DetailModel
 	footer  footer.FooterModel
 	welcome *welcome.WelcomeModel
@@ -89,7 +89,7 @@ type TUIModel struct {
 
 	entryState  EntryState
 	store       *state.Store
-	daemonRepo  *daemon.DaemonRepository
+	daemonRepo  *daemon.Repository
 	worktreeDir string
 	version     string
 
@@ -108,12 +108,12 @@ type TUIModel struct {
 // NewTUIModel creates a fully wired TUIModel. When store is nil (no
 // .wolfcastle directory found), the model opens in welcome mode so the
 // user can pick a directory and initialize.
-func NewTUIModel(store *state.Store, daemonRepo *daemon.DaemonRepository, worktreeDir, version string) TUIModel {
+func NewTUIModel(store *state.Store, daemonRepo *daemon.Repository, worktreeDir, version string) TUIModel {
 	m := TUIModel{
 		treeVisible: true,
 		focused:     PaneTree,
 		header:      header.NewHeaderModel(version),
-		tree:        tree.NewTreeModel(),
+		tree:        tree.NewModel(),
 		detail:      detail.NewDetailModel(),
 		footer:      footer.NewFooterModel(),
 		search:      search.NewSearchModel(),
@@ -250,6 +250,12 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch {
 		case key.Matches(msg, tui.GlobalKeyMap.Quit):
 			return m, tea.Quit
+
+		case key.Matches(msg, tui.GlobalKeyMap.Dashboard):
+			m.detail.SwitchToDashboard()
+			m.focused = PaneDetail
+			m.syncFocus()
+			return m, nil
 
 		case key.Matches(msg, tui.GlobalKeyMap.LogStream):
 			m.activeModal = ModalLog
@@ -615,7 +621,7 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Update store and daemon repo for the new worktree.
 		wolfDir := filepath.Join(msg.Entry.Worktree, ".wolfcastle")
 		m.store = storeFromWolfcastleDir(wolfDir)
-		m.daemonRepo = daemon.NewDaemonRepository(wolfDir)
+		m.daemonRepo = daemon.NewRepository(wolfDir)
 		m.worktreeDir = msg.Entry.Worktree
 
 		// Restart watcher: stop old, create+start+eager-prefetch new.
@@ -688,7 +694,7 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.welcome = nil
 			m.worktreeDir = msg.Dir
 			wolfDir := filepath.Join(msg.Dir, ".wolfcastle")
-			m.daemonRepo = daemon.NewDaemonRepository(wolfDir)
+			m.daemonRepo = daemon.NewRepository(wolfDir)
 			m.store = storeFromWolfcastleDir(wolfDir)
 			m.header.SetLoading(true)
 			cmds = append(cmds, m.detectEntryState(), m.startWatcher(), m.startPoller(), m.loadInitialState())
@@ -704,7 +710,7 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.notify = notify.NewNotificationModel()
 		m.worktreeDir = msg.Entry.Worktree
 		wolfDir := filepath.Join(msg.Entry.Worktree, ".wolfcastle")
-		m.daemonRepo = daemon.NewDaemonRepository(wolfDir)
+		m.daemonRepo = daemon.NewRepository(wolfDir)
 		m.store = storeFromWolfcastleDir(wolfDir)
 		m.instances, _ = instance.List()
 		for i, inst := range m.instances {
@@ -1470,7 +1476,7 @@ func (m *TUIModel) startWatcher() tea.Cmd {
 // any user who switched instances during a session. Routing through
 // this helper makes that class of bug structurally impossible: if
 // you forget to call newWatcherFor, you don't get a watcher at all.
-func newWatcherFor(store *state.Store, repo *daemon.DaemonRepository, events chan tea.Msg) *tui.Watcher {
+func newWatcherFor(store *state.Store, repo *daemon.Repository, events chan tea.Msg) *tui.Watcher {
 	if store == nil {
 		return nil
 	}
@@ -1620,7 +1626,7 @@ func (m *TUIModel) stopCurrentDaemon() tea.Cmd {
 			time.Sleep(200 * time.Millisecond)
 		}
 		//nolint:staticcheck // ST1005: user-facing TUI message displayed in toast notification
-		return tui.DaemonStopFailedMsg{Err: fmt.Errorf("Daemon not responding. Try wolfcastle stop --force.")}
+		return tui.DaemonStopFailedMsg{Err: fmt.Errorf("daemon not responding, try wolfcastle stop --force")}
 	}
 }
 
@@ -1658,7 +1664,7 @@ func (m *TUIModel) handleStopAll() tea.Cmd {
 			return tui.DaemonStopFailedMsg{Err: lastErr}
 		}
 		//nolint:staticcheck // ST1005: user-facing TUI message displayed in toast notification
-		return tui.DaemonStopFailedMsg{Err: fmt.Errorf("Daemon not responding. Try wolfcastle stop --force.")}
+		return tui.DaemonStopFailedMsg{Err: fmt.Errorf("daemon not responding, try wolfcastle stop --force")}
 	}
 }
 

--- a/internal/tui/app/app.go
+++ b/internal/tui/app/app.go
@@ -68,13 +68,13 @@ type TUIModel struct {
 	focused     FocusedPane
 	lastFocused FocusedPane
 
-	header  header.HeaderModel
+	header  header.Model
 	tree    tree.Model
-	detail  detail.DetailModel
-	footer  footer.FooterModel
-	welcome *welcome.WelcomeModel
-	search  search.SearchModel
-	help    help.HelpOverlayModel
+	detail  detail.Model
+	footer  footer.Model
+	welcome *welcome.Model
+	search  search.Model
+	help    help.Model
 	notify  notify.NotificationModel
 
 	// State diffing for toast notifications (Phase 5).
@@ -112,12 +112,12 @@ func NewTUIModel(store *state.Store, daemonRepo *daemon.Repository, worktreeDir,
 	m := TUIModel{
 		treeVisible: true,
 		focused:     PaneTree,
-		header:      header.NewHeaderModel(version),
+		header:      header.NewModel(version),
 		tree:        tree.NewModel(),
-		detail:      detail.NewDetailModel(),
-		footer:      footer.NewFooterModel(),
-		search:      search.NewSearchModel(),
-		help:        help.NewHelpOverlayModel(),
+		detail:      detail.NewModel(),
+		footer:      footer.NewModel(),
+		search:      search.NewModel(),
+		help:        help.NewModel(),
 		notify:      notify.NewNotificationModel(),
 		prevNodes:   make(map[string]*state.NodeState),
 		store:       store,
@@ -136,7 +136,7 @@ func NewTUIModel(store *state.Store, daemonRepo *daemon.Repository, worktreeDir,
 		m.entryState = StateWelcome
 		// Discover running instances for the sessions panel.
 		instances, _ := instance.List()
-		w := welcome.NewWelcomeModel(worktreeDir, instances)
+		w := welcome.NewModel(worktreeDir, instances)
 		m.welcome = &w
 	} else {
 		m.entryState = StateCold
@@ -985,12 +985,12 @@ func (m *TUIModel) computeTreeSearchMatches() {
 	}
 
 	literal := make(map[string]bool)
-	var matches []search.SearchMatch
+	var matches []search.Match
 
 	for addr, entry := range idx.Nodes {
 		if strings.Contains(strings.ToLower(entry.Name), query) {
 			literal[addr] = true
-			matches = append(matches, search.SearchMatch{Address: addr})
+			matches = append(matches, search.Match{Address: addr})
 		}
 		if entry.Type != state.NodeLeaf {
 			continue
@@ -1003,7 +1003,7 @@ func (m *TUIModel) computeTreeSearchMatches() {
 			if strings.Contains(strings.ToLower(task.Title), query) {
 				taskAddr := addr + "/" + task.ID
 				literal[taskAddr] = true
-				matches = append(matches, search.SearchMatch{Address: taskAddr})
+				matches = append(matches, search.Match{Address: taskAddr})
 			}
 		}
 	}
@@ -1034,10 +1034,10 @@ func (m *TUIModel) computeTreeSearchMatches() {
 
 func (m *TUIModel) computeDetailSearchMatches(query string) {
 	lines := m.detail.SearchContent()
-	var matches []search.SearchMatch
+	var matches []search.Match
 	for i, line := range lines {
 		if strings.Contains(strings.ToLower(line), query) {
-			matches = append(matches, search.SearchMatch{Row: i})
+			matches = append(matches, search.Match{Row: i})
 		}
 	}
 	m.search.SetMatches(matches)
@@ -1625,7 +1625,6 @@ func (m *TUIModel) stopCurrentDaemon() tea.Cmd {
 			}
 			time.Sleep(200 * time.Millisecond)
 		}
-		//nolint:staticcheck // ST1005: user-facing TUI message displayed in toast notification
 		return tui.DaemonStopFailedMsg{Err: fmt.Errorf("daemon not responding, try wolfcastle stop --force")}
 	}
 }
@@ -1663,7 +1662,6 @@ func (m *TUIModel) handleStopAll() tea.Cmd {
 		if lastErr != nil {
 			return tui.DaemonStopFailedMsg{Err: lastErr}
 		}
-		//nolint:staticcheck // ST1005: user-facing TUI message displayed in toast notification
 		return tui.DaemonStopFailedMsg{Err: fmt.Errorf("daemon not responding, try wolfcastle stop --force")}
 	}
 }

--- a/internal/tui/app/app_test.go
+++ b/internal/tui/app/app_test.go
@@ -2483,3 +2483,23 @@ func TestOnlyOneModalAtATime(t *testing.T) {
 		t.Error("second modal should not open while first is active")
 	}
 }
+
+func TestDashboardKeySwitch(t *testing.T) {
+	m := newColdModel(t)
+	// Start in some non-dashboard detail mode.
+	m.detail.SetMode(detail.ModeNodeDetail)
+	m.focused = PaneTree
+
+	result, cmd := m.Update(keyMsg("d"))
+	model := toModel(t, result)
+
+	if model.detail.Mode() != detail.ModeDashboard {
+		t.Errorf("expected ModeDashboard after pressing d, got %d", model.detail.Mode())
+	}
+	if model.focused != PaneDetail {
+		t.Errorf("expected focus on PaneDetail after pressing d, got %d", model.focused)
+	}
+	if cmd != nil {
+		t.Error("dashboard switch should not produce a command")
+	}
+}

--- a/internal/tui/app/app_test.go
+++ b/internal/tui/app/app_test.go
@@ -1500,8 +1500,8 @@ func TestJumpTreeToSearchMatch_WithRowMatch(t *testing.T) {
 	m.tree.SetIndex(idx)
 	// Activate search and set a match with an address.
 	m.search.Activate(int(PaneTree))
-	m.search.SetMatches([]search.SearchMatch{{Row: 1, Address: "beta"}})
-	m.search.SetMatches([]search.SearchMatch{{Row: 0, Address: "alpha"}, {Row: 1, Address: "beta"}})
+	m.search.SetMatches([]search.Match{{Row: 1, Address: "beta"}})
+	m.search.SetMatches([]search.Match{{Row: 0, Address: "alpha"}, {Row: 1, Address: "beta"}})
 	m.jumpTreeToSearchMatch()
 }
 
@@ -1805,7 +1805,7 @@ func TestEscClearsSearchHighlights(t *testing.T) {
 	}
 	m.tree.SetIndex(idx)
 	// Set up search state with matches but search bar inactive.
-	m.search.SetMatches([]search.SearchMatch{{Row: 0, Address: "alpha"}})
+	m.search.SetMatches([]search.Match{{Row: 0, Address: "alpha"}})
 	m.tree.SetSearchAddresses(map[string]bool{"alpha": true}, nil)
 
 	result, _ := m.Update(keyMsg("esc"))
@@ -1838,7 +1838,7 @@ func TestSearchMatchNavigation(t *testing.T) {
 	}
 	m.tree.SetIndex(idx)
 	m.search.Activate(int(PaneTree))
-	m.search.SetMatches([]search.SearchMatch{
+	m.search.SetMatches([]search.Match{
 		{Row: 0, Address: "alpha"},
 		{Row: 1, Address: "beta"},
 	})
@@ -1897,7 +1897,7 @@ func TestComputeTreeSearchMatches_EmptyQuery(t *testing.T) {
 	m := newColdModel(t)
 	m.search.Activate(int(PaneTree))
 	// Set some pre-existing matches.
-	m.search.SetMatches([]search.SearchMatch{{Address: "x"}})
+	m.search.SetMatches([]search.Match{{Address: "x"}})
 	// Empty query should clear them.
 	m.computeTreeSearchMatches()
 	if m.search.HasMatches() {
@@ -1959,7 +1959,7 @@ func TestJumpTreeToSearchMatch_DetailMatch(t *testing.T) {
 	m.tree.SetIndex(idx)
 	// Set a match with empty Address (detail pane match, row-based).
 	m.search.Activate(int(PaneDetail))
-	m.search.SetMatches([]search.SearchMatch{{Row: 0, Address: ""}})
+	m.search.SetMatches([]search.Match{{Row: 0, Address: ""}})
 	m.jumpTreeToSearchMatch()
 }
 
@@ -1976,7 +1976,7 @@ func TestJumpTreeToSearchMatch_AddressWithFallback(t *testing.T) {
 	// Match on "parent/child/task-0001" which doesn't exist in flat list.
 	// Should fall back to "parent/child" then "parent".
 	m.search.Activate(int(PaneTree))
-	m.search.SetMatches([]search.SearchMatch{{Address: "parent/child/task-0001"}})
+	m.search.SetMatches([]search.Match{{Address: "parent/child/task-0001"}})
 	m.jumpTreeToSearchMatch()
 }
 
@@ -1991,7 +1991,7 @@ func TestJumpTreeToSearchMatch_NoFallbackFound(t *testing.T) {
 	m.tree.SetIndex(idx)
 	// Match on an address that doesn't exist at any level.
 	m.search.Activate(int(PaneTree))
-	m.search.SetMatches([]search.SearchMatch{{Address: "nonexistent"}})
+	m.search.SetMatches([]search.Match{{Address: "nonexistent"}})
 	m.jumpTreeToSearchMatch()
 	// Should be a no-op (no panic).
 }

--- a/internal/tui/app/wiring_smoke_test.go
+++ b/internal/tui/app/wiring_smoke_test.go
@@ -196,7 +196,7 @@ func TestWiring_TaskCacheReflectsStateFile(t *testing.T) {
 	// alpha so the rendered tree knows the task states without the
 	// user having to expand the leaf manually first.
 	store := state.NewStore(storeDir, 0)
-	m := NewTUIModel(store, daemon.NewDaemonRepository(wcDir), tmp, "1.0.0")
+	m := NewTUIModel(store, daemon.NewRepository(wcDir), tmp, "1.0.0")
 	m.entryState = StateLive
 	m.width = 120
 	m.height = 40
@@ -228,7 +228,7 @@ func TestWiring_TaskCacheReflectsStateFile(t *testing.T) {
 	m.tree = tm
 
 	// Find the task rows in the flat list.
-	var task1Row, task2Row *tree.TreeRow
+	var task1Row, task2Row *tree.Row
 	for i := range m.tree.FlatList() {
 		row := &m.tree.FlatList()[i]
 		if strings.Contains(row.Addr, "task-0001") {
@@ -335,7 +335,7 @@ func TestStartWatcher_TriggersEagerPrefetch(t *testing.T) {
 
 	// Construct the model and run startWatcher cmd.
 	store := state.NewStore(storeDir, 0)
-	m := NewTUIModel(store, daemon.NewDaemonRepository(wcDir), tmp, "1.0.0")
+	m := NewTUIModel(store, daemon.NewRepository(wcDir), tmp, "1.0.0")
 	m.entryState = StateLive
 	m.width = 120
 	m.height = 40
@@ -559,7 +559,7 @@ func TestWiring_LogViewShowsExistingContent(t *testing.T) {
 	// channel so the LogLinesMsg reaches the LogViewModel, then
 	// switch the detail pane to log view.
 	store := state.NewStore(filepath.Join(wcDir, "system", "projects", "default"), 0)
-	m := NewTUIModel(store, daemon.NewDaemonRepository(wcDir), tmp, "1.0.0")
+	m := NewTUIModel(store, daemon.NewRepository(wcDir), tmp, "1.0.0")
 	m.entryState = StateLive
 	m.width = 120
 	m.height = 40

--- a/internal/tui/clipboard/osc52.go
+++ b/internal/tui/clipboard/osc52.go
@@ -1,3 +1,4 @@
+// Package clipboard provides clipboard write support via OSC 52 escape sequences and platform-native tools.
 package clipboard
 
 import (

--- a/internal/tui/detail/model.go
+++ b/internal/tui/detail/model.go
@@ -1,3 +1,4 @@
+// Package detail implements the right-pane detail views: dashboard, node detail, task detail, log stream, and inbox.
 package detail
 
 import (

--- a/internal/tui/detail/model.go
+++ b/internal/tui/detail/model.go
@@ -9,24 +9,24 @@ import (
 	"github.com/dorkusprime/wolfcastle/internal/tui"
 )
 
-// DetailMode selects which sub-view the detail container renders.
-type DetailMode int
+// Mode selects which sub-view the detail container renders.
+type Mode int
 
 const (
-	ModeDashboard DetailMode = iota
+	ModeDashboard Mode = iota
 	ModeNodeDetail
 	ModeTaskDetail
 	ModeLogStream
 	ModeInbox
 )
 
-// DetailModel is the right-pane container that delegates rendering to the
+// Model is the right-pane container that delegates rendering to the
 // active sub-view.
-type DetailModel struct {
-	mode       DetailMode
+type Model struct {
+	mode       Mode
 	dashboard  DashboardModel
-	nodeDetail NodeDetailModel
-	taskDetail TaskDetailModel
+	nodeDetail NodeModel
+	taskDetail TaskModel
 	logView    LogViewModel
 	inbox      InboxModel
 	viewport   viewport.Model
@@ -35,14 +35,14 @@ type DetailModel struct {
 	focused    bool
 }
 
-// NewDetailModel creates a DetailModel starting in dashboard mode.
-func NewDetailModel() DetailModel {
+// NewModel creates a Model starting in dashboard mode.
+func NewModel() Model {
 	vp := viewport.New()
-	return DetailModel{
+	return Model{
 		mode:       ModeDashboard,
 		dashboard:  NewDashboardModel(),
-		nodeDetail: NewNodeDetailModel(),
-		taskDetail: NewTaskDetailModel(),
+		nodeDetail: NewNodeModel(),
+		taskDetail: NewTaskModel(),
 		logView:    NewLogViewModel(),
 		inbox:      NewInboxModel(),
 		viewport:   vp,
@@ -50,27 +50,27 @@ func NewDetailModel() DetailModel {
 }
 
 // Mode returns the current detail mode.
-func (m DetailModel) Mode() DetailMode {
+func (m Model) Mode() Mode {
 	return m.mode
 }
 
 // IsCapturingInput returns true when a sub-view is capturing keyboard
 // input (e.g., the inbox text input field is active). The app
 // orchestrator should suppress global key bindings in this state.
-func (m DetailModel) IsCapturingInput() bool {
+func (m Model) IsCapturingInput() bool {
 	return m.mode == ModeInbox && m.inbox.IsInputActive()
 }
 
 // InboxModelRef returns a pointer to the inbox sub-model so the modal
 // layer can borrow it for rendering and key routing without moving
 // ownership out of the detail container.
-func (m *DetailModel) InboxModelRef() *InboxModel {
+func (m *Model) InboxModelRef() *InboxModel {
 	return &m.inbox
 }
 
 // LogViewModelRef returns a pointer to the log view sub-model so the
 // modal layer can borrow it for rendering and key routing.
-func (m *DetailModel) LogViewModelRef() *LogViewModel {
+func (m *Model) LogViewModelRef() *LogViewModel {
 	return &m.logView
 }
 
@@ -87,7 +87,7 @@ func (m *DetailModel) LogViewModelRef() *LogViewModel {
 //   - NewLogFileMsg   → log view sub-model (same rationale: rotation
 //     events must reach the log view even when it
 //     is not the active mode)
-func (m DetailModel) Update(msg tea.Msg) (DetailModel, tea.Cmd) {
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	if inboxMsg, ok := msg.(tui.InboxUpdatedMsg); ok {
 		m.inbox, _ = m.inbox.Update(inboxMsg)
 	}
@@ -114,7 +114,7 @@ func (m DetailModel) Update(msg tea.Msg) (DetailModel, tea.Cmd) {
 	}
 }
 
-func (m DetailModel) updateDashboard(msg tea.Msg) (DetailModel, tea.Cmd) {
+func (m Model) updateDashboard(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg.(type) {
 	case tui.StateUpdatedMsg, tui.DaemonStatusMsg, tui.LogLinesMsg:
 		var cmd tea.Cmd
@@ -128,7 +128,7 @@ func (m DetailModel) updateDashboard(msg tea.Msg) (DetailModel, tea.Cmd) {
 	return m, nil
 }
 
-func (m DetailModel) updateNodeDetail(msg tea.Msg) (DetailModel, tea.Cmd) {
+func (m Model) updateNodeDetail(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg.(type) {
 	case tea.KeyPressMsg:
 		var cmd tea.Cmd
@@ -138,7 +138,7 @@ func (m DetailModel) updateNodeDetail(msg tea.Msg) (DetailModel, tea.Cmd) {
 	return m, nil
 }
 
-func (m DetailModel) updateTaskDetail(msg tea.Msg) (DetailModel, tea.Cmd) {
+func (m Model) updateTaskDetail(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg.(type) {
 	case tea.KeyPressMsg:
 		var cmd tea.Cmd
@@ -148,7 +148,7 @@ func (m DetailModel) updateTaskDetail(msg tea.Msg) (DetailModel, tea.Cmd) {
 	return m, nil
 }
 
-func (m DetailModel) updateLogView(msg tea.Msg) (DetailModel, tea.Cmd) {
+func (m Model) updateLogView(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg.(type) {
 	case tea.KeyPressMsg, tui.LogLinesMsg, tui.NewLogFileMsg:
 		var cmd tea.Cmd
@@ -158,7 +158,7 @@ func (m DetailModel) updateLogView(msg tea.Msg) (DetailModel, tea.Cmd) {
 	return m, nil
 }
 
-func (m DetailModel) updateInbox(msg tea.Msg) (DetailModel, tea.Cmd) {
+func (m Model) updateInbox(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg.(type) {
 	case tea.KeyPressMsg, tui.InboxUpdatedMsg:
 		var cmd tea.Cmd
@@ -168,7 +168,7 @@ func (m DetailModel) updateInbox(msg tea.Msg) (DetailModel, tea.Cmd) {
 	return m, nil
 }
 
-func (m DetailModel) updatePlaceholder(msg tea.Msg) (DetailModel, tea.Cmd) {
+func (m Model) updatePlaceholder(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg.(type) {
 	case tea.KeyPressMsg:
 		var cmd tea.Cmd
@@ -179,7 +179,7 @@ func (m DetailModel) updatePlaceholder(msg tea.Msg) (DetailModel, tea.Cmd) {
 }
 
 // SetSize propagates dimensions to all sub-models.
-func (m *DetailModel) SetSize(width, height int) {
+func (m *Model) SetSize(width, height int) {
 	m.width = width
 	m.height = height
 	m.dashboard.SetSize(width, height)
@@ -192,44 +192,44 @@ func (m *DetailModel) SetSize(width, height int) {
 }
 
 // SetFocused marks whether this container currently holds keyboard focus.
-func (m *DetailModel) SetFocused(focused bool) {
+func (m *Model) SetFocused(focused bool) {
 	m.focused = focused
 }
 
 // SetMode switches the active sub-view.
-func (m *DetailModel) SetMode(mode DetailMode) {
+func (m *Model) SetMode(mode Mode) {
 	m.mode = mode
 }
 
 // LoadNodeDetail switches to node detail mode and populates the view.
-func (m *DetailModel) LoadNodeDetail(addr string, node *state.NodeState, entry *state.IndexEntry, isTarget bool) {
+func (m *Model) LoadNodeDetail(addr string, node *state.NodeState, entry *state.IndexEntry, isTarget bool) {
 	m.mode = ModeNodeDetail
 	m.nodeDetail.Load(addr, node, entry, isTarget)
 }
 
 // LoadTaskDetail switches to task detail mode and populates the view.
-func (m *DetailModel) LoadTaskDetail(addr, taskID string, task *state.Task) {
+func (m *Model) LoadTaskDetail(addr, taskID string, task *state.Task) {
 	m.mode = ModeTaskDetail
 	m.taskDetail.Load(addr, taskID, task)
 }
 
 // SwitchToLogView switches to log stream mode.
-func (m *DetailModel) SwitchToLogView() {
+func (m *Model) SwitchToLogView() {
 	m.mode = ModeLogStream
 }
 
 // SwitchToDashboard switches to dashboard mode.
-func (m *DetailModel) SwitchToDashboard() {
+func (m *Model) SwitchToDashboard() {
 	m.mode = ModeDashboard
 }
 
 // Reset clears all data from the detail sub-views, used when switching
 // instances. The dashboard shows a "loading..." placeholder until fresh
 // data arrives.
-func (m *DetailModel) Reset() {
+func (m *Model) Reset() {
 	m.dashboard.Reset()
-	m.nodeDetail = NewNodeDetailModel()
-	m.taskDetail = NewTaskDetailModel()
+	m.nodeDetail = NewNodeModel()
+	m.taskDetail = NewTaskModel()
 	m.logView = NewLogViewModel()
 	m.inbox = NewInboxModel()
 	m.mode = ModeDashboard
@@ -237,30 +237,30 @@ func (m *DetailModel) Reset() {
 }
 
 // SwitchToInbox switches to inbox mode.
-func (m *DetailModel) SwitchToInbox() {
+func (m *Model) SwitchToInbox() {
 	m.mode = ModeInbox
 	m.inbox.SetFocused(m.focused)
 }
 
 // LoadInbox updates the inbox model with fresh data.
-func (m *DetailModel) LoadInbox(items []state.InboxItem) {
+func (m *Model) LoadInbox(items []state.InboxItem) {
 	m.inbox.SetItems(items)
 }
 
 // SetDashboardInbox updates the dashboard's cached inbox items for the
 // summary line, independent of the inbox detail view.
-func (m *DetailModel) SetDashboardInbox(items []state.InboxItem) {
+func (m *Model) SetDashboardInbox(items []state.InboxItem) {
 	m.dashboard.SetInbox(items)
 }
 
 // SetInboxReadError flags the inbox as unreadable.
-func (m *DetailModel) SetInboxReadError(err bool) {
+func (m *Model) SetInboxReadError(err bool) {
 	m.inbox.SetReadError(err)
 }
 
 // SearchContent returns the searchable lines for the current detail mode.
 // The app uses this when search is activated on the detail pane.
-func (m DetailModel) SearchContent() []string {
+func (m Model) SearchContent() []string {
 	switch m.mode {
 	case ModeNodeDetail:
 		return m.nodeDetail.SearchContent()
@@ -276,7 +276,7 @@ func (m DetailModel) SearchContent() []string {
 }
 
 // CopyTarget returns the appropriate copy text for the current mode.
-func (m DetailModel) CopyTarget() string {
+func (m Model) CopyTarget() string {
 	switch m.mode {
 	case ModeNodeDetail:
 		return m.nodeDetail.Addr()
@@ -292,7 +292,7 @@ func (m DetailModel) CopyTarget() string {
 }
 
 // View renders the active sub-view.
-func (m DetailModel) View() string {
+func (m Model) View() string {
 	switch m.mode {
 	case ModeDashboard:
 		return m.dashboard.View()

--- a/internal/tui/detail/model_test.go
+++ b/internal/tui/detail/model_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/dorkusprime/wolfcastle/internal/tui"
 )
 
-func TestNewDetailModel_StartsInDashboardMode(t *testing.T) {
+func TestNewModel_StartsInDashboardMode(t *testing.T) {
 	t.Parallel()
-	m := NewDetailModel()
+	m := NewModel()
 	if m.mode != ModeDashboard {
 		t.Errorf("expected ModeDashboard (%d), got %d", ModeDashboard, m.mode)
 	}
@@ -20,7 +20,7 @@ func TestNewDetailModel_StartsInDashboardMode(t *testing.T) {
 
 func TestSetMode_Dashboard(t *testing.T) {
 	t.Parallel()
-	m := NewDetailModel()
+	m := NewModel()
 	m.SetMode(ModeDashboard)
 	if m.mode != ModeDashboard {
 		t.Errorf("expected ModeDashboard, got %d", m.mode)
@@ -34,7 +34,7 @@ func TestSetMode_Dashboard(t *testing.T) {
 
 func TestSetMode_NodeDetail_RendersNodeView(t *testing.T) {
 	t.Parallel()
-	m := NewDetailModel()
+	m := NewModel()
 	m.SetSize(80, 24)
 	m.SetMode(ModeNodeDetail)
 	if m.mode != ModeNodeDetail {
@@ -46,7 +46,7 @@ func TestSetMode_NodeDetail_RendersNodeView(t *testing.T) {
 
 func TestSetMode_LogStream_RendersLogView(t *testing.T) {
 	t.Parallel()
-	m := NewDetailModel()
+	m := NewModel()
 	m.SetSize(80, 24)
 	m.SwitchToLogView()
 	if m.mode != ModeLogStream {
@@ -60,7 +60,7 @@ func TestSetMode_LogStream_RendersLogView(t *testing.T) {
 
 func TestSetMode_TaskDetail_RendersTaskView(t *testing.T) {
 	t.Parallel()
-	m := NewDetailModel()
+	m := NewModel()
 	m.SetSize(80, 24)
 	m.SetMode(ModeTaskDetail)
 	if m.mode != ModeTaskDetail {
@@ -72,7 +72,7 @@ func TestSetMode_TaskDetail_RendersTaskView(t *testing.T) {
 
 func TestSetMode_Inbox_ShowsInboxView(t *testing.T) {
 	t.Parallel()
-	m := NewDetailModel()
+	m := NewModel()
 	m.SetSize(80, 24)
 	m.SetMode(ModeInbox)
 	v := m.View()
@@ -86,7 +86,7 @@ func TestSetMode_Inbox_ShowsInboxView(t *testing.T) {
 
 func TestUpdate_ForwardsStateUpdatedMsg(t *testing.T) {
 	t.Parallel()
-	m := NewDetailModel()
+	m := NewModel()
 	idx := &state.RootIndex{
 		Nodes: map[string]state.IndexEntry{
 			"a": {State: state.StatusComplete},
@@ -101,7 +101,7 @@ func TestUpdate_ForwardsStateUpdatedMsg(t *testing.T) {
 
 func TestUpdate_ForwardsDaemonStatusMsg(t *testing.T) {
 	t.Parallel()
-	m := NewDetailModel()
+	m := NewModel()
 	m, _ = m.Update(tui.DaemonStatusMsg{
 		Status:    "on patrol",
 		Branch:    "main",
@@ -117,7 +117,7 @@ func TestUpdate_ForwardsDaemonStatusMsg(t *testing.T) {
 
 func TestUpdate_ForwardsLogLinesMsg(t *testing.T) {
 	t.Parallel()
-	m := NewDetailModel()
+	m := NewModel()
 	m, _ = m.Update(tui.LogLinesMsg{Lines: []string{
 		`{"type":"stage_start","stage":"intake","node":"alpha"}`,
 		`{"type":"stage_complete","stage":"exec","node":"alpha","exit_code":0}`,
@@ -129,7 +129,7 @@ func TestUpdate_ForwardsLogLinesMsg(t *testing.T) {
 
 func TestUpdate_NonDashboardModeIgnoresStateMsg(t *testing.T) {
 	t.Parallel()
-	m := NewDetailModel()
+	m := NewModel()
 	m.SetMode(ModeNodeDetail)
 	m, _ = m.Update(tui.StateUpdatedMsg{Index: &state.RootIndex{
 		Nodes: map[string]state.IndexEntry{"a": {State: state.StatusComplete}},
@@ -142,7 +142,7 @@ func TestUpdate_NonDashboardModeIgnoresStateMsg(t *testing.T) {
 
 func TestUpdate_LogStreamModeHandlesKeyPress(t *testing.T) {
 	t.Parallel()
-	m := NewDetailModel()
+	m := NewModel()
 	m.SetSize(80, 24)
 	m.SwitchToLogView()
 	// Should not panic on key press in log stream mode
@@ -154,7 +154,7 @@ func TestUpdate_LogStreamModeHandlesKeyPress(t *testing.T) {
 
 func TestUpdate_DashboardModeHandlesKeyPress(t *testing.T) {
 	t.Parallel()
-	m := NewDetailModel()
+	m := NewModel()
 	m.SetSize(80, 24)
 	// Should not panic on key press in dashboard mode
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
@@ -165,7 +165,7 @@ func TestUpdate_DashboardModeHandlesKeyPress(t *testing.T) {
 
 func TestSetSize_PropagatesDimensions(t *testing.T) {
 	t.Parallel()
-	m := NewDetailModel()
+	m := NewModel()
 	m.SetSize(100, 50)
 	if m.width != 100 || m.height != 50 {
 		t.Errorf("expected 100x50, got %dx%d", m.width, m.height)
@@ -177,7 +177,7 @@ func TestSetSize_PropagatesDimensions(t *testing.T) {
 
 func TestSetFocused(t *testing.T) {
 	t.Parallel()
-	m := NewDetailModel()
+	m := NewModel()
 	m.SetFocused(true)
 	if !m.focused {
 		t.Error("expected focused to be true")
@@ -190,7 +190,7 @@ func TestSetFocused(t *testing.T) {
 
 func TestView_DashboardMode(t *testing.T) {
 	t.Parallel()
-	m := NewDetailModel()
+	m := NewModel()
 	v := m.View()
 	if !strings.Contains(v, "MISSION BRIEFING") {
 		t.Errorf("expected MISSION BRIEFING in dashboard view, got: %s", v)
@@ -199,7 +199,7 @@ func TestView_DashboardMode(t *testing.T) {
 
 func TestView_InboxMode_ShowsInboxView(t *testing.T) {
 	t.Parallel()
-	m := NewDetailModel()
+	m := NewModel()
 	m.SetSize(80, 24)
 	m.SetMode(ModeInbox)
 	v := m.View()
@@ -210,7 +210,7 @@ func TestView_InboxMode_ShowsInboxView(t *testing.T) {
 
 func TestUpdate_UnhandledMsgReturnsSelf(t *testing.T) {
 	t.Parallel()
-	m := NewDetailModel()
+	m := NewModel()
 	m2, cmd := m.Update(tea.FocusMsg{})
 	if cmd != nil {
 		t.Error("expected nil cmd for unhandled msg")

--- a/internal/tui/detail/model_test.go
+++ b/internal/tui/detail/model_test.go
@@ -219,3 +219,319 @@ func TestUpdate_UnhandledMsgReturnsSelf(t *testing.T) {
 		t.Error("model should be unchanged for unhandled msg")
 	}
 }
+
+func TestMode_Accessor(t *testing.T) {
+	t.Parallel()
+	m := NewModel()
+	if m.Mode() != ModeDashboard {
+		t.Errorf("expected ModeDashboard, got %d", m.Mode())
+	}
+	m.SetMode(ModeLogStream)
+	if m.Mode() != ModeLogStream {
+		t.Errorf("expected ModeLogStream, got %d", m.Mode())
+	}
+}
+
+func TestIsCapturingInput_FalseOutsideInbox(t *testing.T) {
+	t.Parallel()
+	m := NewModel()
+	if m.IsCapturingInput() {
+		t.Error("should not be capturing input in dashboard mode")
+	}
+	m.SetMode(ModeNodeDetail)
+	if m.IsCapturingInput() {
+		t.Error("should not be capturing input in node detail mode")
+	}
+}
+
+func TestIsCapturingInput_InboxNotActive(t *testing.T) {
+	t.Parallel()
+	m := NewModel()
+	m.SetMode(ModeInbox)
+	// Inbox input is not active by default
+	if m.IsCapturingInput() {
+		t.Error("inbox input should not be active by default")
+	}
+}
+
+func TestInboxModelRef(t *testing.T) {
+	t.Parallel()
+	m := NewModel()
+	ref := m.InboxModelRef()
+	if ref == nil {
+		t.Fatal("InboxModelRef should not return nil")
+	}
+	// Verify it points to the actual inbox sub-model by mutating through the ref.
+	ref.SetReadError(true)
+	if !m.inbox.readErr {
+		t.Error("InboxModelRef should return a pointer to the actual inbox sub-model")
+	}
+}
+
+func TestLogViewModelRef(t *testing.T) {
+	t.Parallel()
+	m := NewModel()
+	ref := m.LogViewModelRef()
+	if ref == nil {
+		t.Fatal("LogViewModelRef should not return nil")
+	}
+	// Verify it points to the actual log view sub-model.
+	ref.SetSize(42, 10)
+	if m.logView.width != 42 {
+		t.Error("LogViewModelRef should return a pointer to the actual log view sub-model")
+	}
+}
+
+func TestUpdatePlaceholder_KeyPress(t *testing.T) {
+	t.Parallel()
+	m := NewModel()
+	m.SetSize(80, 24)
+	// Set mode to something beyond the known modes to hit the default branch.
+	m.mode = Mode(99)
+	m, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	if cmd != nil {
+		// viewport.Update may or may not produce a cmd; the key thing is no panic.
+		_ = cmd
+	}
+	if m.mode != Mode(99) {
+		t.Errorf("mode should remain 99, got %d", m.mode)
+	}
+}
+
+func TestUpdatePlaceholder_NonKeyMsg(t *testing.T) {
+	t.Parallel()
+	m := NewModel()
+	m.SetSize(80, 24)
+	m.mode = Mode(99)
+	m, cmd := m.Update(tea.FocusMsg{})
+	if cmd != nil {
+		t.Error("expected nil cmd for non-key msg in placeholder mode")
+	}
+}
+
+func TestLoadNodeDetail(t *testing.T) {
+	t.Parallel()
+	m := NewModel()
+	m.SetSize(80, 24)
+	node := &state.NodeState{
+		Tasks: []state.Task{{ID: "t1", Title: "Task", State: state.StatusComplete}},
+	}
+	entry := &state.IndexEntry{Name: "Alpha", Type: state.NodeLeaf, State: state.StatusInProgress}
+	m.LoadNodeDetail("alpha", node, entry, true)
+	if m.mode != ModeNodeDetail {
+		t.Errorf("expected ModeNodeDetail, got %d", m.mode)
+	}
+	if m.nodeDetail.Addr() != "alpha" {
+		t.Errorf("expected addr 'alpha', got %q", m.nodeDetail.Addr())
+	}
+}
+
+func TestLoadTaskDetail(t *testing.T) {
+	t.Parallel()
+	m := NewModel()
+	m.SetSize(80, 24)
+	task := &state.Task{ID: "t1", Title: "Build", State: state.StatusInProgress}
+	m.LoadTaskDetail("alpha", "t1", task)
+	if m.mode != ModeTaskDetail {
+		t.Errorf("expected ModeTaskDetail, got %d", m.mode)
+	}
+	if m.taskDetail.TaskAddr() != "alpha/t1" {
+		t.Errorf("expected task addr 'alpha/t1', got %q", m.taskDetail.TaskAddr())
+	}
+}
+
+func TestSwitchToDashboard(t *testing.T) {
+	t.Parallel()
+	m := NewModel()
+	m.SetMode(ModeLogStream)
+	m.SwitchToDashboard()
+	if m.mode != ModeDashboard {
+		t.Errorf("expected ModeDashboard, got %d", m.mode)
+	}
+}
+
+func TestReset(t *testing.T) {
+	t.Parallel()
+	m := NewModel()
+	m.SetSize(80, 24)
+	m.SetMode(ModeLogStream)
+	m.logView.AppendLines([]string{
+		`{"type":"daemon_start","timestamp":"2026-01-01T00:00:00Z","level":"info"}`,
+	})
+	m.Reset()
+	if m.mode != ModeDashboard {
+		t.Errorf("expected ModeDashboard after Reset, got %d", m.mode)
+	}
+}
+
+func TestSwitchToInbox(t *testing.T) {
+	t.Parallel()
+	m := NewModel()
+	m.SetFocused(true)
+	m.SwitchToInbox()
+	if m.mode != ModeInbox {
+		t.Errorf("expected ModeInbox, got %d", m.mode)
+	}
+}
+
+func TestLoadInbox(t *testing.T) {
+	t.Parallel()
+	m := NewModel()
+	items := []state.InboxItem{
+		{Text: "first", Status: state.InboxNew},
+		{Text: "second", Status: state.InboxFiled},
+	}
+	m.LoadInbox(items)
+	if len(m.inbox.items) != 2 {
+		t.Errorf("expected 2 inbox items, got %d", len(m.inbox.items))
+	}
+}
+
+func TestSetDashboardInbox(t *testing.T) {
+	t.Parallel()
+	m := NewModel()
+	items := []state.InboxItem{
+		{Text: "a", Status: state.InboxNew},
+	}
+	m.SetDashboardInbox(items)
+	if len(m.dashboard.inboxItems) != 1 {
+		t.Errorf("expected 1 dashboard inbox item, got %d", len(m.dashboard.inboxItems))
+	}
+}
+
+func TestSetInboxReadError(t *testing.T) {
+	t.Parallel()
+	m := NewModel()
+	m.SetInboxReadError(true)
+	if !m.inbox.readErr {
+		t.Error("expected inbox readErr to be true")
+	}
+	m.SetInboxReadError(false)
+	if m.inbox.readErr {
+		t.Error("expected inbox readErr to be false")
+	}
+}
+
+func TestSearchContent_NodeDetail(t *testing.T) {
+	t.Parallel()
+	m := NewModel()
+	m.SetSize(80, 24)
+	node := &state.NodeState{
+		Tasks: []state.Task{{ID: "t1", Title: "Build widgets", State: state.StatusComplete}},
+	}
+	entry := &state.IndexEntry{Name: "Alpha", Type: state.NodeLeaf, State: state.StatusInProgress}
+	m.LoadNodeDetail("alpha", node, entry, false)
+	content := m.SearchContent()
+	if len(content) == 0 {
+		t.Error("expected non-empty SearchContent for node detail")
+	}
+}
+
+func TestSearchContent_TaskDetail(t *testing.T) {
+	t.Parallel()
+	m := NewModel()
+	m.SetSize(80, 24)
+	task := &state.Task{ID: "t1", Title: "Build", State: state.StatusInProgress}
+	m.LoadTaskDetail("alpha", "t1", task)
+	content := m.SearchContent()
+	if len(content) == 0 {
+		t.Error("expected non-empty SearchContent for task detail")
+	}
+}
+
+func TestSearchContent_LogStream(t *testing.T) {
+	t.Parallel()
+	m := NewModel()
+	m.SetSize(80, 24)
+	m.SwitchToLogView()
+	m.logView.AppendLines([]string{
+		`{"type":"stage_start","stage":"exec","node":"alpha","timestamp":"2026-01-01T00:00:00Z","level":"info"}`,
+	})
+	content := m.SearchContent()
+	if len(content) == 0 {
+		t.Error("expected non-empty SearchContent for log stream")
+	}
+}
+
+func TestSearchContent_Inbox(t *testing.T) {
+	t.Parallel()
+	m := NewModel()
+	m.SetSize(80, 24)
+	m.SwitchToInbox()
+	m.LoadInbox([]state.InboxItem{{Text: "hello", Status: state.InboxNew}})
+	content := m.SearchContent()
+	if len(content) == 0 {
+		t.Error("expected non-empty SearchContent for inbox")
+	}
+}
+
+func TestSearchContent_Dashboard_ReturnsNil(t *testing.T) {
+	t.Parallel()
+	m := NewModel()
+	content := m.SearchContent()
+	if content != nil {
+		t.Errorf("expected nil SearchContent for dashboard, got %d items", len(content))
+	}
+}
+
+func TestCopyTarget_NodeDetail(t *testing.T) {
+	t.Parallel()
+	m := NewModel()
+	m.SetSize(80, 24)
+	node := &state.NodeState{}
+	entry := &state.IndexEntry{Name: "Alpha", Type: state.NodeLeaf}
+	m.LoadNodeDetail("alpha", node, entry, false)
+	if m.CopyTarget() != "alpha" {
+		t.Errorf("expected copy target 'alpha', got %q", m.CopyTarget())
+	}
+}
+
+func TestCopyTarget_TaskDetail(t *testing.T) {
+	t.Parallel()
+	m := NewModel()
+	m.SetSize(80, 24)
+	task := &state.Task{ID: "t1", Title: "Build"}
+	m.LoadTaskDetail("alpha", "t1", task)
+	if m.CopyTarget() != "alpha/t1" {
+		t.Errorf("expected copy target 'alpha/t1', got %q", m.CopyTarget())
+	}
+}
+
+func TestCopyTarget_LogStream(t *testing.T) {
+	t.Parallel()
+	m := NewModel()
+	m.SetSize(80, 24)
+	m.SwitchToLogView()
+	// No lines loaded, so SelectedLineJSON returns empty
+	if m.CopyTarget() != "" {
+		t.Errorf("expected empty copy target for empty log view, got %q", m.CopyTarget())
+	}
+}
+
+func TestCopyTarget_Inbox(t *testing.T) {
+	t.Parallel()
+	m := NewModel()
+	m.SetSize(80, 24)
+	m.SwitchToInbox()
+	// No items loaded, so SelectedText returns empty
+	if m.CopyTarget() != "" {
+		t.Errorf("expected empty copy target for empty inbox, got %q", m.CopyTarget())
+	}
+}
+
+func TestCopyTarget_Dashboard_ReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	m := NewModel()
+	if m.CopyTarget() != "" {
+		t.Errorf("expected empty copy target for dashboard, got %q", m.CopyTarget())
+	}
+}
+
+func TestView_PlaceholderMode(t *testing.T) {
+	t.Parallel()
+	m := NewModel()
+	m.SetSize(80, 24)
+	m.mode = Mode(99)
+	// Should render the viewport's view without panic
+	_ = m.View()
+}

--- a/internal/tui/detail/nodedetail.go
+++ b/internal/tui/detail/nodedetail.go
@@ -12,9 +12,9 @@ import (
 	"github.com/dorkusprime/wolfcastle/internal/tui"
 )
 
-// NodeDetailModel renders detailed information about a single node, including
+// NodeModel renders detailed information about a single node, including
 // scope, success criteria, children or tasks, audit state, and specs.
-type NodeDetailModel struct {
+type NodeModel struct {
 	addr     string
 	node     *state.NodeState
 	index    *state.IndexEntry
@@ -25,15 +25,15 @@ type NodeDetailModel struct {
 	isTarget bool
 }
 
-// NewNodeDetailModel creates a NodeDetailModel with an empty viewport.
-func NewNodeDetailModel() NodeDetailModel {
-	return NodeDetailModel{
+// NewNodeModel creates a NodeModel with an empty viewport.
+func NewNodeModel() NodeModel {
+	return NodeModel{
 		viewport: viewport.New(),
 	}
 }
 
 // Load populates the model with node data and rebuilds the viewport content.
-func (m *NodeDetailModel) Load(addr string, node *state.NodeState, entry *state.IndexEntry, isTarget bool) {
+func (m *NodeModel) Load(addr string, node *state.NodeState, entry *state.IndexEntry, isTarget bool) {
 	m.addr = addr
 	m.node = node
 	m.index = entry
@@ -43,7 +43,7 @@ func (m *NodeDetailModel) Load(addr string, node *state.NodeState, entry *state.
 }
 
 // SetSize stores the available rendering area and propagates to the viewport.
-func (m *NodeDetailModel) SetSize(width, height int) {
+func (m *NodeModel) SetSize(width, height int) {
 	m.width = width
 	m.height = height
 	m.viewport.SetWidth(width)
@@ -52,7 +52,7 @@ func (m *NodeDetailModel) SetSize(width, height int) {
 }
 
 // SetReadError marks the model as unable to read node state.
-func (m *NodeDetailModel) SetReadError(addr string) {
+func (m *NodeModel) SetReadError(addr string) {
 	m.addr = addr
 	m.node = nil
 	m.index = nil
@@ -65,12 +65,12 @@ func (m *NodeDetailModel) SetReadError(addr string) {
 }
 
 // Addr returns the node address, suitable for clipboard copy.
-func (m NodeDetailModel) Addr() string {
+func (m NodeModel) Addr() string {
 	return m.addr
 }
 
 // Update forwards key events to the viewport for scrolling.
-func (m NodeDetailModel) Update(msg tea.Msg) (NodeDetailModel, tea.Cmd) {
+func (m NodeModel) Update(msg tea.Msg) (NodeModel, tea.Cmd) {
 	switch msg.(type) {
 	case tea.KeyPressMsg:
 		var cmd tea.Cmd
@@ -81,11 +81,11 @@ func (m NodeDetailModel) Update(msg tea.Msg) (NodeDetailModel, tea.Cmd) {
 }
 
 // View renders the viewport.
-func (m NodeDetailModel) View() string {
+func (m NodeModel) View() string {
 	return m.viewport.View()
 }
 
-func (m *NodeDetailModel) rebuildContent() {
+func (m *NodeModel) rebuildContent() {
 	if m.readErr || m.node == nil {
 		return
 	}
@@ -226,7 +226,7 @@ func (m *NodeDetailModel) rebuildContent() {
 }
 
 // SearchContent returns the viewport content split into lines for search.
-func (m NodeDetailModel) SearchContent() []string {
+func (m NodeModel) SearchContent() []string {
 	return strings.Split(m.viewport.GetContent(), "\n")
 }
 

--- a/internal/tui/detail/nodedetail_test.go
+++ b/internal/tui/detail/nodedetail_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/dorkusprime/wolfcastle/internal/state"
 )
 
-func TestNewNodeDetailModel_Defaults(t *testing.T) {
+func TestNewNodeModel_Defaults(t *testing.T) {
 	t.Parallel()
-	m := NewNodeDetailModel()
+	m := NewNodeModel()
 	if m.addr != "" {
 		t.Errorf("addr should be empty, got %q", m.addr)
 	}
@@ -57,7 +57,7 @@ func makeLeafNode() *state.NodeState {
 
 func TestLoad_OrchestratorNode(t *testing.T) {
 	t.Parallel()
-	m := NewNodeDetailModel()
+	m := NewNodeModel()
 	m.SetSize(80, 40)
 	node := makeOrchestratorNode()
 	m.Load("root", node, nil, false)
@@ -82,7 +82,7 @@ func TestLoad_OrchestratorNode(t *testing.T) {
 
 func TestLoad_LeafNode(t *testing.T) {
 	t.Parallel()
-	m := NewNodeDetailModel()
+	m := NewNodeModel()
 	m.SetSize(80, 40)
 	node := makeLeafNode()
 	m.Load("root/leaf-1", node, nil, false)
@@ -108,7 +108,7 @@ func TestLoad_LeafNode(t *testing.T) {
 
 func TestLoad_WithAuditData(t *testing.T) {
 	t.Parallel()
-	m := NewNodeDetailModel()
+	m := NewNodeModel()
 	m.SetSize(80, 40)
 
 	started := time.Now().Add(-5 * time.Minute)
@@ -157,7 +157,7 @@ func TestLoad_WithAuditData(t *testing.T) {
 
 func TestLoad_WithScope(t *testing.T) {
 	t.Parallel()
-	m := NewNodeDetailModel()
+	m := NewNodeModel()
 	m.SetSize(80, 40)
 
 	node := &state.NodeState{
@@ -181,7 +181,7 @@ func TestLoad_WithScope(t *testing.T) {
 
 func TestLoad_WithCriteria(t *testing.T) {
 	t.Parallel()
-	m := NewNodeDetailModel()
+	m := NewNodeModel()
 	m.SetSize(80, 40)
 
 	node := &state.NodeState{
@@ -208,7 +208,7 @@ func TestLoad_WithCriteria(t *testing.T) {
 
 func TestLoad_WithSpecs(t *testing.T) {
 	t.Parallel()
-	m := NewNodeDetailModel()
+	m := NewNodeModel()
 	m.SetSize(80, 40)
 
 	node := &state.NodeState{
@@ -232,7 +232,7 @@ func TestLoad_WithSpecs(t *testing.T) {
 
 func TestLoad_IsTarget(t *testing.T) {
 	t.Parallel()
-	m := NewNodeDetailModel()
+	m := NewNodeModel()
 	m.SetSize(80, 40)
 
 	node := &state.NodeState{
@@ -252,7 +252,7 @@ func TestLoad_IsTarget(t *testing.T) {
 
 func TestLoad_NotTarget(t *testing.T) {
 	t.Parallel()
-	m := NewNodeDetailModel()
+	m := NewNodeModel()
 	m.SetSize(80, 40)
 
 	node := &state.NodeState{
@@ -272,7 +272,7 @@ func TestLoad_NotTarget(t *testing.T) {
 
 func TestSetReadError(t *testing.T) {
 	t.Parallel()
-	m := NewNodeDetailModel()
+	m := NewNodeModel()
 	m.SetSize(80, 40)
 	m.SetReadError("root/broken")
 
@@ -290,7 +290,7 @@ func TestSetReadError(t *testing.T) {
 
 func TestAddr(t *testing.T) {
 	t.Parallel()
-	m := NewNodeDetailModel()
+	m := NewNodeModel()
 	m.SetSize(80, 40)
 	node := makeOrchestratorNode()
 	m.Load("root/proj", node, nil, false)
@@ -302,7 +302,7 @@ func TestAddr(t *testing.T) {
 
 func TestSetSize_Propagates(t *testing.T) {
 	t.Parallel()
-	m := NewNodeDetailModel()
+	m := NewNodeModel()
 	m.SetSize(120, 50)
 
 	if m.width != 120 {
@@ -391,7 +391,7 @@ func TestRelativeTime_Future(t *testing.T) {
 
 func TestEmptySections_Omitted(t *testing.T) {
 	t.Parallel()
-	m := NewNodeDetailModel()
+	m := NewNodeModel()
 	m.SetSize(80, 40)
 
 	// A minimal node with no scope, criteria, children, tasks, audit, specs
@@ -424,7 +424,7 @@ func TestEmptySections_Omitted(t *testing.T) {
 
 func TestAudit_InProgress_ShowsInProgress(t *testing.T) {
 	t.Parallel()
-	m := NewNodeDetailModel()
+	m := NewNodeModel()
 	m.SetSize(80, 40)
 
 	started := time.Now().Add(-10 * time.Minute)
@@ -449,7 +449,7 @@ func TestAudit_InProgress_ShowsInProgress(t *testing.T) {
 
 func TestAudit_NoSummary_ShowsNoneYet(t *testing.T) {
 	t.Parallel()
-	m := NewNodeDetailModel()
+	m := NewNodeModel()
 	m.SetSize(80, 40)
 
 	node := &state.NodeState{
@@ -472,7 +472,7 @@ func TestAudit_NoSummary_ShowsNoneYet(t *testing.T) {
 
 func TestUpdate_PassesToViewport(t *testing.T) {
 	t.Parallel()
-	m := NewNodeDetailModel()
+	m := NewNodeModel()
 	m.SetSize(80, 40)
 	node := makeOrchestratorNode()
 	m.Load("root", node, nil, false)
@@ -483,7 +483,7 @@ func TestUpdate_PassesToViewport(t *testing.T) {
 
 func TestNodeDetail_Update_NonKeyMsg_Ignored(t *testing.T) {
 	t.Parallel()
-	m := NewNodeDetailModel()
+	m := NewNodeModel()
 	type customMsg struct{}
 	_, _ = m.Update(customMsg{})
 }
@@ -562,7 +562,7 @@ func TestWrapIndent_NarrowWidth(t *testing.T) {
 
 func TestRebuildContent_NilNode(t *testing.T) {
 	t.Parallel()
-	m := NewNodeDetailModel()
+	m := NewNodeModel()
 	m.SetSize(80, 40)
 	// rebuildContent with nil node should not panic
 	m.rebuildContent()
@@ -570,7 +570,7 @@ func TestRebuildContent_NilNode(t *testing.T) {
 
 func TestRebuildContent_ReadError(t *testing.T) {
 	t.Parallel()
-	m := NewNodeDetailModel()
+	m := NewNodeModel()
 	m.SetSize(80, 40)
 	m.readErr = true
 	// rebuildContent with readErr should bail early without panic
@@ -579,7 +579,7 @@ func TestRebuildContent_ReadError(t *testing.T) {
 
 func TestSetSize_SmallWidth(t *testing.T) {
 	t.Parallel()
-	m := NewNodeDetailModel()
+	m := NewNodeModel()
 	node := makeOrchestratorNode()
 	node.Scope = "Some scope text that needs wrapping"
 	m.SetSize(10, 40)

--- a/internal/tui/detail/taskdetail.go
+++ b/internal/tui/detail/taskdetail.go
@@ -11,10 +11,10 @@ import (
 	"github.com/dorkusprime/wolfcastle/internal/tui"
 )
 
-// TaskDetailModel renders detailed information about a single task, including
+// TaskModel renders detailed information about a single task, including
 // description, body, deliverables, acceptance criteria, constraints, and
 // failure information.
-type TaskDetailModel struct {
+type TaskModel struct {
 	addr     string
 	taskID   string
 	task     *state.Task
@@ -23,15 +23,15 @@ type TaskDetailModel struct {
 	height   int
 }
 
-// NewTaskDetailModel creates a TaskDetailModel with an empty viewport.
-func NewTaskDetailModel() TaskDetailModel {
-	return TaskDetailModel{
+// NewTaskModel creates a TaskModel with an empty viewport.
+func NewTaskModel() TaskModel {
+	return TaskModel{
 		viewport: viewport.New(),
 	}
 }
 
 // Load populates the model with task data and rebuilds the viewport content.
-func (m *TaskDetailModel) Load(addr, taskID string, task *state.Task) {
+func (m *TaskModel) Load(addr, taskID string, task *state.Task) {
 	m.addr = addr
 	m.taskID = taskID
 	m.task = task
@@ -39,7 +39,7 @@ func (m *TaskDetailModel) Load(addr, taskID string, task *state.Task) {
 }
 
 // SetSize stores the available rendering area and propagates to the viewport.
-func (m *TaskDetailModel) SetSize(width, height int) {
+func (m *TaskModel) SetSize(width, height int) {
 	m.width = width
 	m.height = height
 	m.viewport.SetWidth(width)
@@ -48,12 +48,12 @@ func (m *TaskDetailModel) SetSize(width, height int) {
 }
 
 // TaskAddr returns the fully qualified task address for clipboard copy.
-func (m TaskDetailModel) TaskAddr() string {
+func (m TaskModel) TaskAddr() string {
 	return m.addr + "/" + m.taskID
 }
 
 // Update forwards key events to the viewport for scrolling.
-func (m TaskDetailModel) Update(msg tea.Msg) (TaskDetailModel, tea.Cmd) {
+func (m TaskModel) Update(msg tea.Msg) (TaskModel, tea.Cmd) {
 	switch msg.(type) {
 	case tea.KeyPressMsg:
 		var cmd tea.Cmd
@@ -64,16 +64,16 @@ func (m TaskDetailModel) Update(msg tea.Msg) (TaskDetailModel, tea.Cmd) {
 }
 
 // View renders the viewport.
-func (m TaskDetailModel) View() string {
+func (m TaskModel) View() string {
 	return m.viewport.View()
 }
 
 // SearchContent returns the viewport content split into lines for search.
-func (m TaskDetailModel) SearchContent() []string {
+func (m TaskModel) SearchContent() []string {
 	return strings.Split(m.viewport.GetContent(), "\n")
 }
 
-func (m *TaskDetailModel) rebuildContent() {
+func (m *TaskModel) rebuildContent() {
 	if m.task == nil {
 		return
 	}

--- a/internal/tui/detail/taskdetail_test.go
+++ b/internal/tui/detail/taskdetail_test.go
@@ -36,9 +36,9 @@ func makeMinimalTask() *state.Task {
 	}
 }
 
-func TestNewTaskDetailModel_Defaults(t *testing.T) {
+func TestNewTaskModel_Defaults(t *testing.T) {
 	t.Parallel()
-	m := NewTaskDetailModel()
+	m := NewTaskModel()
 	if m.addr != "" {
 		t.Errorf("addr should be empty, got %q", m.addr)
 	}
@@ -52,7 +52,7 @@ func TestNewTaskDetailModel_Defaults(t *testing.T) {
 
 func TestLoad_FullTask(t *testing.T) {
 	t.Parallel()
-	m := NewTaskDetailModel()
+	m := NewTaskModel()
 	m.SetSize(80, 40)
 	task := makeFullTask()
 	m.Load("root/leaf", "task-0001", task)
@@ -148,7 +148,7 @@ func TestLoad_FullTask(t *testing.T) {
 
 func TestLoad_MinimalTask(t *testing.T) {
 	t.Parallel()
-	m := NewTaskDetailModel()
+	m := NewTaskModel()
 	m.SetSize(80, 40)
 	task := makeMinimalTask()
 	m.Load("root/leaf", "task-0002", task)
@@ -192,7 +192,7 @@ func TestLoad_MinimalTask(t *testing.T) {
 
 func TestTaskAddr(t *testing.T) {
 	t.Parallel()
-	m := NewTaskDetailModel()
+	m := NewTaskModel()
 	m.Load("root/leaf", "task-0001", makeFullTask())
 
 	got := m.TaskAddr()
@@ -203,7 +203,7 @@ func TestTaskAddr(t *testing.T) {
 
 func TestBlockReason_None(t *testing.T) {
 	t.Parallel()
-	m := NewTaskDetailModel()
+	m := NewTaskModel()
 	m.SetSize(80, 40)
 	task := &state.Task{
 		ID:          "t1",
@@ -220,7 +220,7 @@ func TestBlockReason_None(t *testing.T) {
 
 func TestBlockReason_Present(t *testing.T) {
 	t.Parallel()
-	m := NewTaskDetailModel()
+	m := NewTaskModel()
 	m.SetSize(80, 40)
 	task := &state.Task{
 		ID:            "t1",
@@ -238,7 +238,7 @@ func TestBlockReason_Present(t *testing.T) {
 
 func TestFailureCount(t *testing.T) {
 	t.Parallel()
-	m := NewTaskDetailModel()
+	m := NewTaskModel()
 	m.SetSize(80, 40)
 	task := &state.Task{
 		ID:           "t1",
@@ -256,7 +256,7 @@ func TestFailureCount(t *testing.T) {
 
 func TestLastFailureType(t *testing.T) {
 	t.Parallel()
-	m := NewTaskDetailModel()
+	m := NewTaskModel()
 	m.SetSize(80, 40)
 	task := &state.Task{
 		ID:              "t1",
@@ -274,7 +274,7 @@ func TestLastFailureType(t *testing.T) {
 
 func TestNeedsDecomposition_Yes(t *testing.T) {
 	t.Parallel()
-	m := NewTaskDetailModel()
+	m := NewTaskModel()
 	m.SetSize(80, 40)
 	task := &state.Task{
 		ID:                 "t1",
@@ -292,7 +292,7 @@ func TestNeedsDecomposition_Yes(t *testing.T) {
 
 func TestNeedsDecomposition_No(t *testing.T) {
 	t.Parallel()
-	m := NewTaskDetailModel()
+	m := NewTaskModel()
 	m.SetSize(80, 40)
 	task := &state.Task{
 		ID:          "t1",
@@ -309,7 +309,7 @@ func TestNeedsDecomposition_No(t *testing.T) {
 
 func TestIsAudit_Yes(t *testing.T) {
 	t.Parallel()
-	m := NewTaskDetailModel()
+	m := NewTaskModel()
 	m.SetSize(80, 40)
 	task := &state.Task{
 		ID:          "t1",
@@ -327,7 +327,7 @@ func TestIsAudit_Yes(t *testing.T) {
 
 func TestIsAudit_No(t *testing.T) {
 	t.Parallel()
-	m := NewTaskDetailModel()
+	m := NewTaskModel()
 	m.SetSize(80, 40)
 	task := &state.Task{
 		ID:          "t1",
@@ -344,7 +344,7 @@ func TestIsAudit_No(t *testing.T) {
 
 func TestDeliverables_Bulleted(t *testing.T) {
 	t.Parallel()
-	m := NewTaskDetailModel()
+	m := NewTaskModel()
 	m.SetSize(80, 40)
 	task := &state.Task{
 		ID:           "t1",
@@ -368,7 +368,7 @@ func TestDeliverables_Bulleted(t *testing.T) {
 
 func TestAcceptanceCriteria_Bulleted(t *testing.T) {
 	t.Parallel()
-	m := NewTaskDetailModel()
+	m := NewTaskModel()
 	m.SetSize(80, 40)
 	task := &state.Task{
 		ID:                 "t1",
@@ -386,7 +386,7 @@ func TestAcceptanceCriteria_Bulleted(t *testing.T) {
 
 func TestConstraints_Bulleted(t *testing.T) {
 	t.Parallel()
-	m := NewTaskDetailModel()
+	m := NewTaskModel()
 	m.SetSize(80, 40)
 	task := &state.Task{
 		ID:          "t1",
@@ -404,7 +404,7 @@ func TestConstraints_Bulleted(t *testing.T) {
 
 func TestReferences_Listed(t *testing.T) {
 	t.Parallel()
-	m := NewTaskDetailModel()
+	m := NewTaskModel()
 	m.SetSize(80, 40)
 	task := &state.Task{
 		ID:          "t1",
@@ -425,7 +425,7 @@ func TestReferences_Listed(t *testing.T) {
 
 func TestBody_Present(t *testing.T) {
 	t.Parallel()
-	m := NewTaskDetailModel()
+	m := NewTaskModel()
 	m.SetSize(80, 40)
 	task := &state.Task{
 		ID:          "t1",
@@ -446,7 +446,7 @@ func TestBody_Present(t *testing.T) {
 
 func TestClassAndType(t *testing.T) {
 	t.Parallel()
-	m := NewTaskDetailModel()
+	m := NewTaskModel()
 	m.SetSize(80, 40)
 	task := &state.Task{
 		ID:          "t1",
@@ -468,7 +468,7 @@ func TestClassAndType(t *testing.T) {
 
 func TestClassAndType_OnlyClass(t *testing.T) {
 	t.Parallel()
-	m := NewTaskDetailModel()
+	m := NewTaskModel()
 	m.SetSize(80, 40)
 	task := &state.Task{
 		ID:          "t1",
@@ -486,7 +486,7 @@ func TestClassAndType_OnlyClass(t *testing.T) {
 
 func TestClassAndType_Neither(t *testing.T) {
 	t.Parallel()
-	m := NewTaskDetailModel()
+	m := NewTaskModel()
 	m.SetSize(80, 40)
 	task := &state.Task{
 		ID:          "t1",
@@ -503,7 +503,7 @@ func TestClassAndType_Neither(t *testing.T) {
 
 func TestSetSize_Propagates_Task(t *testing.T) {
 	t.Parallel()
-	m := NewTaskDetailModel()
+	m := NewTaskModel()
 	m.SetSize(100, 30)
 
 	if m.width != 100 {
@@ -516,7 +516,7 @@ func TestSetSize_Propagates_Task(t *testing.T) {
 
 func TestSetSize_SmallWidth_Task(t *testing.T) {
 	t.Parallel()
-	m := NewTaskDetailModel()
+	m := NewTaskModel()
 	m.SetSize(10, 30)
 	task := makeFullTask()
 	m.Load("root/leaf", "task-0001", task)
@@ -530,7 +530,7 @@ func TestSetSize_SmallWidth_Task(t *testing.T) {
 
 func TestUpdate_Task_PassesToViewport(t *testing.T) {
 	t.Parallel()
-	m := NewTaskDetailModel()
+	m := NewTaskModel()
 	m.SetSize(80, 40)
 	m.Load("root", "t1", makeFullTask())
 
@@ -540,14 +540,14 @@ func TestUpdate_Task_PassesToViewport(t *testing.T) {
 
 func TestUpdate_Task_NonKeyMsg_Ignored(t *testing.T) {
 	t.Parallel()
-	m := NewTaskDetailModel()
+	m := NewTaskModel()
 	type customMsg struct{}
 	_, _ = m.Update(customMsg{})
 }
 
 func TestRebuildContent_NilTask(t *testing.T) {
 	t.Parallel()
-	m := NewTaskDetailModel()
+	m := NewTaskModel()
 	m.SetSize(80, 40)
 	// rebuildContent with nil task should not panic
 	m.rebuildContent()
@@ -565,7 +565,7 @@ func TestBoolYesNo(t *testing.T) {
 
 func TestTitle_Present(t *testing.T) {
 	t.Parallel()
-	m := NewTaskDetailModel()
+	m := NewTaskModel()
 	m.SetSize(80, 40)
 	task := &state.Task{
 		ID:          "t1",
@@ -583,7 +583,7 @@ func TestTitle_Present(t *testing.T) {
 
 func TestTitle_Empty(t *testing.T) {
 	t.Parallel()
-	m := NewTaskDetailModel()
+	m := NewTaskModel()
 	m.SetSize(80, 40)
 	task := &state.Task{
 		ID:          "t1",

--- a/internal/tui/footer/model.go
+++ b/internal/tui/footer/model.go
@@ -1,3 +1,4 @@
+// Package footer implements the single-line key-hint bar displayed at the bottom of the TUI.
 package footer
 
 import (

--- a/internal/tui/footer/model.go
+++ b/internal/tui/footer/model.go
@@ -10,21 +10,21 @@ import (
 	"github.com/dorkusprime/wolfcastle/internal/tui"
 )
 
-// FooterModel renders a single-line key-hint bar at the bottom of the TUI.
-type FooterModel struct {
+// Model renders a single-line key-hint bar at the bottom of the TUI.
+type Model struct {
 	focusedPane   int // 0=PaneTree, 1=PaneDetail
 	detailMode    int // 0=Dashboard, 1=NodeDetail, 2=TaskDetail, 3=LogStream, 4=Inbox
 	daemonRunning bool
 	width         int
 }
 
-// NewFooterModel returns a zero-value footer ready for use.
-func NewFooterModel() FooterModel {
-	return FooterModel{}
+// NewModel returns a zero-value footer ready for use.
+func NewModel() Model {
+	return Model{}
 }
 
 // Update handles messages relevant to the footer.
-func (m FooterModel) Update(msg tea.Msg) (FooterModel, tea.Cmd) {
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
@@ -36,22 +36,22 @@ func (m FooterModel) Update(msg tea.Msg) (FooterModel, tea.Cmd) {
 }
 
 // SetFocus updates which pane is focused.
-func (m *FooterModel) SetFocus(pane int) {
+func (m *Model) SetFocus(pane int) {
 	m.focusedPane = pane
 }
 
 // SetDetailMode updates the current detail-pane mode.
-func (m *FooterModel) SetDetailMode(mode int) {
+func (m *Model) SetDetailMode(mode int) {
 	m.detailMode = mode
 }
 
 // SetSize updates the available width for rendering.
-func (m *FooterModel) SetSize(width int) {
+func (m *Model) SetSize(width int) {
 	m.width = width
 }
 
 // View renders the footer as a single line of key hints.
-func (m FooterModel) View() string {
+func (m Model) View() string {
 	style := lipgloss.NewStyle().Foreground(tui.ColorDimWhite)
 
 	// Build hints in priority order (highest priority first).

--- a/internal/tui/footer/model_test.go
+++ b/internal/tui/footer/model_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/dorkusprime/wolfcastle/internal/tui"
 )
 
-func TestNewFooterModel_ZeroValues(t *testing.T) {
+func TestNewModel_ZeroValues(t *testing.T) {
 	t.Parallel()
-	m := NewFooterModel()
+	m := NewModel()
 	if m.focusedPane != 0 {
 		t.Errorf("expected focusedPane 0, got %d", m.focusedPane)
 	}
@@ -25,7 +25,7 @@ func TestNewFooterModel_ZeroValues(t *testing.T) {
 
 func TestView_RendersKeyHints(t *testing.T) {
 	t.Parallel()
-	m := NewFooterModel()
+	m := NewModel()
 	m.width = 200 // wide enough for all hints
 	v := m.View()
 	if !strings.Contains(v, "[q] quit") {
@@ -44,7 +44,7 @@ func TestView_RendersKeyHints(t *testing.T) {
 
 func TestDaemonStatusMsg_Running_ShowsStop(t *testing.T) {
 	t.Parallel()
-	m := NewFooterModel()
+	m := NewModel()
 	m.width = 200
 	m, _ = m.Update(tui.DaemonStatusMsg{IsRunning: true})
 	v := m.View()
@@ -55,7 +55,7 @@ func TestDaemonStatusMsg_Running_ShowsStop(t *testing.T) {
 
 func TestDaemonStatusMsg_NotRunning_ShowsStart(t *testing.T) {
 	t.Parallel()
-	m := NewFooterModel()
+	m := NewModel()
 	m.width = 200
 	m, _ = m.Update(tui.DaemonStatusMsg{IsRunning: false})
 	v := m.View()
@@ -66,7 +66,7 @@ func TestDaemonStatusMsg_NotRunning_ShowsStart(t *testing.T) {
 
 func TestSetFocus_UpdatesPane(t *testing.T) {
 	t.Parallel()
-	m := NewFooterModel()
+	m := NewModel()
 	m.SetFocus(1)
 	if m.focusedPane != 1 {
 		t.Errorf("expected focusedPane 1, got %d", m.focusedPane)
@@ -79,7 +79,7 @@ func TestSetFocus_UpdatesPane(t *testing.T) {
 
 func TestSetSize_UpdatesWidth(t *testing.T) {
 	t.Parallel()
-	m := NewFooterModel()
+	m := NewModel()
 	m.SetSize(80)
 	if m.width != 80 {
 		t.Errorf("expected width 80, got %d", m.width)
@@ -88,7 +88,7 @@ func TestSetSize_UpdatesWidth(t *testing.T) {
 
 func TestSetDetailMode(t *testing.T) {
 	t.Parallel()
-	m := NewFooterModel()
+	m := NewModel()
 	m.SetDetailMode(2)
 	if m.detailMode != 2 {
 		t.Errorf("expected detailMode 2, got %d", m.detailMode)
@@ -97,7 +97,7 @@ func TestSetDetailMode(t *testing.T) {
 
 func TestTruncation_NarrowWidth(t *testing.T) {
 	t.Parallel()
-	m := NewFooterModel()
+	m := NewModel()
 	// Set width so narrow that only a few hints fit
 	m.width = 25
 	v := m.View()
@@ -113,7 +113,7 @@ func TestTruncation_NarrowWidth(t *testing.T) {
 
 func TestTruncation_VeryNarrow(t *testing.T) {
 	t.Parallel()
-	m := NewFooterModel()
+	m := NewModel()
 	m.width = 10
 	v := m.View()
 	// At width 10, only "[q] quit" (8 chars) should fit
@@ -127,7 +127,7 @@ func TestTruncation_VeryNarrow(t *testing.T) {
 
 func TestTruncation_ZeroWidth_NoLimit(t *testing.T) {
 	t.Parallel()
-	m := NewFooterModel()
+	m := NewModel()
 	m.width = 0 // zero means no limit
 	v := m.View()
 	// All hints should render
@@ -138,7 +138,7 @@ func TestTruncation_ZeroWidth_NoLimit(t *testing.T) {
 
 func TestWindowSizeMsg_UpdatesWidth(t *testing.T) {
 	t.Parallel()
-	m := NewFooterModel()
+	m := NewModel()
 	m, _ = m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 	if m.width != 120 {
 		t.Errorf("expected width 120, got %d", m.width)
@@ -147,7 +147,7 @@ func TestWindowSizeMsg_UpdatesWidth(t *testing.T) {
 
 func TestUpdate_UnhandledMsg_NoChange(t *testing.T) {
 	t.Parallel()
-	m := NewFooterModel()
+	m := NewModel()
 	m.width = 80
 	m2, cmd := m.Update(tea.FocusMsg{})
 	if cmd != nil {

--- a/internal/tui/header/model.go
+++ b/internal/tui/header/model.go
@@ -82,11 +82,11 @@ var statusOrder = []state.NodeStatus{
 }
 
 // ---------------------------------------------------------------------------
-// HeaderModel
+// Model
 // ---------------------------------------------------------------------------
 
-// HeaderModel is the sub-model for the TUI top bar.
-type HeaderModel struct {
+// Model is the sub-model for the TUI top bar.
+type Model struct {
 	version         string
 	daemonStatus    string
 	branch          string
@@ -106,9 +106,9 @@ type HeaderModel struct {
 	statusHint  string // transient hint like "Starting daemon..."
 }
 
-// NewHeaderModel creates a HeaderModel with sensible zero-state defaults.
-func NewHeaderModel(version string) HeaderModel {
-	return HeaderModel{
+// NewModel creates a Model with sensible zero-state defaults.
+func NewModel(version string) Model {
+	return Model{
 		version:      version,
 		daemonStatus: "standing down",
 		nodeCounts:   make(map[state.NodeStatus]int),
@@ -117,22 +117,22 @@ func NewHeaderModel(version string) HeaderModel {
 }
 
 // SetSize updates the available width.
-func (m *HeaderModel) SetSize(width int) {
+func (m *Model) SetSize(width int) {
 	m.width = width
 }
 
 // SetLoading sets the loading spinner state.
-func (m *HeaderModel) SetLoading(loading bool) {
+func (m *Model) SetLoading(loading bool) {
 	m.loading = loading
 }
 
 // IsLoading returns true when the loading spinner is active.
-func (m HeaderModel) IsLoading() bool {
+func (m Model) IsLoading() bool {
 	return m.loading
 }
 
 // SetInstances updates the instance list and active index for the tab bar.
-func (m *HeaderModel) SetInstances(entries []instance.Entry, activeIdx int) {
+func (m *Model) SetInstances(entries []instance.Entry, activeIdx int) {
 	m.instances = entries
 	m.activeIndex = activeIdx
 	m.instanceCount = len(entries)
@@ -140,7 +140,7 @@ func (m *HeaderModel) SetInstances(entries []instance.Entry, activeIdx int) {
 
 // SetStatusHint sets a transient status message (e.g. "Starting daemon...").
 // Pass an empty string to clear.
-func (m *HeaderModel) SetStatusHint(hint string) {
+func (m *Model) SetStatusHint(hint string) {
 	m.statusHint = hint
 }
 
@@ -149,7 +149,7 @@ func (m *HeaderModel) SetStatusHint(hint string) {
 // ---------------------------------------------------------------------------
 
 // Update processes messages relevant to the header.
-func (m HeaderModel) Update(msg tea.Msg) (HeaderModel, tea.Cmd) {
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 
 	case DaemonStatusMsg:
@@ -191,7 +191,7 @@ func (m HeaderModel) Update(msg tea.Msg) (HeaderModel, tea.Cmd) {
 // ---------------------------------------------------------------------------
 
 // View renders the header bar with top/bottom and left/right padding.
-func (m HeaderModel) View() string {
+func (m Model) View() string {
 	if m.width <= 0 {
 		return ""
 	}
@@ -293,7 +293,7 @@ func daemonStatusString(msg DaemonStatusMsg) string {
 }
 
 // renderNodeCounts builds the "12 nodes: 4● 3◐ 3◯ 2☢" string.
-func (m HeaderModel) renderNodeCounts(base lipgloss.Style) string {
+func (m Model) renderNodeCounts(base lipgloss.Style) string {
 	if m.totalNodes == 0 {
 		return base.Render("0 nodes")
 	}
@@ -331,7 +331,7 @@ func composeLine(base lipgloss.Style, left, right string, width int) string {
 }
 
 // renderTabBar builds the instance tab bar: [feat/auth ●] [fix/login]
-func (m HeaderModel) renderTabBar(base, bold lipgloss.Style, width int) string {
+func (m Model) renderTabBar(base, bold lipgloss.Style, width int) string {
 	dimStyle := lipgloss.NewStyle().
 		Background(headerBg).
 		Foreground(clrDim)

--- a/internal/tui/header/model_test.go
+++ b/internal/tui/header/model_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSetInstances(t *testing.T) {
-	m := NewHeaderModel("1.0.0")
+	m := NewModel("1.0.0")
 
 	entries := []instance.Entry{
 		{PID: 100, Worktree: "/a", Branch: "feat/auth"},
@@ -31,7 +31,7 @@ func TestSetInstances(t *testing.T) {
 }
 
 func TestViewTabBarWideTerminal(t *testing.T) {
-	m := NewHeaderModel("1.0.0")
+	m := NewModel("1.0.0")
 	m.SetSize(120)
 	m.SetInstances([]instance.Entry{
 		{PID: 100, Branch: "feat/auth"},
@@ -56,7 +56,7 @@ func TestViewTabBarWideTerminal(t *testing.T) {
 }
 
 func TestViewNoTabBarNarrowTerminal(t *testing.T) {
-	m := NewHeaderModel("1.0.0")
+	m := NewModel("1.0.0")
 	m.SetSize(80) // <= 100: no tab bar
 	m.SetInstances([]instance.Entry{
 		{PID: 100, Branch: "feat/auth"},
@@ -78,7 +78,7 @@ func TestViewNoTabBarNarrowTerminal(t *testing.T) {
 }
 
 func TestActiveInstanceMarker(t *testing.T) {
-	m := NewHeaderModel("1.0.0")
+	m := NewModel("1.0.0")
 	m.SetSize(120)
 	m.SetInstances([]instance.Entry{
 		{PID: 100, Branch: "feat/auth"},
@@ -107,7 +107,7 @@ func TestActiveInstanceMarker(t *testing.T) {
 }
 
 func TestSetLoadingAndIsLoading(t *testing.T) {
-	m := NewHeaderModel("1.0.0")
+	m := NewModel("1.0.0")
 	if m.IsLoading() {
 		t.Error("new model should not be loading")
 	}
@@ -124,7 +124,7 @@ func TestSetLoadingAndIsLoading(t *testing.T) {
 }
 
 func TestViewZeroWidth(t *testing.T) {
-	m := NewHeaderModel("1.0.0")
+	m := NewModel("1.0.0")
 	// Width 0 should return empty string.
 	if v := m.View(); v != "" {
 		t.Errorf("expected empty view for zero width, got %q", v)
@@ -132,7 +132,7 @@ func TestViewZeroWidth(t *testing.T) {
 }
 
 func TestViewNarrowTerminal(t *testing.T) {
-	m := NewHeaderModel("1.0.0")
+	m := NewModel("1.0.0")
 	m.SetSize(30) // < 40 triggers single-line mode
 	view := m.View()
 	lines := strings.Split(view, "\n")
@@ -142,7 +142,7 @@ func TestViewNarrowTerminal(t *testing.T) {
 }
 
 func TestViewContainsVersion(t *testing.T) {
-	m := NewHeaderModel("2.3.4")
+	m := NewModel("2.3.4")
 	m.SetSize(120)
 	view := m.View()
 	if !strings.Contains(view, "2.3.4") {
@@ -151,7 +151,7 @@ func TestViewContainsVersion(t *testing.T) {
 }
 
 func TestViewShowsLoadingSpinner(t *testing.T) {
-	m := NewHeaderModel("1.0.0")
+	m := NewModel("1.0.0")
 	m.SetSize(120)
 	m.SetLoading(true)
 	view := m.View()
@@ -162,7 +162,7 @@ func TestViewShowsLoadingSpinner(t *testing.T) {
 }
 
 func TestUpdateDaemonStatusMsg(t *testing.T) {
-	m := NewHeaderModel("1.0.0")
+	m := NewModel("1.0.0")
 	m.SetSize(120)
 
 	msg := DaemonStatusMsg{
@@ -188,7 +188,7 @@ func TestUpdateDaemonStatusMsg(t *testing.T) {
 }
 
 func TestUpdateStateUpdatedMsg(t *testing.T) {
-	m := NewHeaderModel("1.0.0")
+	m := NewModel("1.0.0")
 	m.SetSize(120)
 
 	idx := &state.RootIndex{
@@ -214,7 +214,7 @@ func TestUpdateStateUpdatedMsg(t *testing.T) {
 }
 
 func TestUpdateStateUpdatedMsgNilIndex(t *testing.T) {
-	m := NewHeaderModel("1.0.0")
+	m := NewModel("1.0.0")
 	m.SetSize(120)
 	m, _ = m.Update(StateUpdatedMsg{Index: nil})
 	if m.totalNodes != 0 {
@@ -223,7 +223,7 @@ func TestUpdateStateUpdatedMsgNilIndex(t *testing.T) {
 }
 
 func TestUpdateInstancesUpdatedMsg(t *testing.T) {
-	m := NewHeaderModel("1.0.0")
+	m := NewModel("1.0.0")
 	m, _ = m.Update(InstancesUpdatedMsg{Instances: []instance.Entry{{PID: 1}, {PID: 2}, {PID: 3}}})
 	if m.instanceCount != 3 {
 		t.Errorf("instanceCount = %d, want 3", m.instanceCount)
@@ -231,7 +231,7 @@ func TestUpdateInstancesUpdatedMsg(t *testing.T) {
 }
 
 func TestUpdateSpinnerTickMsg(t *testing.T) {
-	m := NewHeaderModel("1.0.0")
+	m := NewModel("1.0.0")
 	if m.spinner != 0 {
 		t.Fatalf("initial spinner = %d, want 0", m.spinner)
 	}
@@ -249,7 +249,7 @@ func TestUpdateSpinnerTickMsg(t *testing.T) {
 }
 
 func TestUpdateWindowSizeMsg(t *testing.T) {
-	m := NewHeaderModel("1.0.0")
+	m := NewModel("1.0.0")
 	m, _ = m.Update(tea.WindowSizeMsg{Width: 200, Height: 50})
 	if m.width != 200 {
 		t.Errorf("width = %d, want 200", m.width)
@@ -312,7 +312,7 @@ func TestPluralize(t *testing.T) {
 }
 
 func TestRenderTabBarSingleInstance(t *testing.T) {
-	m := NewHeaderModel("1.0.0")
+	m := NewModel("1.0.0")
 	m.SetSize(120)
 	m.SetInstances([]instance.Entry{
 		{PID: 100, Branch: "main"},
@@ -327,7 +327,7 @@ func TestRenderTabBarSingleInstance(t *testing.T) {
 }
 
 func TestRenderNodeCountsZero(t *testing.T) {
-	m := NewHeaderModel("1.0.0")
+	m := NewModel("1.0.0")
 	m.SetSize(120)
 	view := m.View()
 	if !strings.Contains(view, "0 nodes") {
@@ -336,7 +336,7 @@ func TestRenderNodeCountsZero(t *testing.T) {
 }
 
 func TestSetStatusHintReplacesStatus(t *testing.T) {
-	m := NewHeaderModel("1.0.0")
+	m := NewModel("1.0.0")
 	m.SetSize(120)
 
 	// Default should show daemon status text.

--- a/internal/tui/help/model.go
+++ b/internal/tui/help/model.go
@@ -1,3 +1,4 @@
+// Package help implements the scrollable key-binding help overlay for the TUI.
 package help
 
 import (
@@ -146,10 +147,15 @@ func (m *HelpOverlayModel) buildContent() {
 			title: "Log Stream",
 			bindings: []binding{
 				{"L", "open log stream"},
+				{"f", "toggle follow"},
+				{"L", "cycle level filter"},
+				{"T", "cycle trace filter"},
 				{"j / \u2193", "scroll down"},
 				{"k / \u2191", "scroll up"},
 				{"g", "jump to top"},
 				{"G", "jump to bottom"},
+				{"Ctrl+D", "half page down"},
+				{"Ctrl+U", "half page up"},
 			},
 		},
 		{

--- a/internal/tui/help/model.go
+++ b/internal/tui/help/model.go
@@ -12,8 +12,8 @@ import (
 	"github.com/dorkusprime/wolfcastle/internal/tui"
 )
 
-// HelpOverlayModel renders a scrollable help overlay listing key bindings.
-type HelpOverlayModel struct {
+// Model renders a scrollable help overlay listing key bindings.
+type Model struct {
 	active  bool
 	scroll  int
 	width   int
@@ -22,13 +22,13 @@ type HelpOverlayModel struct {
 	lines   int    // total lines in content
 }
 
-// NewHelpOverlayModel returns a help overlay ready for use.
-func NewHelpOverlayModel() HelpOverlayModel {
-	return HelpOverlayModel{}
+// NewModel returns a help overlay ready for use.
+func NewModel() Model {
+	return Model{}
 }
 
 // Update handles messages relevant to the help overlay.
-func (m HelpOverlayModel) Update(msg tea.Msg) (HelpOverlayModel, tea.Cmd) {
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyPressMsg:
 		if !m.active {
@@ -66,7 +66,7 @@ func (m HelpOverlayModel) Update(msg tea.Msg) (HelpOverlayModel, tea.Cmd) {
 
 // Toggle flips the overlay between active and inactive. When activating,
 // the scroll position resets and the content is rebuilt.
-func (m *HelpOverlayModel) Toggle() {
+func (m *Model) Toggle() {
 	m.active = !m.active
 	if m.active {
 		m.scroll = 0
@@ -75,19 +75,19 @@ func (m *HelpOverlayModel) Toggle() {
 }
 
 // IsActive reports whether the overlay is currently visible.
-func (m HelpOverlayModel) IsActive() bool {
+func (m Model) IsActive() bool {
 	return m.active
 }
 
 // SetSize updates the terminal dimensions and rebuilds the content.
-func (m *HelpOverlayModel) SetSize(width, height int) {
+func (m *Model) SetSize(width, height int) {
 	m.width = width
 	m.height = height
 	m.buildContent()
 }
 
 // buildContent generates the formatted help text from the key binding groups.
-func (m *HelpOverlayModel) buildContent() {
+func (m *Model) buildContent() {
 	type binding struct {
 		key  string
 		desc string
@@ -187,7 +187,7 @@ func (m *HelpOverlayModel) buildContent() {
 }
 
 // View renders the help overlay centered on the terminal.
-func (m HelpOverlayModel) View() string {
+func (m Model) View() string {
 	if !m.active {
 		return ""
 	}
@@ -261,7 +261,7 @@ func (m HelpOverlayModel) View() string {
 }
 
 // maxScroll returns the highest valid scroll offset.
-func (m HelpOverlayModel) maxScroll() int {
+func (m Model) maxScroll() int {
 	overlayH := m.height * 80 / 100
 	if overlayH < 20 {
 		overlayH = 20

--- a/internal/tui/help/model_test.go
+++ b/internal/tui/help/model_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestHelpContentIncludesDaemonControl(t *testing.T) {
-	m := NewHelpOverlayModel()
+	m := NewModel()
 	m.SetSize(120, 80) // tall enough to show all sections without scrolling
 	m.Toggle()         // activate to build content
 
@@ -32,7 +32,7 @@ func TestHelpContentIncludesDaemonControl(t *testing.T) {
 }
 
 func TestHelpToggleActivatesAndDeactivates(t *testing.T) {
-	m := NewHelpOverlayModel()
+	m := NewModel()
 	m.SetSize(120, 40)
 
 	if m.IsActive() {
@@ -51,7 +51,7 @@ func TestHelpToggleActivatesAndDeactivates(t *testing.T) {
 }
 
 func TestHelpViewEmptyWhenInactive(t *testing.T) {
-	m := NewHelpOverlayModel()
+	m := NewModel()
 	m.SetSize(120, 40)
 
 	if m.View() != "" {
@@ -69,7 +69,7 @@ func specialKey(code rune) tea.KeyPressMsg {
 }
 
 func TestUpdate_InactiveSwallowsKeys(t *testing.T) {
-	m := NewHelpOverlayModel()
+	m := NewModel()
 	m.SetSize(120, 40)
 	// Inactive: keys should be swallowed without state change.
 	m2, cmd := m.Update(keyPress('j'))
@@ -82,7 +82,7 @@ func TestUpdate_InactiveSwallowsKeys(t *testing.T) {
 }
 
 func TestUpdate_DismissKey(t *testing.T) {
-	m := NewHelpOverlayModel()
+	m := NewModel()
 	m.SetSize(120, 40)
 	m.Toggle()
 	if !m.IsActive() {
@@ -96,7 +96,7 @@ func TestUpdate_DismissKey(t *testing.T) {
 }
 
 func TestUpdate_ScrollDownAndUp(t *testing.T) {
-	m := NewHelpOverlayModel()
+	m := NewModel()
 	// Tiny size forces a small visible window so scrolling is meaningful.
 	m.SetSize(40, 20)
 	m.Toggle()
@@ -123,7 +123,7 @@ func TestUpdate_ScrollDownAndUp(t *testing.T) {
 }
 
 func TestUpdate_UnknownKeyAbsorbed(t *testing.T) {
-	m := NewHelpOverlayModel()
+	m := NewModel()
 	m.SetSize(120, 40)
 	m.Toggle()
 
@@ -138,7 +138,7 @@ func TestUpdate_UnknownKeyAbsorbed(t *testing.T) {
 }
 
 func TestUpdate_WindowSizeRebuildsContent(t *testing.T) {
-	m := NewHelpOverlayModel()
+	m := NewModel()
 	// First Toggle builds content at zero size.
 	m.Toggle()
 	initialLines := m.lines
@@ -158,7 +158,7 @@ func TestUpdate_WindowSizeRebuildsContent(t *testing.T) {
 }
 
 func TestMaxScroll_ZeroWhenContentFits(t *testing.T) {
-	m := NewHelpOverlayModel()
+	m := NewModel()
 	m.SetSize(200, 200) // huge window so all content fits
 	m.Toggle()
 
@@ -168,7 +168,7 @@ func TestMaxScroll_ZeroWhenContentFits(t *testing.T) {
 }
 
 func TestMaxScroll_PositiveWhenContentOverflows(t *testing.T) {
-	m := NewHelpOverlayModel()
+	m := NewModel()
 	m.SetSize(40, 20) // small window so content overflows
 	m.Toggle()
 
@@ -178,7 +178,7 @@ func TestMaxScroll_PositiveWhenContentOverflows(t *testing.T) {
 }
 
 func TestView_ClampsScrollOnRender(t *testing.T) {
-	m := NewHelpOverlayModel()
+	m := NewModel()
 	m.SetSize(40, 20)
 	m.Toggle()
 

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -1,10 +1,13 @@
+// Package tui provides shared types, messages, key bindings, and styles for the Wolfcastle terminal UI.
 package tui
 
 import "charm.land/bubbles/v2/key"
 
+// GlobalKeys defines key bindings available in every TUI context.
 type GlobalKeys struct {
 	Quit       key.Binding
 	ForceQuit  key.Binding
+	Dashboard  key.Binding
 	LogStream  key.Binding
 	Inbox      key.Binding
 	ToggleTree key.Binding
@@ -15,9 +18,11 @@ type GlobalKeys struct {
 	Copy       key.Binding
 }
 
+// GlobalKeyMap is the default set of global key bindings.
 var GlobalKeyMap = GlobalKeys{
 	Quit:       key.NewBinding(key.WithKeys("q"), key.WithHelp("q", "quit")),
 	ForceQuit:  key.NewBinding(key.WithKeys("ctrl+c"), key.WithHelp("ctrl+c", "quit")),
+	Dashboard:  key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "dashboard")),
 	LogStream:  key.NewBinding(key.WithKeys("L"), key.WithHelp("L", "logs")),
 	Inbox:      key.NewBinding(key.WithKeys("i"), key.WithHelp("i", "inbox")),
 	ToggleTree: key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "tree")),
@@ -28,6 +33,7 @@ var GlobalKeyMap = GlobalKeys{
 	Copy:       key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "copy")),
 }
 
+// TreeKeys defines key bindings for navigating the project tree pane.
 type TreeKeys struct {
 	MoveDown key.Binding
 	MoveUp   key.Binding
@@ -37,6 +43,7 @@ type TreeKeys struct {
 	Bottom   key.Binding
 }
 
+// TreeKeyMap is the default set of tree navigation key bindings.
 var TreeKeyMap = TreeKeys{
 	MoveDown: key.NewBinding(key.WithKeys("j", "down"), key.WithHelp("j/↓", "down")),
 	MoveUp:   key.NewBinding(key.WithKeys("k", "up"), key.WithHelp("k/↑", "up")),
@@ -46,6 +53,7 @@ var TreeKeyMap = TreeKeys{
 	Bottom:   key.NewBinding(key.WithKeys("G"), key.WithHelp("G", "bottom")),
 }
 
+// DaemonKeys defines key bindings for daemon control actions.
 type DaemonKeys struct {
 	ToggleDaemon key.Binding
 	StopAll      key.Binding
@@ -53,6 +61,7 @@ type DaemonKeys struct {
 	NextInstance key.Binding
 }
 
+// DaemonKeyMap is the default set of daemon control key bindings.
 var DaemonKeyMap = DaemonKeys{
 	ToggleDaemon: key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "start/stop")),
 	StopAll:      key.NewBinding(key.WithKeys("S"), key.WithHelp("S", "stop all")),
@@ -60,6 +69,7 @@ var DaemonKeyMap = DaemonKeys{
 	NextInstance: key.NewBinding(key.WithKeys(">"), key.WithHelp(">", "next instance")),
 }
 
+// SearchKeys defines key bindings for the search bar and match navigation.
 type SearchKeys struct {
 	Confirm   key.Binding
 	Cancel    key.Binding
@@ -67,6 +77,7 @@ type SearchKeys struct {
 	PrevMatch key.Binding
 }
 
+// SearchKeyMap is the default set of search navigation key bindings.
 var SearchKeyMap = SearchKeys{
 	Confirm:   key.NewBinding(key.WithKeys("enter"), key.WithHelp("Enter", "confirm")),
 	Cancel:    key.NewBinding(key.WithKeys("esc"), key.WithHelp("Esc", "cancel")),
@@ -74,18 +85,21 @@ var SearchKeyMap = SearchKeys{
 	PrevMatch: key.NewBinding(key.WithKeys("N"), key.WithHelp("N", "prev")),
 }
 
+// HelpKeys defines key bindings for the help overlay.
 type HelpKeys struct {
 	Dismiss    key.Binding
 	ScrollDown key.Binding
 	ScrollUp   key.Binding
 }
 
+// HelpKeyMap is the default set of help overlay key bindings.
 var HelpKeyMap = HelpKeys{
 	Dismiss:    key.NewBinding(key.WithKeys("?", "esc"), key.WithHelp("?/Esc", "close")),
 	ScrollDown: key.NewBinding(key.WithKeys("j", "down"), key.WithHelp("j/↓", "down")),
 	ScrollUp:   key.NewBinding(key.WithKeys("k", "up"), key.WithHelp("k/↑", "up")),
 }
 
+// WelcomeKeys defines key bindings for the welcome/init screen.
 type WelcomeKeys struct {
 	MoveDown key.Binding
 	MoveUp   key.Binding
@@ -96,6 +110,7 @@ type WelcomeKeys struct {
 	Quit     key.Binding
 }
 
+// WelcomeKeyMap is the default set of welcome screen key bindings.
 var WelcomeKeyMap = WelcomeKeys{
 	MoveDown: key.NewBinding(key.WithKeys("j", "down"), key.WithHelp("j/↓", "down")),
 	MoveUp:   key.NewBinding(key.WithKeys("k", "up"), key.WithHelp("k/↑", "up")),

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -11,15 +11,18 @@ import (
 
 // Phase 1 messages
 
+// StateUpdatedMsg signals that the project tree root index has changed on disk.
 type StateUpdatedMsg struct {
 	Index *state.RootIndex
 }
 
+// NodeUpdatedMsg signals that a single node's state file has been refreshed.
 type NodeUpdatedMsg struct {
 	Address string
 	Node    *state.NodeState
 }
 
+// DaemonStatusMsg carries a snapshot of daemon process status for display.
 type DaemonStatusMsg struct {
 	Status       string
 	Branch       string
@@ -33,10 +36,12 @@ type DaemonStatusMsg struct {
 	CurrentTask  string
 }
 
+// InstancesUpdatedMsg signals that the set of registered daemon instances changed.
 type InstancesUpdatedMsg struct {
 	Instances []instance.Entry
 }
 
+// WatcherEventMsg carries a raw filesystem event from the watcher.
 type WatcherEventMsg struct {
 	Path string
 	Op   fsnotify.Op
@@ -52,102 +57,129 @@ type WatcherMsg struct {
 	Inner tea.Msg
 }
 
+// PollTickMsg triggers a periodic state-refresh cycle from the model's tick scheduler.
 type PollTickMsg struct{}
 
+// SpinnerTickMsg advances the spinner animation by one frame.
 type SpinnerTickMsg struct{}
 
+// ErrorMsg reports a file-level error to be displayed in the error bar.
 type ErrorMsg struct {
 	Filename string
 	Message  string
 }
 
+// ErrorClearedMsg signals that a previously reported file error has been resolved.
 type ErrorClearedMsg struct {
 	Filename string
 }
 
+// InitStartedMsg signals that project initialization has begun.
 type InitStartedMsg struct{}
 
+// InitCompleteMsg signals that project initialization finished, possibly with an error.
 type InitCompleteMsg struct {
 	Dir string
 	Err error
 }
 
+// ToggleHelpMsg toggles the help overlay on or off.
 type ToggleHelpMsg struct{}
 
+// CopyMsg requests that the given text be copied to the clipboard.
 type CopyMsg struct {
 	Text string
 }
 
+// CopiedMsg confirms that a clipboard copy operation completed.
 type CopiedMsg struct{}
 
 // Phase 2 placeholder messages
 
+// LogLinesMsg delivers one or more new log lines from the active log file.
 type LogLinesMsg struct {
 	Lines []string // raw JSON strings, one per log line
 }
 
+// NewLogFileMsg signals that the daemon rotated to a new log file.
 type NewLogFileMsg struct {
 	Path string
 }
 
 // Phase 3 messages
 
+// SwitchInstanceMsg requests switching the active daemon instance.
 type SwitchInstanceMsg struct {
 	Entry instance.Entry
 }
 
+// InstanceSwitchedMsg confirms that the active instance was changed successfully.
 type InstanceSwitchedMsg struct {
 	Index *state.RootIndex
 	Entry instance.Entry
 }
 
+// DaemonStartMsg requests that a daemon process be started for the current worktree.
 type DaemonStartMsg struct{}
 
+// DaemonStartedMsg confirms that a daemon process launched successfully.
 type DaemonStartedMsg struct {
 	Entry instance.Entry
 }
 
+// DaemonStartFailedMsg reports that a daemon start attempt failed.
 type DaemonStartFailedMsg struct {
 	Err    error
 	Stderr string
 }
 
+// DaemonStopMsg requests that the current daemon process be stopped.
 type DaemonStopMsg struct{}
 
+// DaemonStoppedMsg confirms that the daemon process was stopped.
 type DaemonStoppedMsg struct{}
 
+// DaemonStopAllMsg requests that all running daemon instances be stopped.
 type DaemonStopAllMsg struct{}
 
+// DaemonStopFailedMsg reports that a daemon stop attempt failed.
 type DaemonStopFailedMsg struct {
 	Err error
 }
 
+// WorktreeGoneMsg signals that a registered instance's worktree no longer exists.
 type WorktreeGoneMsg struct {
 	Entry instance.Entry
 }
 
 // Phase 4: Inbox
 
+// InboxUpdatedMsg signals that the inbox file was reloaded from disk.
 type InboxUpdatedMsg struct {
 	Inbox *state.InboxFile
 }
 
+// InboxItemAddedMsg confirms that an inbox item was written successfully.
 type InboxItemAddedMsg struct{}
 
+// InboxAddFailedMsg reports that adding an inbox item failed.
 type InboxAddFailedMsg struct {
 	Err error
 }
 
+// AddInboxItemCmd is a command message requesting a new inbox item be persisted.
 type AddInboxItemCmd struct {
 	Text string
 }
 
 // Modal messages
 
+// DaemonConfirmedMsg signals that the user confirmed a daemon action in a modal dialog.
 type DaemonConfirmedMsg struct{}
 
 // Phase 5 messages
 
+// ToastMsg requests that a transient notification toast be displayed.
 type ToastMsg struct {
 	Text string
 }

--- a/internal/tui/notify/model.go
+++ b/internal/tui/notify/model.go
@@ -1,3 +1,4 @@
+// Package notify implements a transient toast notification stack for the TUI.
 package notify
 
 import (

--- a/internal/tui/search/model.go
+++ b/internal/tui/search/model.go
@@ -1,3 +1,4 @@
+// Package search implements the interactive search bar and match navigation for TUI panes.
 package search
 
 import (

--- a/internal/tui/search/model.go
+++ b/internal/tui/search/model.go
@@ -11,42 +11,42 @@ import (
 	"github.com/dorkusprime/wolfcastle/internal/tui"
 )
 
-// SearchMatch identifies a single match position within pane content.
+// Match identifies a single match position within pane content.
 // Address is the tree address of the matching node or task and is the
 // identity that survives flat-list rebuilds (collapse/expand). Row is
 // retained for the detail-pane line-based search where addresses do
 // not apply.
-type SearchMatch struct {
+type Match struct {
 	Row     int
 	Col     int
 	Length  int
 	Address string
 }
 
-// SearchModel manages the search bar state, match navigation, and input
+// Model manages the search bar state, match navigation, and input
 // handling for a single pane.
-type SearchModel struct {
+type Model struct {
 	input    textinput.Model
 	active   bool
 	query    string
-	matches  []SearchMatch
+	matches  []Match
 	current  int // index into matches for n/N navigation
 	paneType int // which pane this search is bound to (0=tree, 1=detail)
 }
 
-// NewSearchModel returns a SearchModel with a textinput configured for
+// NewModel returns a Model with a textinput configured for
 // slash-prompt search entry.
-func NewSearchModel() SearchModel {
+func NewModel() Model {
 	ti := textinput.New()
 	ti.Prompt = "/"
 	ti.CharLimit = 0
-	return SearchModel{input: ti}
+	return Model{input: ti}
 }
 
 // Update processes key messages for the search bar. When active, it captures
 // Esc, Enter, and printable input. When inactive with confirmed matches, it
 // handles n/N for match cycling.
-func (m SearchModel) Update(msg tea.Msg) (SearchModel, tea.Cmd) {
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyPressMsg:
 		if m.active {
@@ -82,7 +82,7 @@ func (m SearchModel) Update(msg tea.Msg) (SearchModel, tea.Cmd) {
 
 // Activate opens the search bar for the given pane, clearing any previous
 // search state and focusing the text input.
-func (m *SearchModel) Activate(paneType int) {
+func (m *Model) Activate(paneType int) {
 	m.active = true
 	m.paneType = paneType
 	m.query = ""
@@ -93,7 +93,7 @@ func (m *SearchModel) Activate(paneType int) {
 }
 
 // Dismiss closes the search bar and clears all state.
-func (m *SearchModel) Dismiss() {
+func (m *Model) Dismiss() {
 	m.active = false
 	m.query = ""
 	m.matches = nil
@@ -103,7 +103,7 @@ func (m *SearchModel) Dismiss() {
 
 // Confirm closes the search bar but preserves matches and the current index
 // so that n/N navigation continues to work.
-func (m *SearchModel) Confirm() {
+func (m *Model) Confirm() {
 	m.active = false
 	m.input.Blur()
 	if len(m.matches) > 0 && m.current >= len(m.matches) {
@@ -112,42 +112,42 @@ func (m *SearchModel) Confirm() {
 }
 
 // IsActive reports whether the search bar is open and accepting input.
-func (m SearchModel) IsActive() bool {
+func (m Model) IsActive() bool {
 	return m.active
 }
 
 // PaneType returns which pane this search is bound to (0=tree, 1=detail).
-func (m SearchModel) PaneType() int {
+func (m Model) PaneType() int {
 	return m.paneType
 }
 
 // HasMatches reports whether there are any search matches.
-func (m SearchModel) HasMatches() bool {
+func (m Model) HasMatches() bool {
 	return len(m.matches) > 0
 }
 
 // Query returns the current search string.
-func (m SearchModel) Query() string {
+func (m Model) Query() string {
 	return m.query
 }
 
 // Current returns the index of the currently selected match.
-func (m SearchModel) Current() int {
+func (m Model) Current() int {
 	return m.current
 }
 
 // CurrentMatch returns the match at the current index, or false if there are
 // no matches.
-func (m SearchModel) CurrentMatch() (SearchMatch, bool) {
+func (m Model) CurrentMatch() (Match, bool) {
 	if len(m.matches) == 0 {
-		return SearchMatch{}, false
+		return Match{}, false
 	}
 	return m.matches[m.current], true
 }
 
 // SetMatches replaces the match list. Called by the parent model after
 // filtering pane content against the query.
-func (m *SearchModel) SetMatches(matches []SearchMatch) {
+func (m *Model) SetMatches(matches []Match) {
 	m.matches = matches
 	if len(matches) == 0 {
 		m.current = 0
@@ -157,7 +157,7 @@ func (m *SearchModel) SetMatches(matches []SearchMatch) {
 }
 
 // NextMatch advances to the next match, wrapping to the beginning.
-func (m *SearchModel) NextMatch() {
+func (m *Model) NextMatch() {
 	if len(m.matches) == 0 {
 		return
 	}
@@ -165,7 +165,7 @@ func (m *SearchModel) NextMatch() {
 }
 
 // PrevMatch moves to the previous match, wrapping to the end.
-func (m *SearchModel) PrevMatch() {
+func (m *Model) PrevMatch() {
 	if len(m.matches) == 0 {
 		return
 	}
@@ -174,7 +174,7 @@ func (m *SearchModel) PrevMatch() {
 
 // View renders the search bar line. The parent is responsible for placing this
 // at the bottom of the appropriate pane.
-func (m SearchModel) View() string {
+func (m Model) View() string {
 	if !m.active && len(m.matches) == 0 {
 		return ""
 	}

--- a/internal/tui/search/model_test.go
+++ b/internal/tui/search/model_test.go
@@ -7,8 +7,8 @@ import (
 	tea "charm.land/bubbletea/v2"
 )
 
-func TestNewSearchModel(t *testing.T) {
-	m := NewSearchModel()
+func TestNewModel(t *testing.T) {
+	m := NewModel()
 	if m.IsActive() {
 		t.Error("new model should not be active")
 	}
@@ -21,7 +21,7 @@ func TestNewSearchModel(t *testing.T) {
 }
 
 func TestActivate(t *testing.T) {
-	m := NewSearchModel()
+	m := NewModel()
 	m.Activate(1)
 	if !m.IsActive() {
 		t.Error("expected active after Activate")
@@ -38,9 +38,9 @@ func TestActivate(t *testing.T) {
 }
 
 func TestDismiss(t *testing.T) {
-	m := NewSearchModel()
+	m := NewModel()
 	m.Activate(0)
-	m.SetMatches([]SearchMatch{{Row: 1, Col: 2, Length: 3}})
+	m.SetMatches([]Match{{Row: 1, Col: 2, Length: 3}})
 	m.Dismiss()
 
 	if m.IsActive() {
@@ -55,10 +55,10 @@ func TestDismiss(t *testing.T) {
 }
 
 func TestConfirm(t *testing.T) {
-	m := NewSearchModel()
+	m := NewModel()
 	m.Activate(0)
 	m.query = "test"
-	m.SetMatches([]SearchMatch{
+	m.SetMatches([]Match{
 		{Row: 0, Col: 0, Length: 4},
 		{Row: 1, Col: 5, Length: 4},
 	})
@@ -73,9 +73,9 @@ func TestConfirm(t *testing.T) {
 }
 
 func TestConfirmClampsCurrentIndex(t *testing.T) {
-	m := NewSearchModel()
+	m := NewModel()
 	m.Activate(0)
-	m.SetMatches([]SearchMatch{{Row: 0, Col: 0, Length: 1}})
+	m.SetMatches([]Match{{Row: 0, Col: 0, Length: 1}})
 	m.current = 5 // artificially out of range
 	m.Confirm()
 	if m.current != 0 {
@@ -84,7 +84,7 @@ func TestConfirmClampsCurrentIndex(t *testing.T) {
 }
 
 func TestAccessors(t *testing.T) {
-	m := NewSearchModel()
+	m := NewModel()
 	if m.IsActive() {
 		t.Error("IsActive should be false on new model")
 	}
@@ -107,8 +107,8 @@ func TestAccessors(t *testing.T) {
 }
 
 func TestSetMatches(t *testing.T) {
-	m := NewSearchModel()
-	matches := []SearchMatch{
+	m := NewModel()
+	matches := []Match{
 		{Row: 0, Col: 0, Length: 3},
 		{Row: 2, Col: 1, Length: 3},
 	}
@@ -122,18 +122,18 @@ func TestSetMatches(t *testing.T) {
 }
 
 func TestSetMatchesClampsCurrentIndex(t *testing.T) {
-	m := NewSearchModel()
-	m.SetMatches([]SearchMatch{{}, {}, {}})
+	m := NewModel()
+	m.SetMatches([]Match{{}, {}, {}})
 	m.current = 2
 	// Now shrink matches so current is out of range.
-	m.SetMatches([]SearchMatch{{Row: 0}})
+	m.SetMatches([]Match{{Row: 0}})
 	if m.current != 0 {
 		t.Errorf("current = %d, want 0 after clamp", m.current)
 	}
 }
 
 func TestSetMatchesEmpty(t *testing.T) {
-	m := NewSearchModel()
+	m := NewModel()
 	m.current = 5
 	m.SetMatches(nil)
 	if m.current != 0 {
@@ -142,8 +142,8 @@ func TestSetMatchesEmpty(t *testing.T) {
 }
 
 func TestNextMatch(t *testing.T) {
-	m := NewSearchModel()
-	m.SetMatches([]SearchMatch{{Row: 0}, {Row: 1}, {Row: 2}})
+	m := NewModel()
+	m.SetMatches([]Match{{Row: 0}, {Row: 1}, {Row: 2}})
 	m.NextMatch()
 	if m.Current() != 1 {
 		t.Errorf("after NextMatch: current = %d, want 1", m.Current())
@@ -160,7 +160,7 @@ func TestNextMatch(t *testing.T) {
 }
 
 func TestNextMatchNoMatches(t *testing.T) {
-	m := NewSearchModel()
+	m := NewModel()
 	m.NextMatch() // should not panic
 	if m.Current() != 0 {
 		t.Errorf("current = %d, want 0", m.Current())
@@ -168,8 +168,8 @@ func TestNextMatchNoMatches(t *testing.T) {
 }
 
 func TestPrevMatch(t *testing.T) {
-	m := NewSearchModel()
-	m.SetMatches([]SearchMatch{{Row: 0}, {Row: 1}, {Row: 2}})
+	m := NewModel()
+	m.SetMatches([]Match{{Row: 0}, {Row: 1}, {Row: 2}})
 	// Wrap backward from 0.
 	m.PrevMatch()
 	if m.Current() != 2 {
@@ -182,7 +182,7 @@ func TestPrevMatch(t *testing.T) {
 }
 
 func TestPrevMatchNoMatches(t *testing.T) {
-	m := NewSearchModel()
+	m := NewModel()
 	m.PrevMatch() // should not panic
 	if m.Current() != 0 {
 		t.Errorf("current = %d, want 0", m.Current())
@@ -190,8 +190,8 @@ func TestPrevMatchNoMatches(t *testing.T) {
 }
 
 func TestCurrentMatch(t *testing.T) {
-	m := NewSearchModel()
-	m.SetMatches([]SearchMatch{
+	m := NewModel()
+	m.SetMatches([]Match{
 		{Row: 5, Col: 3, Length: 2},
 		{Row: 10, Col: 0, Length: 4},
 	})
@@ -214,7 +214,7 @@ func TestCurrentMatch(t *testing.T) {
 }
 
 func TestCurrentMatchEmpty(t *testing.T) {
-	m := NewSearchModel()
+	m := NewModel()
 	_, ok := m.CurrentMatch()
 	if ok {
 		t.Error("expected ok = false when no matches")
@@ -222,9 +222,9 @@ func TestCurrentMatchEmpty(t *testing.T) {
 }
 
 func TestUpdateEscWhenActive(t *testing.T) {
-	m := NewSearchModel()
+	m := NewModel()
 	m.Activate(0)
-	m.SetMatches([]SearchMatch{{Row: 1}})
+	m.SetMatches([]Match{{Row: 1}})
 
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 	if m.IsActive() {
@@ -236,10 +236,10 @@ func TestUpdateEscWhenActive(t *testing.T) {
 }
 
 func TestUpdateEnterWhenActive(t *testing.T) {
-	m := NewSearchModel()
+	m := NewModel()
 	m.Activate(0)
 	m.query = "foo"
-	m.SetMatches([]SearchMatch{{Row: 0}, {Row: 1}})
+	m.SetMatches([]Match{{Row: 0}, {Row: 1}})
 
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	if m.IsActive() {
@@ -251,7 +251,7 @@ func TestUpdateEnterWhenActive(t *testing.T) {
 }
 
 func TestUpdateTypingWhenActive(t *testing.T) {
-	m := NewSearchModel()
+	m := NewModel()
 	m.Activate(0)
 
 	// Send a regular key; the textinput should process it.
@@ -263,8 +263,8 @@ func TestUpdateTypingWhenActive(t *testing.T) {
 }
 
 func TestUpdateNWhenInactiveWithMatches(t *testing.T) {
-	m := NewSearchModel()
-	m.SetMatches([]SearchMatch{{Row: 0}, {Row: 1}, {Row: 2}})
+	m := NewModel()
+	m.SetMatches([]Match{{Row: 0}, {Row: 1}, {Row: 2}})
 
 	m, _ = m.Update(tea.KeyPressMsg{Code: 'n', Text: "n"})
 	if m.Current() != 1 {
@@ -273,8 +273,8 @@ func TestUpdateNWhenInactiveWithMatches(t *testing.T) {
 }
 
 func TestUpdateShiftNWhenInactiveWithMatches(t *testing.T) {
-	m := NewSearchModel()
-	m.SetMatches([]SearchMatch{{Row: 0}, {Row: 1}, {Row: 2}})
+	m := NewModel()
+	m.SetMatches([]Match{{Row: 0}, {Row: 1}, {Row: 2}})
 
 	m, _ = m.Update(tea.KeyPressMsg{Code: 'N', Text: "N", Mod: tea.ModShift})
 	if m.Current() != 2 {
@@ -283,7 +283,7 @@ func TestUpdateShiftNWhenInactiveWithMatches(t *testing.T) {
 }
 
 func TestUpdateNonKeyMsg(t *testing.T) {
-	m := NewSearchModel()
+	m := NewModel()
 	m.Activate(0)
 	// A non-key message should pass through without error.
 	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
@@ -293,10 +293,10 @@ func TestUpdateNonKeyMsg(t *testing.T) {
 }
 
 func TestViewActiveWithMatches(t *testing.T) {
-	m := NewSearchModel()
+	m := NewModel()
 	m.Activate(0)
 	m.query = "test"
-	m.SetMatches([]SearchMatch{{Row: 0}, {Row: 3}})
+	m.SetMatches([]Match{{Row: 0}, {Row: 3}})
 
 	v := m.View()
 	if !strings.Contains(v, "1/2 matches") {
@@ -305,7 +305,7 @@ func TestViewActiveWithMatches(t *testing.T) {
 }
 
 func TestViewActiveNoMatches(t *testing.T) {
-	m := NewSearchModel()
+	m := NewModel()
 	m.Activate(0)
 	m.query = "nonexistent"
 
@@ -316,7 +316,7 @@ func TestViewActiveNoMatches(t *testing.T) {
 }
 
 func TestViewActiveEmptyQuery(t *testing.T) {
-	m := NewSearchModel()
+	m := NewModel()
 	m.Activate(0)
 
 	v := m.View()
@@ -327,7 +327,7 @@ func TestViewActiveEmptyQuery(t *testing.T) {
 }
 
 func TestViewInactiveNoMatches(t *testing.T) {
-	m := NewSearchModel()
+	m := NewModel()
 	v := m.View()
 	if v != "" {
 		t.Errorf("expected empty view when inactive with no matches, got: %q", v)
@@ -335,10 +335,10 @@ func TestViewInactiveNoMatches(t *testing.T) {
 }
 
 func TestViewInactiveWithConfirmedMatches(t *testing.T) {
-	m := NewSearchModel()
+	m := NewModel()
 	m.Activate(0)
 	m.query = "foo"
-	m.SetMatches([]SearchMatch{{Row: 0}, {Row: 1}})
+	m.SetMatches([]Match{{Row: 0}, {Row: 1}})
 	m.Confirm()
 
 	v := m.View()

--- a/internal/tui/search/model_test.go
+++ b/internal/tui/search/model_test.go
@@ -334,6 +334,17 @@ func TestViewInactiveNoMatches(t *testing.T) {
 	}
 }
 
+func TestPaneType(t *testing.T) {
+	m := NewModel()
+	if m.PaneType() != 0 {
+		t.Errorf("default PaneType = %d, want 0", m.PaneType())
+	}
+	m.Activate(1)
+	if m.PaneType() != 1 {
+		t.Errorf("PaneType after Activate(1) = %d, want 1", m.PaneType())
+	}
+}
+
 func TestViewInactiveWithConfirmedMatches(t *testing.T) {
 	m := NewModel()
 	m.Activate(0)

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -8,6 +8,7 @@ import (
 	"charm.land/lipgloss/v2"
 
 	"github.com/dorkusprime/wolfcastle/internal/instance"
+	"github.com/dorkusprime/wolfcastle/internal/state"
 )
 
 // Color palette constants
@@ -123,18 +124,20 @@ type StatusGlyph struct {
 	Color color.Color
 }
 
+// NodeStatusGlyphs maps node statuses (complete, in_progress, etc.) to their display glyphs and colors.
 var NodeStatusGlyphs = map[string]StatusGlyph{
-	"complete":    {Glyph: "●", Color: ColorGreen},
-	"in_progress": {Glyph: "◐", Color: ColorYellow},
-	"not_started": {Glyph: "◯", Color: ColorDimWhite},
-	"blocked":     {Glyph: "☢", Color: ColorRed},
+	string(state.StatusComplete):   {Glyph: "●", Color: ColorGreen},
+	string(state.StatusInProgress): {Glyph: "◐", Color: ColorYellow},
+	string(state.StatusNotStarted): {Glyph: "◯", Color: ColorDimWhite},
+	string(state.StatusBlocked):    {Glyph: "☢", Color: ColorRed},
 }
 
+// AuditStatusGlyphs maps audit statuses (passed, failed, etc.) to their display glyphs and colors.
 var AuditStatusGlyphs = map[string]StatusGlyph{
-	"passed":      {Glyph: "⏸", Color: ColorGreen},
-	"in_progress": {Glyph: "◐", Color: ColorYellow},
-	"pending":     {Glyph: "◯", Color: ColorDimWhite},
-	"failed":      {Glyph: "⊘", Color: ColorRed},
+	string(state.AuditPassed):     {Glyph: "⏸", Color: ColorGreen},
+	string(state.AuditInProgress): {Glyph: "◐", Color: ColorYellow},
+	string(state.AuditPending):    {Glyph: "◯", Color: ColorDimWhite},
+	string(state.AuditFailed):     {Glyph: "⊘", Color: ColorRed},
 }
 
 // GlyphForStatus returns the styled glyph string for a node status.

--- a/internal/tui/tree/model.go
+++ b/internal/tui/tree/model.go
@@ -1,3 +1,4 @@
+// Package tree implements the project tree pane, rendering hierarchical node navigation with expand/collapse and search highlighting.
 package tree
 
 import (
@@ -38,8 +39,8 @@ type LoadNodeMsg struct {
 	Err     error
 }
 
-// TreeRow is a single visible line in the flattened tree view.
-type TreeRow struct {
+// Row is a single visible line in the flattened tree view.
+type Row struct {
 	Addr       string
 	Name       string
 	Depth      int
@@ -51,12 +52,12 @@ type TreeRow struct {
 	TaskHint   string // e.g. "(5 tasks)" or "(3 tasks, 2 failures)" for collapsed leaves
 }
 
-// TreeModel is the sub-model that owns the project tree panel.
-type TreeModel struct {
+// Model is the sub-model that owns the project tree panel.
+type Model struct {
 	index         *state.RootIndex
 	nodes         map[string]*state.NodeState
 	cacheExpiry   map[string]time.Time
-	flatList      []TreeRow
+	flatList      []Row
 	cursor        int
 	scrollTop     int
 	expanded      map[string]bool
@@ -74,9 +75,9 @@ type TreeModel struct {
 	searchAncestor map[string]bool
 }
 
-// NewTreeModel returns an initialized TreeModel with empty maps.
-func NewTreeModel() TreeModel {
-	return TreeModel{
+// NewModel returns an initialized Model with empty maps.
+func NewModel() Model {
+	return Model{
 		nodes:       make(map[string]*state.NodeState),
 		cacheExpiry: make(map[string]time.Time),
 		expanded:    make(map[string]bool),
@@ -103,7 +104,7 @@ var keys = struct {
 
 // Update processes incoming messages and returns the updated model plus any
 // commands that should fire next.
-func (m TreeModel) Update(msg tea.Msg) (TreeModel, tea.Cmd) {
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyPressMsg:
 		if !m.focused {
@@ -148,7 +149,7 @@ func (m TreeModel) Update(msg tea.Msg) (TreeModel, tea.Cmd) {
 	return m, nil
 }
 
-func (m TreeModel) handleKey(msg tea.KeyPressMsg) (TreeModel, tea.Cmd) {
+func (m Model) handleKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 	switch {
 	case key.Matches(msg, keys.MoveDown):
 		if m.cursor < len(m.flatList)-1 {
@@ -182,7 +183,7 @@ func (m TreeModel) handleKey(msg tea.KeyPressMsg) (TreeModel, tea.Cmd) {
 	return m, nil
 }
 
-func (m TreeModel) handleExpand() (TreeModel, tea.Cmd) {
+func (m Model) handleExpand() (Model, tea.Cmd) {
 	if len(m.flatList) == 0 {
 		return m, nil
 	}
@@ -222,7 +223,7 @@ func (m TreeModel) handleExpand() (TreeModel, tea.Cmd) {
 	return m, nil
 }
 
-func (m TreeModel) handleCollapse() (TreeModel, tea.Cmd) {
+func (m Model) handleCollapse() (Model, tea.Cmd) {
 	if len(m.flatList) == 0 {
 		return m, func() tea.Msg { return CollapseAtRootMsg{} }
 	}
@@ -251,18 +252,18 @@ func (m TreeModel) handleCollapse() (TreeModel, tea.Cmd) {
 }
 
 // SetSize updates the viewport dimensions.
-func (m *TreeModel) SetSize(width, height int) {
+func (m *Model) SetSize(width, height int) {
 	m.width = width
 	m.height = height
 }
 
 // SetFocused marks whether the tree panel currently owns keyboard input.
-func (m *TreeModel) SetFocused(focused bool) {
+func (m *Model) SetFocused(focused bool) {
 	m.focused = focused
 }
 
 // SetIndex replaces the root index and rebuilds the flat list.
-func (m *TreeModel) SetIndex(index *state.RootIndex) {
+func (m *Model) SetIndex(index *state.RootIndex) {
 	m.index = index
 	m.buildFlatList()
 	m.clampCursor()
@@ -270,7 +271,7 @@ func (m *TreeModel) SetIndex(index *state.RootIndex) {
 }
 
 // SetCurrentTarget sets the address of the node the daemon is working on.
-func (m *TreeModel) SetCurrentTarget(addr string) {
+func (m *Model) SetCurrentTarget(addr string) {
 	m.currentTarget = addr
 }
 
@@ -278,34 +279,34 @@ func (m *TreeModel) SetCurrentTarget(addr string) {
 // highlight sets. Both maps are keyed by tree address so they survive
 // flat-list rebuilds (collapse/expand). Pass two nil maps to clear
 // all highlighting.
-func (m *TreeModel) SetSearchAddresses(literal, ancestor map[string]bool) {
+func (m *Model) SetSearchAddresses(literal, ancestor map[string]bool) {
 	m.searchLiteral = literal
 	m.searchAncestor = ancestor
 }
 
 // SearchLiteralAddresses returns the literal-match address set.
 // Read-only accessor used by wiring smoke tests.
-func (m *TreeModel) SearchLiteralAddresses() map[string]bool {
+func (m *Model) SearchLiteralAddresses() map[string]bool {
 	return m.searchLiteral
 }
 
 // SearchAncestorAddresses returns the ancestor-of-match address set.
 // Read-only accessor used by wiring smoke tests.
-func (m *TreeModel) SearchAncestorAddresses() map[string]bool {
+func (m *Model) SearchAncestorAddresses() map[string]bool {
 	return m.searchAncestor
 }
 
 // HasSearchHighlights reports whether any search highlights are
 // currently active. Used by the Esc handler to decide whether to
 // clear highlights or fall through to other Esc semantics.
-func (m *TreeModel) HasSearchHighlights() bool {
+func (m *Model) HasSearchHighlights() bool {
 	return len(m.searchLiteral) > 0 || len(m.searchAncestor) > 0
 }
 
 // Reset collapses all expanded nodes, clears the cursor back to row 0,
 // and rebuilds the flat list. Used when switching instances so the tree
 // doesn't carry stale expand state from the previous project.
-func (m *TreeModel) Reset() {
+func (m *Model) Reset() {
 	m.expanded = make(map[string]bool)
 	m.cursor = 0
 	m.scrollTop = 0
@@ -315,14 +316,14 @@ func (m *TreeModel) Reset() {
 
 // SetCursor moves the cursor to the given row index (clamped to bounds)
 // and scrolls it into view.
-func (m *TreeModel) SetCursor(row int) {
+func (m *Model) SetCursor(row int) {
 	m.cursor = row
 	m.clampCursor()
 	m.scrollIntoCursor()
 }
 
 // CleanCache removes cached node entries whose expiry time has passed.
-func (m *TreeModel) CleanCache() {
+func (m *Model) CleanCache() {
 	now := time.Now()
 	for addr, exp := range m.cacheExpiry {
 		if now.After(exp) {
@@ -334,22 +335,22 @@ func (m *TreeModel) CleanCache() {
 
 // FlatList returns the current flattened tree rows. The returned slice
 // should be treated as read-only.
-func (m *TreeModel) FlatList() []TreeRow {
+func (m *Model) FlatList() []Row {
 	return m.flatList
 }
 
 // SelectedAddr returns the address of the row under the cursor, or empty
 // if the list is empty.
-func (m *TreeModel) SelectedAddr() string {
+func (m *Model) SelectedAddr() string {
 	if m.cursor >= 0 && m.cursor < len(m.flatList) {
 		return m.flatList[m.cursor].Addr
 	}
 	return ""
 }
 
-// SelectedRow returns a pointer to the TreeRow under the cursor, or nil if
+// SelectedRow returns a pointer to the Row under the cursor, or nil if
 // the list is empty.
-func (m *TreeModel) SelectedRow() *TreeRow {
+func (m *Model) SelectedRow() *Row {
 	if m.cursor >= 0 && m.cursor < len(m.flatList) {
 		return &m.flatList[m.cursor]
 	}
@@ -358,18 +359,18 @@ func (m *TreeModel) SelectedRow() *TreeRow {
 
 // CachedNode returns the cached NodeState for the given address, or nil if
 // not cached.
-func (m *TreeModel) CachedNode(addr string) *state.NodeState {
+func (m *Model) CachedNode(addr string) *state.NodeState {
 	return m.nodes[addr]
 }
 
 // Index returns the current root index, or nil if none has been set.
-func (m *TreeModel) Index() *state.RootIndex {
+func (m *Model) Index() *state.RootIndex {
 	return m.index
 }
 
 // buildFlatList walks the index tree, respecting expand state, and produces
-// the ordered slice of TreeRows that the renderer will draw.
-func (m *TreeModel) buildFlatList() {
+// the ordered slice of Rows that the renderer will draw.
+func (m *Model) buildFlatList() {
 	if m.index == nil {
 		m.flatList = nil
 		return
@@ -380,7 +381,7 @@ func (m *TreeModel) buildFlatList() {
 	}
 }
 
-func (m *TreeModel) appendNodeAtDepth(addr string, depth int) {
+func (m *Model) appendNodeAtDepth(addr string, depth int) {
 	entry, ok := m.index.Nodes[addr]
 	if !ok {
 		return
@@ -394,7 +395,7 @@ func (m *TreeModel) appendNodeAtDepth(addr string, depth int) {
 
 	isExpanded := m.expanded[addr]
 
-	row := TreeRow{
+	row := Row{
 		Addr:       addr,
 		Name:       entry.Name,
 		Depth:      depth,
@@ -428,7 +429,7 @@ func (m *TreeModel) appendNodeAtDepth(addr string, depth int) {
 	if entry.Type == state.NodeLeaf {
 		if ns, ok := m.nodes[addr]; ok {
 			for _, task := range ns.Tasks {
-				m.flatList = append(m.flatList, TreeRow{
+				m.flatList = append(m.flatList, Row{
 					Addr:   addr + "/" + task.ID,
 					Name:   task.Title,
 					Depth:  depth + 1,
@@ -441,7 +442,7 @@ func (m *TreeModel) appendNodeAtDepth(addr string, depth int) {
 }
 
 // scrollIntoCursor adjusts scrollTop so the cursor row is visible.
-func (m *TreeModel) scrollIntoCursor() {
+func (m *Model) scrollIntoCursor() {
 	if m.height <= 0 {
 		return
 	}
@@ -454,7 +455,7 @@ func (m *TreeModel) scrollIntoCursor() {
 }
 
 // clampCursor keeps the cursor within bounds after the flat list changes.
-func (m *TreeModel) clampCursor() {
+func (m *Model) clampCursor() {
 	if len(m.flatList) == 0 {
 		m.cursor = 0
 		return
@@ -469,7 +470,7 @@ func (m *TreeModel) clampCursor() {
 
 // parentOf finds the flatList index of the parent node for the given
 // address. Returns -1 if no parent is found.
-func (m *TreeModel) parentOf(addr string) int {
+func (m *Model) parentOf(addr string) int {
 	if m.index == nil {
 		return -1
 	}

--- a/internal/tui/tree/model_test.go
+++ b/internal/tui/tree/model_test.go
@@ -781,6 +781,109 @@ func TestCleanCache_EmptyIsNoop(t *testing.T) {
 	m.CleanCache()
 }
 
+func TestSearchLiteralAddresses(t *testing.T) {
+	m := NewModel()
+	literal := map[string]bool{"alpha": true, "beta": true}
+	ancestor := map[string]bool{"root": true}
+	m.SetSearchAddresses(literal, ancestor)
+
+	got := m.SearchLiteralAddresses()
+	if got == nil || !got["alpha"] || !got["beta"] {
+		t.Errorf("SearchLiteralAddresses returned unexpected value: %v", got)
+	}
+}
+
+func TestSearchAncestorAddresses(t *testing.T) {
+	m := NewModel()
+	literal := map[string]bool{"alpha": true}
+	ancestor := map[string]bool{"root": true, "mid": true}
+	m.SetSearchAddresses(literal, ancestor)
+
+	got := m.SearchAncestorAddresses()
+	if got == nil || !got["root"] || !got["mid"] {
+		t.Errorf("SearchAncestorAddresses returned unexpected value: %v", got)
+	}
+}
+
+func TestReset(t *testing.T) {
+	m := NewModel()
+	m.SetFocused(true)
+	m.SetIndex(simpleIndex())
+	m.SetSize(80, 20)
+	m.expanded["alpha"] = true
+	m.cursor = 2
+	m.scrollTop = 1
+
+	m.Reset()
+
+	if len(m.expanded) != 0 {
+		t.Errorf("expected expanded map to be empty after Reset, got %d entries", len(m.expanded))
+	}
+	if m.cursor != 0 {
+		t.Errorf("expected cursor 0 after Reset, got %d", m.cursor)
+	}
+	if m.scrollTop != 0 {
+		t.Errorf("expected scrollTop 0 after Reset, got %d", m.scrollTop)
+	}
+}
+
+func TestSelectedRow(t *testing.T) {
+	m := NewModel()
+	m.SetIndex(simpleIndex())
+
+	row := m.SelectedRow()
+	if row == nil {
+		t.Fatal("SelectedRow should not return nil when list is non-empty")
+	}
+	if row.Addr != "alpha" {
+		t.Errorf("expected row addr 'alpha', got %q", row.Addr)
+	}
+
+	m.cursor = 1
+	row = m.SelectedRow()
+	if row == nil || row.Addr != "beta" {
+		t.Errorf("expected row addr 'beta', got %v", row)
+	}
+}
+
+func TestSelectedRow_Empty(t *testing.T) {
+	m := NewModel()
+	row := m.SelectedRow()
+	if row != nil {
+		t.Error("SelectedRow should return nil for empty list")
+	}
+}
+
+func TestCachedNode(t *testing.T) {
+	m := NewModel()
+	ns := &state.NodeState{
+		Tasks: []state.Task{{ID: "t1", Title: "T1", State: state.StatusComplete}},
+	}
+	m.nodes["alpha"] = ns
+
+	got := m.CachedNode("alpha")
+	if got != ns {
+		t.Error("CachedNode should return the cached node state")
+	}
+
+	got = m.CachedNode("nonexistent")
+	if got != nil {
+		t.Error("CachedNode should return nil for uncached addresses")
+	}
+}
+
+func TestIndex(t *testing.T) {
+	m := NewModel()
+	if m.Index() != nil {
+		t.Error("Index should return nil before SetIndex")
+	}
+	idx := simpleIndex()
+	m.SetIndex(idx)
+	if m.Index() != idx {
+		t.Error("Index should return the set index")
+	}
+}
+
 // TestCollapse_DoesNotSetCacheExpiry replaces the original test that
 // asserted the opposite. The eviction-on-collapse behavior has been
 // removed: the watcher's per-leaf fsnotify subscription keeps every

--- a/internal/tui/tree/model_test.go
+++ b/internal/tui/tree/model_test.go
@@ -19,8 +19,8 @@ func specialKey(code rune) tea.KeyPressMsg {
 	return tea.KeyPressMsg{Code: code}
 }
 
-func TestNewTreeModel(t *testing.T) {
-	m := NewTreeModel()
+func TestNewModel(t *testing.T) {
+	m := NewModel()
 
 	if m.nodes == nil {
 		t.Error("nodes map should be initialized")
@@ -77,7 +77,7 @@ func orchestratorIndex() *state.RootIndex {
 }
 
 func TestSetIndex_SimpleFlatList(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetIndex(simpleIndex())
 
 	if len(m.flatList) != 3 {
@@ -93,7 +93,7 @@ func TestSetIndex_SimpleFlatList(t *testing.T) {
 }
 
 func TestSetIndex_OrchestratorCollapsed(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetIndex(orchestratorIndex())
 
 	// Orchestrator collapsed: only the parent should appear.
@@ -109,7 +109,7 @@ func TestSetIndex_OrchestratorCollapsed(t *testing.T) {
 }
 
 func TestSetIndex_OrchestratorExpanded(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.expanded["parent"] = true
 	m.SetIndex(orchestratorIndex())
 
@@ -125,7 +125,7 @@ func TestSetIndex_OrchestratorExpanded(t *testing.T) {
 }
 
 func TestCursorDown(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetFocused(true)
 	m.SetIndex(simpleIndex())
 	m.SetSize(80, 20)
@@ -137,7 +137,7 @@ func TestCursorDown(t *testing.T) {
 }
 
 func TestCursorDown_ClampsAtBottom(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetFocused(true)
 	m.SetIndex(simpleIndex())
 	m.SetSize(80, 20)
@@ -152,7 +152,7 @@ func TestCursorDown_ClampsAtBottom(t *testing.T) {
 }
 
 func TestCursorUp(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetFocused(true)
 	m.SetIndex(simpleIndex())
 	m.SetSize(80, 20)
@@ -165,7 +165,7 @@ func TestCursorUp(t *testing.T) {
 }
 
 func TestCursorUp_ClampsAt0(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetFocused(true)
 	m.SetIndex(simpleIndex())
 	m.SetSize(80, 20)
@@ -177,7 +177,7 @@ func TestCursorUp_ClampsAt0(t *testing.T) {
 }
 
 func TestJumpTop(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetFocused(true)
 	m.SetIndex(simpleIndex())
 	m.SetSize(80, 20)
@@ -190,7 +190,7 @@ func TestJumpTop(t *testing.T) {
 }
 
 func TestJumpBottom(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetFocused(true)
 	m.SetIndex(simpleIndex())
 	m.SetSize(80, 20)
@@ -203,7 +203,7 @@ func TestJumpBottom(t *testing.T) {
 }
 
 func TestExpandOrchestrator(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetFocused(true)
 	m.SetIndex(orchestratorIndex())
 	m.SetSize(80, 20)
@@ -220,7 +220,7 @@ func TestExpandOrchestrator(t *testing.T) {
 }
 
 func TestCollapseOrchestrator(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetFocused(true)
 	m.expanded["parent"] = true
 	m.SetIndex(orchestratorIndex())
@@ -239,7 +239,7 @@ func TestCollapseOrchestrator(t *testing.T) {
 }
 
 func TestCollapse_AlreadyCollapsed_JumpsToParent(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetFocused(true)
 	m.expanded["parent"] = true
 	m.SetIndex(orchestratorIndex())
@@ -256,7 +256,7 @@ func TestCollapse_AlreadyCollapsed_JumpsToParent(t *testing.T) {
 }
 
 func TestExpandLeaf_FiresLoadNodeCmd(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetFocused(true)
 	m.SetIndex(simpleIndex())
 	m.SetSize(80, 20)
@@ -279,7 +279,7 @@ func TestExpandLeaf_FiresLoadNodeCmd(t *testing.T) {
 }
 
 func TestExpandLeaf_CachedNode_NoCmd(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetFocused(true)
 	m.SetIndex(simpleIndex())
 	m.SetSize(80, 20)
@@ -310,7 +310,7 @@ func TestExpandLeaf_CachedNode_NoCmd(t *testing.T) {
 }
 
 func TestLoadNodeMsg_TasksAppear(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetFocused(true)
 	m.SetIndex(simpleIndex())
 	m.SetSize(80, 20)
@@ -340,7 +340,7 @@ func TestLoadNodeMsg_TasksAppear(t *testing.T) {
 }
 
 func TestLoadNodeMsg_Error_Ignored(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetFocused(true)
 	m.SetIndex(simpleIndex())
 	m.SetSize(80, 20)
@@ -361,7 +361,7 @@ type testError struct{}
 func (e *testError) Error() string { return "test error" }
 
 func TestSetFocused(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetFocused(true)
 	if !m.focused {
 		t.Error("SetFocused(true) should set focused")
@@ -373,7 +373,7 @@ func TestSetFocused(t *testing.T) {
 }
 
 func TestSetCurrentTarget(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetCurrentTarget("some/addr")
 	if m.currentTarget != "some/addr" {
 		t.Errorf("currentTarget = %q, want %q", m.currentTarget, "some/addr")
@@ -381,7 +381,7 @@ func TestSetCurrentTarget(t *testing.T) {
 }
 
 func TestSelectedAddr(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetIndex(simpleIndex())
 
 	addr := m.SelectedAddr()
@@ -397,7 +397,7 @@ func TestSelectedAddr(t *testing.T) {
 }
 
 func TestSelectedAddr_Empty(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	addr := m.SelectedAddr()
 	if addr != "" {
 		t.Errorf("SelectedAddr on empty list = %q, want empty", addr)
@@ -405,7 +405,7 @@ func TestSelectedAddr_Empty(t *testing.T) {
 }
 
 func TestScrollIntoCursor(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetIndex(simpleIndex())
 	m.SetSize(80, 2) // only 2 visible rows
 
@@ -426,7 +426,7 @@ func TestScrollIntoCursor(t *testing.T) {
 }
 
 func TestScrollIntoCursor_ZeroHeight(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetIndex(simpleIndex())
 	m.SetSize(80, 0)
 
@@ -436,7 +436,7 @@ func TestScrollIntoCursor_ZeroHeight(t *testing.T) {
 }
 
 func TestUnfocused_IgnoresKeys(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetFocused(false)
 	m.SetIndex(simpleIndex())
 	m.SetSize(80, 20)
@@ -448,7 +448,7 @@ func TestUnfocused_IgnoresKeys(t *testing.T) {
 }
 
 func TestStateUpdatedMsg_RebuildsFlatList(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetIndex(simpleIndex())
 
 	if len(m.flatList) != 3 {
@@ -470,7 +470,7 @@ func TestStateUpdatedMsg_RebuildsFlatList(t *testing.T) {
 }
 
 func TestNodeUpdatedMsg_UpdatesCache(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetIndex(simpleIndex())
 	m.expanded["alpha"] = true
 
@@ -500,7 +500,7 @@ func TestNodeUpdatedMsg_UpdatesCache(t *testing.T) {
 // the eager-loaded state would silently disappear after the next
 // poll tick and the active-task display would go stale again.
 func TestNodeUpdatedMsg_DoesNotSetCacheExpiryWhenCollapsed(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetIndex(simpleIndex())
 	// Deliberately NOT expanded.
 
@@ -523,7 +523,7 @@ func TestNodeUpdatedMsg_DoesNotSetCacheExpiryWhenCollapsed(t *testing.T) {
 // the same eviction removal on the collapse path. Collapsing a
 // previously-expanded leaf should NOT start an eviction timer.
 func TestHandleCollapse_DoesNotSetCacheExpiry(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetFocused(true)
 	m.SetIndex(orchestratorIndex())
 	m.SetSize(80, 20)
@@ -552,7 +552,7 @@ func TestHandleCollapse_DoesNotSetCacheExpiry(t *testing.T) {
 }
 
 func TestExpandToggle_AlreadyExpanded(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetFocused(true)
 	m.SetIndex(orchestratorIndex())
 	m.SetSize(80, 20)
@@ -571,7 +571,7 @@ func TestExpandToggle_AlreadyExpanded(t *testing.T) {
 }
 
 func TestExpandTask_Noop(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetFocused(true)
 	m.SetIndex(simpleIndex())
 	m.SetSize(80, 20)
@@ -600,7 +600,7 @@ func TestExpandTask_Noop(t *testing.T) {
 }
 
 func TestBuildFlatList_NilIndex(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.buildFlatList()
 
 	if m.flatList != nil {
@@ -609,7 +609,7 @@ func TestBuildFlatList_NilIndex(t *testing.T) {
 }
 
 func TestClampCursor_EmptyList(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.cursor = 5
 	m.clampCursor()
 	if m.cursor != 0 {
@@ -618,7 +618,7 @@ func TestClampCursor_EmptyList(t *testing.T) {
 }
 
 func TestClampCursor_BeyondEnd(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetIndex(simpleIndex())
 	m.cursor = 100
 	m.clampCursor()
@@ -628,7 +628,7 @@ func TestClampCursor_BeyondEnd(t *testing.T) {
 }
 
 func TestClampCursor_Negative(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetIndex(simpleIndex())
 	m.cursor = -5
 	m.clampCursor()
@@ -638,7 +638,7 @@ func TestClampCursor_Negative(t *testing.T) {
 }
 
 func TestFlatList_Accessor(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetIndex(simpleIndex())
 
 	fl := m.FlatList()
@@ -648,7 +648,7 @@ func TestFlatList_Accessor(t *testing.T) {
 }
 
 func TestSetSize(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetSize(60, 25)
 	if m.width != 60 {
 		t.Errorf("width = %d, want 60", m.width)
@@ -659,7 +659,7 @@ func TestSetSize(t *testing.T) {
 }
 
 func TestParentOf_TaskRow(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetIndex(simpleIndex())
 	m.expanded["alpha"] = true
 	m.nodes["alpha"] = &state.NodeState{
@@ -675,7 +675,7 @@ func TestParentOf_TaskRow(t *testing.T) {
 }
 
 func TestParentOf_NilIndex(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	idx := m.parentOf("anything")
 	if idx != -1 {
 		t.Errorf("parentOf with nil index = %d, want -1", idx)
@@ -683,7 +683,7 @@ func TestParentOf_NilIndex(t *testing.T) {
 }
 
 func TestHandleCollapse_EmptyList(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetFocused(true)
 
 	// Should not panic.
@@ -691,7 +691,7 @@ func TestHandleCollapse_EmptyList(t *testing.T) {
 }
 
 func TestHandleExpand_EmptyList(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetFocused(true)
 
 	// Should not panic.
@@ -702,7 +702,7 @@ func TestHandleExpand_EmptyList(t *testing.T) {
 }
 
 func TestSetSearchAddresses(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetIndex(simpleIndex())
 
 	literal := map[string]bool{"alpha": true, "alpha/beta": true}
@@ -729,7 +729,7 @@ func TestSetSearchAddresses(t *testing.T) {
 }
 
 func TestSetCursor(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetIndex(simpleIndex())
 	m.SetSize(80, 20)
 
@@ -751,7 +751,7 @@ func TestSetCursor(t *testing.T) {
 }
 
 func TestCleanCache_RemovesExpired(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetIndex(simpleIndex())
 
 	// Add a node with an already-expired cache entry.
@@ -776,7 +776,7 @@ func TestCleanCache_RemovesExpired(t *testing.T) {
 }
 
 func TestCleanCache_EmptyIsNoop(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	// Should not panic on empty maps.
 	m.CleanCache()
 }
@@ -788,7 +788,7 @@ func TestCleanCache_EmptyIsNoop(t *testing.T) {
 // eager-prefetch path needs collapsed entries to persist so search
 // can walk task content even when the leaf is folded.
 func TestCollapse_DoesNotSetCacheExpiry(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetFocused(true)
 	m.expanded["parent"] = true
 	m.SetIndex(orchestratorIndex())

--- a/internal/tui/tree/render.go
+++ b/internal/tui/tree/render.go
@@ -80,7 +80,7 @@ func taskStatusGlyphOnBg(s state.NodeStatus, bg color.Color) string {
 	return statusGlyphOnBg(s, bg)
 }
 
-// RenderRow produces a single styled line for the given TreeRow.
+// RenderRow produces a single styled line for the given Row.
 //
 // hits encodes the search highlight state for this row:
 //
@@ -95,7 +95,7 @@ func taskStatusGlyphOnBg(s state.NodeStatus, bg color.Color) string {
 // When both flags are set the literal treatment wins. Older callers
 // may pass a single bool which is interpreted as literal-only for
 // backward compatibility with the variadic shape.
-func RenderRow(row TreeRow, width int, selected bool, isCurrentTarget bool, hits ...bool) string {
+func RenderRow(row Row, width int, selected bool, isCurrentTarget bool, hits ...bool) string {
 	literal := len(hits) > 0 && hits[0]
 	ancestor := len(hits) > 1 && hits[1]
 	if row.IsTask {
@@ -104,7 +104,7 @@ func RenderRow(row TreeRow, width int, selected bool, isCurrentTarget bool, hits
 	return renderNodeRow(row, width, selected, isCurrentTarget, literal, ancestor)
 }
 
-func renderNodeRow(row TreeRow, width int, selected bool, isCurrentTarget bool, literalHit, ancestorHit bool) string {
+func renderNodeRow(row Row, width int, selected bool, isCurrentTarget bool, literalHit, ancestorHit bool) string {
 	indent := strings.Repeat("  ", row.Depth)
 
 	var marker string
@@ -186,7 +186,7 @@ func renderNodeRow(row TreeRow, width int, selected bool, isCurrentTarget bool, 
 // color (used for both literal-match and ancestor-of-match
 // highlights). The two cases differ only in the bg/fg pair, so the
 // shared layout/padding logic lives here.
-func renderNodeRowWithBg(row TreeRow, width int, indent, marker, name string, isCurrentTarget bool, bgColor, fgColor color.Color) string {
+func renderNodeRowWithBg(row Row, width int, indent, marker, name string, isCurrentTarget bool, bgColor, fgColor color.Color) string {
 	bg := lipgloss.NewStyle().Background(bgColor).Foreground(fgColor)
 	var target string
 	if isCurrentTarget {
@@ -205,7 +205,7 @@ func renderNodeRowWithBg(row TreeRow, width int, indent, marker, name string, is
 	return text
 }
 
-func renderTaskRow(row TreeRow, width int, selected bool, literalHit, ancestorHit bool) string {
+func renderTaskRow(row Row, width int, selected bool, literalHit, ancestorHit bool) string {
 	indent := strings.Repeat("  ", row.Depth)
 
 	// Extract the task ID from the address (last segment after /).
@@ -253,7 +253,7 @@ func renderTaskRow(row TreeRow, width int, selected bool, literalHit, ancestorHi
 // renderTaskRowWithBg renders a task row with a solid background
 // for both literal-match and ancestor-of-match highlight cases.
 // The two differ only in the bg/fg pair.
-func renderTaskRowWithBg(row TreeRow, width int, indent, taskID, title string, bgColor, fgColor color.Color) string {
+func renderTaskRowWithBg(row Row, width int, indent, taskID, title string, bgColor, fgColor color.Color) string {
 	glyph := taskStatusGlyphOnBg(row.Status, bgColor)
 	bg := lipgloss.NewStyle().Background(bgColor).Foreground(fgColor)
 	text := bg.Render(indent) + glyph + bg.Render(" "+taskID+": "+title)
@@ -265,7 +265,7 @@ func renderTaskRowWithBg(row TreeRow, width int, indent, taskID, title string, b
 }
 
 // View renders the visible portion of the tree as a single string.
-func (m TreeModel) View() string {
+func (m Model) View() string {
 	if len(m.flatList) == 0 {
 		return styleNormal.Render("  (no nodes)")
 	}

--- a/internal/tui/tree/render_test.go
+++ b/internal/tui/tree/render_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestRenderRow_OrchestratorCollapsed(t *testing.T) {
-	row := TreeRow{
+	row := Row{
 		Addr:       "parent",
 		Name:       "My Orchestrator",
 		Depth:      0,
@@ -30,7 +30,7 @@ func TestRenderRow_OrchestratorCollapsed(t *testing.T) {
 }
 
 func TestRenderRow_OrchestratorExpanded(t *testing.T) {
-	row := TreeRow{
+	row := Row{
 		Addr:       "parent",
 		Name:       "My Orchestrator",
 		Depth:      0,
@@ -47,7 +47,7 @@ func TestRenderRow_OrchestratorExpanded(t *testing.T) {
 }
 
 func TestRenderRow_Leaf_NoExpandMarker(t *testing.T) {
-	row := TreeRow{
+	row := Row{
 		Addr:       "leaf1",
 		Name:       "Simple Leaf",
 		Depth:      1,
@@ -64,7 +64,7 @@ func TestRenderRow_Leaf_NoExpandMarker(t *testing.T) {
 }
 
 func TestRenderRow_Task(t *testing.T) {
-	row := TreeRow{
+	row := Row{
 		Addr:   "leaf1/t-001",
 		Name:   "Implement feature",
 		Depth:  2,
@@ -82,11 +82,11 @@ func TestRenderRow_Task(t *testing.T) {
 }
 
 func TestRenderRow_Selected(t *testing.T) {
-	normal := RenderRow(TreeRow{
+	normal := RenderRow(Row{
 		Addr: "a", Name: "Node", NodeType: state.NodeLeaf, Expandable: true,
 	}, 40, false, false)
 
-	selected := RenderRow(TreeRow{
+	selected := RenderRow(Row{
 		Addr: "a", Name: "Node", NodeType: state.NodeLeaf, Expandable: true,
 	}, 40, true, false)
 
@@ -97,7 +97,7 @@ func TestRenderRow_Selected(t *testing.T) {
 }
 
 func TestRenderRow_CurrentTarget(t *testing.T) {
-	row := TreeRow{
+	row := Row{
 		Addr:       "target-node",
 		Name:       "Target",
 		Depth:      0,
@@ -113,7 +113,7 @@ func TestRenderRow_CurrentTarget(t *testing.T) {
 }
 
 func TestRenderRow_NotCurrentTarget(t *testing.T) {
-	row := TreeRow{
+	row := Row{
 		Addr:       "other-node",
 		Name:       "Other",
 		Depth:      0,
@@ -191,7 +191,7 @@ func TestTruncate(t *testing.T) {
 }
 
 func TestView_Empty(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	v := m.View()
 	if !strings.Contains(v, "no nodes") {
 		t.Errorf("empty tree view should contain 'no nodes', got %q", v)
@@ -199,7 +199,7 @@ func TestView_Empty(t *testing.T) {
 }
 
 func TestView_RendersVisibleRows(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetIndex(simpleIndex())
 	m.SetSize(60, 2) // only 2 rows visible
 
@@ -211,7 +211,7 @@ func TestView_RendersVisibleRows(t *testing.T) {
 }
 
 func TestView_ScrollTopRespected(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetIndex(simpleIndex())
 	m.SetSize(60, 2)
 	m.scrollTop = 1
@@ -228,7 +228,7 @@ func TestView_ScrollTopRespected(t *testing.T) {
 }
 
 func TestView_ScrollTopBeyondList(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetIndex(simpleIndex())
 	m.SetSize(60, 10)
 	m.scrollTop = 100
@@ -240,7 +240,7 @@ func TestView_ScrollTopBeyondList(t *testing.T) {
 }
 
 func TestView_NegativeScrollTop(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetIndex(simpleIndex())
 	m.SetSize(60, 10)
 	m.scrollTop = -5
@@ -254,7 +254,7 @@ func TestView_NegativeScrollTop(t *testing.T) {
 
 func TestRenderRow_LongNameTruncation(t *testing.T) {
 	longName := strings.Repeat("A", 200)
-	row := TreeRow{
+	row := Row{
 		Addr:       "long",
 		Name:       longName,
 		Depth:      0,
@@ -273,7 +273,7 @@ func TestRenderRow_LongNameTruncation(t *testing.T) {
 }
 
 func TestRenderRow_VeryNarrowWidth(t *testing.T) {
-	row := TreeRow{
+	row := Row{
 		Addr:       "narrow",
 		Name:       "Some Node",
 		Depth:      0,
@@ -290,7 +290,7 @@ func TestRenderRow_VeryNarrowWidth(t *testing.T) {
 }
 
 func TestView_CurrentTargetHighlighted(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetIndex(simpleIndex())
 	m.SetSize(60, 10)
 	m.SetCurrentTarget("beta")
@@ -303,7 +303,7 @@ func TestView_CurrentTargetHighlighted(t *testing.T) {
 
 func TestRenderTaskRow_IDExtraction(t *testing.T) {
 	// The task ID is extracted from the last segment of the address.
-	row := TreeRow{
+	row := Row{
 		Addr:   "deep/nested/node/task-42",
 		Name:   "A Task",
 		Depth:  3,
@@ -318,7 +318,7 @@ func TestRenderTaskRow_IDExtraction(t *testing.T) {
 }
 
 func TestRenderRow_SearchHit(t *testing.T) {
-	row := TreeRow{
+	row := Row{
 		Addr:       "a",
 		Name:       "SearchMe",
 		Depth:      0,
@@ -336,7 +336,7 @@ func TestRenderRow_SearchHit(t *testing.T) {
 }
 
 func TestRenderRow_SearchHit_SelectedTakesPrecedence(t *testing.T) {
-	row := TreeRow{
+	row := Row{
 		Addr:       "a",
 		Name:       "SearchMe",
 		Depth:      0,
@@ -355,7 +355,7 @@ func TestRenderRow_SearchHit_SelectedTakesPrecedence(t *testing.T) {
 }
 
 func TestView_SearchMatchHighlighted(t *testing.T) {
-	m := NewTreeModel()
+	m := NewModel()
 	m.SetIndex(simpleIndex())
 	m.SetSize(60, 10)
 	m.SetSearchAddresses(map[string]bool{"beta": true}, nil)
@@ -368,7 +368,7 @@ func TestView_SearchMatchHighlighted(t *testing.T) {
 }
 
 func TestRenderRow_TaskSearchHit(t *testing.T) {
-	row := TreeRow{
+	row := Row{
 		Addr:   "node/t-001",
 		Name:   "A task",
 		Depth:  1,
@@ -385,11 +385,11 @@ func TestRenderRow_TaskSearchHit(t *testing.T) {
 }
 
 func TestRenderRow_DepthIndentation(t *testing.T) {
-	shallow := RenderRow(TreeRow{
+	shallow := RenderRow(Row{
 		Addr: "a", Name: "Shallow", Depth: 0, NodeType: state.NodeLeaf, Expandable: true,
 	}, 80, false, false)
 
-	deep := RenderRow(TreeRow{
+	deep := RenderRow(Row{
 		Addr: "b", Name: "Deep", Depth: 3, NodeType: state.NodeLeaf, Expandable: true,
 	}, 80, false, false)
 
@@ -465,7 +465,7 @@ func TestTaskStatusGlyphOnBg_InProgressShowsArrow(t *testing.T) {
 // row rendering path (not just the glyph helper) to confirm the
 // new glyph reaches the rendered output.
 func TestRenderTaskRow_InProgressUsesArrow(t *testing.T) {
-	row := TreeRow{
+	row := Row{
 		Addr:   "alpha/task-0001",
 		Name:   "deploy frobnicator",
 		Depth:  1,

--- a/internal/tui/welcome/model.go
+++ b/internal/tui/welcome/model.go
@@ -40,8 +40,8 @@ type ConnectInstanceMsg struct {
 	Entry instance.Entry
 }
 
-// WelcomeModel drives the launcher screen.
-type WelcomeModel struct {
+// Model drives the launcher screen.
+type Model struct {
 	// Sessions panel
 	instances     []instance.Entry
 	sessionCursor int
@@ -61,15 +61,15 @@ type WelcomeModel struct {
 	spinnerFrame int
 }
 
-// NewWelcomeModel creates a launcher rooted at startDir's parent directory.
+// NewModel creates a launcher rooted at startDir's parent directory.
 // If instances are provided, the sessions panel starts with focus.
-func NewWelcomeModel(startDir string, instances []instance.Entry) WelcomeModel {
+func NewModel(startDir string, instances []instance.Entry) Model {
 	abs, err := filepath.Abs(startDir)
 	if err != nil {
 		abs = startDir
 	}
 
-	m := WelcomeModel{
+	m := Model{
 		currentDir: abs,
 		instances:  instances,
 	}
@@ -94,20 +94,22 @@ func NewWelcomeModel(startDir string, instances []instance.Entry) WelcomeModel {
 	return m
 }
 
-func (m *WelcomeModel) SetSize(width, height int) {
+// SetSize updates the terminal dimensions for layout calculations.
+func (m *Model) SetSize(width, height int) {
 	m.width = width
 	m.height = height
 }
 
 // SetInstances updates the running sessions list (called on InstancesUpdatedMsg).
-func (m *WelcomeModel) SetInstances(instances []instance.Entry) {
+func (m *Model) SetInstances(instances []instance.Entry) {
 	m.instances = instances
 	if m.sessionCursor >= len(instances) {
 		m.sessionCursor = max(0, len(instances)-1)
 	}
 }
 
-func (m WelcomeModel) Update(msg tea.Msg) (WelcomeModel, tea.Cmd) {
+// Update handles keyboard input and messages for the welcome screen.
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyPressMsg:
 		return m.handleKey(msg)
@@ -139,7 +141,7 @@ func (m WelcomeModel) Update(msg tea.Msg) (WelcomeModel, tea.Cmd) {
 	return m, nil
 }
 
-func (m WelcomeModel) handleKey(msg tea.KeyPressMsg) (WelcomeModel, tea.Cmd) {
+func (m Model) handleKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 	if m.initializing {
 		if key.Matches(msg, tui.WelcomeKeyMap.Quit) {
 			return m, tea.Quit
@@ -163,7 +165,7 @@ func (m WelcomeModel) handleKey(msg tea.KeyPressMsg) (WelcomeModel, tea.Cmd) {
 	return m.handleDirKey(msg)
 }
 
-func (m WelcomeModel) handleSessionKey(msg tea.KeyPressMsg) (WelcomeModel, tea.Cmd) {
+func (m Model) handleSessionKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 	switch {
 	case key.Matches(msg, tui.WelcomeKeyMap.MoveDown):
 		if m.sessionCursor < len(m.instances)-1 {
@@ -191,7 +193,7 @@ func (m WelcomeModel) handleSessionKey(msg tea.KeyPressMsg) (WelcomeModel, tea.C
 	return m, nil
 }
 
-func (m WelcomeModel) handleDirKey(msg tea.KeyPressMsg) (WelcomeModel, tea.Cmd) {
+func (m Model) handleDirKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 	switch {
 	case key.Matches(msg, tui.WelcomeKeyMap.MoveDown):
 		if m.dirCursor < len(m.entries)-1 {
@@ -231,7 +233,7 @@ func (m WelcomeModel) handleDirKey(msg tea.KeyPressMsg) (WelcomeModel, tea.Cmd) 
 	return m, nil
 }
 
-func (m WelcomeModel) handleEnter(msg tea.KeyPressMsg) (WelcomeModel, tea.Cmd) {
+func (m Model) handleEnter(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 	if len(m.entries) == 0 {
 		return m, nil
 	}
@@ -253,7 +255,7 @@ func (m WelcomeModel) handleEnter(msg tea.KeyPressMsg) (WelcomeModel, tea.Cmd) {
 	return m, nil
 }
 
-func (m WelcomeModel) startInit() (WelcomeModel, tea.Cmd) {
+func (m Model) startInit() (Model, tea.Cmd) {
 	m.initializing = true
 	m.spinnerFrame = 0
 	m.err = nil
@@ -265,7 +267,7 @@ func (m WelcomeModel) startInit() (WelcomeModel, tea.Cmd) {
 	)
 }
 
-func (m WelcomeModel) runInit(dir string) tea.Cmd {
+func (m Model) runInit(dir string) tea.Cmd {
 	return func() tea.Msg {
 		wcDir := filepath.Join(dir, ".wolfcastle")
 		// If the directory already exists, treat init as a no-op success
@@ -284,13 +286,13 @@ func (m WelcomeModel) runInit(dir string) tea.Cmd {
 	}
 }
 
-func (m WelcomeModel) tickSpinner() tea.Cmd {
+func (m Model) tickSpinner() tea.Cmd {
 	return tea.Tick(80*time.Millisecond, func(time.Time) tea.Msg {
 		return tui.SpinnerTickMsg{}
 	})
 }
 
-func (m *WelcomeModel) loadDir() {
+func (m *Model) loadDir() {
 	dirEntries, err := os.ReadDir(m.currentDir)
 	if err != nil {
 		m.entries = nil
@@ -325,7 +327,7 @@ func (m *WelcomeModel) loadDir() {
 	m.entries = filtered
 }
 
-func (m *WelcomeModel) scrollIntoCursor() {
+func (m *Model) scrollIntoCursor() {
 	if m.dirCursor < m.scrollTop {
 		m.scrollTop = m.dirCursor
 	}
@@ -335,10 +337,8 @@ func (m *WelcomeModel) scrollIntoCursor() {
 }
 
 // ---------------------------------------------------------------------------
-// View
-// ---------------------------------------------------------------------------
-
-func (m WelcomeModel) View() string {
+// View renders the welcome screen with session and directory panels.
+func (m Model) View() string {
 	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(tui.ColorWhite)
 	subtitleStyle := lipgloss.NewStyle().Foreground(tui.ColorDimWhite)
 	spinnerStyle := lipgloss.NewStyle().Foreground(tui.ColorYellow)
@@ -405,7 +405,7 @@ func (m WelcomeModel) View() string {
 	return m.place(b.String())
 }
 
-func (m WelcomeModel) renderSessions() string {
+func (m Model) renderSessions() string {
 	headingStyle := lipgloss.NewStyle().Bold(true).Foreground(tui.ColorWhite)
 	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(tui.ColorWhite).Background(tui.ColorDarkGray)
 	normalStyle := lipgloss.NewStyle().Foreground(tui.ColorLightGray)
@@ -440,7 +440,7 @@ func (m WelcomeModel) renderSessions() string {
 	return b.String()
 }
 
-func (m WelcomeModel) renderDirBrowser() string {
+func (m Model) renderDirBrowser() string {
 	headingStyle := lipgloss.NewStyle().Bold(true).Foreground(tui.ColorWhite)
 	subtitleStyle := lipgloss.NewStyle().Foreground(tui.ColorDimWhite)
 	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(tui.ColorWhite).Background(tui.ColorDarkGray)
@@ -511,7 +511,7 @@ func (m WelcomeModel) renderDirBrowser() string {
 	return b.String()
 }
 
-func (m WelcomeModel) renderHints() string {
+func (m Model) renderHints() string {
 	hintStyle := lipgloss.NewStyle().Foreground(tui.ColorDimWhite)
 	dir := filepath.Base(m.currentDir)
 	if dir == "" || dir == "/" {
@@ -538,7 +538,7 @@ func (m WelcomeModel) renderHints() string {
 	return hintStyle.Render(line1) + "\n" + hintStyle.Render(line2)
 }
 
-func (m WelcomeModel) visibleEntries() []os.DirEntry {
+func (m Model) visibleEntries() []os.DirEntry {
 	end := m.scrollTop + maxVisible
 	if end > len(m.entries) {
 		end = len(m.entries)
@@ -546,7 +546,7 @@ func (m WelcomeModel) visibleEntries() []os.DirEntry {
 	return m.entries[m.scrollTop:end]
 }
 
-func (m WelcomeModel) place(content string) string {
+func (m Model) place(content string) string {
 	w := m.width
 	h := m.height
 	if w <= 0 {

--- a/internal/tui/welcome/model_test.go
+++ b/internal/tui/welcome/model_test.go
@@ -34,7 +34,7 @@ func lKey() tea.KeyPressMsg      { return keyPress('l') }
 func initKey() tea.KeyPressMsg   { return keyPress('I') }
 
 // setupTestDir creates a directory with the given subdirectories inside it.
-// NewWelcomeModel(dir, nil) will open in dir showing its subdirectories.
+// NewModel(dir, nil) will open in dir showing its subdirectories.
 func setupTestDir(t *testing.T, subdirs ...string) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -48,10 +48,10 @@ func setupTestDir(t *testing.T, subdirs ...string) string {
 
 // ---------- Construction ----------
 
-func TestNewWelcomeModel_StartsInCWD(t *testing.T) {
+func TestNewModel_StartsInCWD(t *testing.T) {
 	dir := setupTestDir(t, "aaa", "bbb")
 
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 
 	if m.currentDir != dir {
 		t.Fatalf("expected currentDir=%q, got %q", dir, m.currentDir)
@@ -61,10 +61,10 @@ func TestNewWelcomeModel_StartsInCWD(t *testing.T) {
 	}
 }
 
-func TestNewWelcomeModel_CursorStartsAtZero(t *testing.T) {
+func TestNewModel_CursorStartsAtZero(t *testing.T) {
 	dir := setupTestDir(t, "aaa", "zzz")
 
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 
 	if m.dirCursor != 0 {
 		t.Fatalf("expected cursor at 0, got %d", m.dirCursor)
@@ -78,7 +78,7 @@ func TestNewWelcomeModel_CursorStartsAtZero(t *testing.T) {
 
 func TestCursorDown(t *testing.T) {
 	dir := setupTestDir(t, "aaa", "bbb", "ccc", "ddd", "eee")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 	start := m.dirCursor
 
 	m, _ = m.Update(downKey())
@@ -89,7 +89,7 @@ func TestCursorDown(t *testing.T) {
 
 func TestCursorDown_Clamps(t *testing.T) {
 	dir := setupTestDir(t, "aaa", "bbb")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 
 	// Move well past the end
 	for range len(m.entries) + 2 {
@@ -102,7 +102,7 @@ func TestCursorDown_Clamps(t *testing.T) {
 
 func TestCursorUp(t *testing.T) {
 	dir := setupTestDir(t, "aaa", "bbb", "ccc", "ddd", "eee")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 
 	// Move down twice, then up
 	m, _ = m.Update(downKey())
@@ -116,7 +116,7 @@ func TestCursorUp(t *testing.T) {
 
 func TestCursorUp_ClampsAtZero(t *testing.T) {
 	dir := setupTestDir(t, "aaa", "zzz")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 
 	// Move to top first
 	m, _ = m.Update(topKey())
@@ -128,7 +128,7 @@ func TestCursorUp_ClampsAtZero(t *testing.T) {
 
 func TestJumpToTop(t *testing.T) {
 	dir := setupTestDir(t, "aaa", "bbb", "ccc", "ddd", "eee")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 
 	m, _ = m.Update(bottomKey())
 	m, _ = m.Update(topKey())
@@ -139,7 +139,7 @@ func TestJumpToTop(t *testing.T) {
 
 func TestJumpToBottom(t *testing.T) {
 	dir := setupTestDir(t, "aaa", "bbb", "ccc", "ddd", "eee")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 
 	m, _ = m.Update(bottomKey())
 	if m.dirCursor != len(m.entries)-1 {
@@ -154,7 +154,7 @@ func TestEnterOnDirectory_Descends(t *testing.T) {
 	// Create a grandchild so "target" has contents
 	_ = os.Mkdir(filepath.Join(dir, "target", "inner"), 0o755)
 
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 	// Cursor is on "target". Enter should descend into it.
 	targetDir := filepath.Join(dir, "target")
 	m, _ = m.Update(enterKey())
@@ -166,7 +166,7 @@ func TestEnterOnDirectory_Descends(t *testing.T) {
 func TestLKey_DescendsButDoesNotInit(t *testing.T) {
 	dir := setupTestDir(t, "empty")
 
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 	// Cursor is on "empty". Enter descends into it.
 	m, _ = m.Update(enterKey())
 	// Now inside "empty" which has no entries. l should NOT init.
@@ -181,7 +181,7 @@ func TestLKey_DescendsButDoesNotInit(t *testing.T) {
 
 func TestBack_GoesToParent(t *testing.T) {
 	dir := setupTestDir(t, "target")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 	parentDir := m.currentDir
 
 	// Descend first, then back
@@ -198,7 +198,7 @@ func TestBack_GoesToParent(t *testing.T) {
 func TestEnterOnEmptyDir_StartsInit(t *testing.T) {
 	dir := setupTestDir(t, "empty")
 
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 	// Descend into "empty"
 	m, _ = m.Update(enterKey())
 
@@ -215,7 +215,7 @@ func TestEnterOnEmptyDir_StartsInit(t *testing.T) {
 func TestInitKey_StartsInitInCurrentDir(t *testing.T) {
 	dir := setupTestDir(t, "subdir")
 
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 
 	m, cmd := m.Update(initKey())
 	if !m.initializing {
@@ -229,7 +229,7 @@ func TestInitKey_StartsInitInCurrentDir(t *testing.T) {
 func TestEnterOnDotWolfcastle_DoesNotInit(t *testing.T) {
 	dir := setupTestDir(t, ".wolfcastle")
 
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 	for i, e := range m.entries {
 		if e.Name() == ".wolfcastle" {
 			m.dirCursor = i
@@ -245,7 +245,7 @@ func TestEnterOnDotWolfcastle_DoesNotInit(t *testing.T) {
 
 func TestInitCompleteMsg_Success(t *testing.T) {
 	dir := setupTestDir(t, "target")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 	m.initializing = true
 
 	m, _ = m.Update(tui.InitCompleteMsg{Dir: dir, Err: nil})
@@ -259,7 +259,7 @@ func TestInitCompleteMsg_Success(t *testing.T) {
 
 func TestInitCompleteMsg_Failure(t *testing.T) {
 	dir := setupTestDir(t, "target")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 	m.initializing = true
 
 	testErr := errors.New("boom")
@@ -276,7 +276,7 @@ func TestInitCompleteMsg_Failure(t *testing.T) {
 
 func TestSpinnerTickMsg_WhileInitializing(t *testing.T) {
 	dir := setupTestDir(t, "target")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 	m.initializing = true
 	m.spinnerFrame = 0
 
@@ -291,7 +291,7 @@ func TestSpinnerTickMsg_WhileInitializing(t *testing.T) {
 
 func TestSpinnerTickMsg_WhileNotInitializing(t *testing.T) {
 	dir := setupTestDir(t, "target")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 	m.initializing = false
 
 	m, cmd := m.Update(tui.SpinnerTickMsg{})
@@ -307,7 +307,7 @@ func TestSpinnerTickMsg_WhileNotInitializing(t *testing.T) {
 
 func TestWindowSizeMsg(t *testing.T) {
 	dir := setupTestDir(t, "target")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 
 	m, _ = m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 	if m.width != 120 || m.height != 40 {
@@ -317,7 +317,7 @@ func TestWindowSizeMsg(t *testing.T) {
 
 func TestSetSize(t *testing.T) {
 	dir := setupTestDir(t, "target")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 
 	m.SetSize(100, 50)
 	if m.width != 100 || m.height != 50 {
@@ -329,7 +329,7 @@ func TestSetSize(t *testing.T) {
 
 func TestView_ShowsTitle(t *testing.T) {
 	dir := setupTestDir(t, "target")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 	m.SetSize(80, 24)
 
 	view := m.View()
@@ -340,7 +340,7 @@ func TestView_ShowsTitle(t *testing.T) {
 
 func TestView_ShowsTreeConnectors(t *testing.T) {
 	dir := setupTestDir(t, "aaa", "bbb", "ccc")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 	m.SetSize(80, 24)
 
 	view := m.View()
@@ -351,7 +351,7 @@ func TestView_ShowsTreeConnectors(t *testing.T) {
 
 func TestView_WithError(t *testing.T) {
 	dir := setupTestDir(t, "target")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 	m.SetSize(80, 24)
 	m.err = errors.New("test error")
 
@@ -363,7 +363,7 @@ func TestView_WithError(t *testing.T) {
 
 func TestView_WhileInitializing(t *testing.T) {
 	dir := setupTestDir(t, "target")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 	m.SetSize(80, 24)
 	m.initializing = true
 
@@ -376,7 +376,7 @@ func TestView_WhileInitializing(t *testing.T) {
 func TestView_EmptyDir_ShowsHint(t *testing.T) {
 	dir := setupTestDir(t, "empty")
 
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 	// Descend into empty
 	m, _ = m.Update(enterKey())
 	m.SetSize(80, 24)
@@ -389,7 +389,7 @@ func TestView_EmptyDir_ShowsHint(t *testing.T) {
 
 func TestView_WithEntries_ShowsDirNames(t *testing.T) {
 	dir := setupTestDir(t, "alpha", "beta", "target")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 	m.SetSize(80, 24)
 
 	view := m.View()
@@ -403,7 +403,7 @@ func TestView_WithEntries_ShowsDirNames(t *testing.T) {
 
 func TestView_SelectedEntryHasMarker(t *testing.T) {
 	dir := setupTestDir(t, "target", "other")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 	m.SetSize(80, 24)
 
 	view := m.View()
@@ -414,7 +414,7 @@ func TestView_SelectedEntryHasMarker(t *testing.T) {
 
 func TestView_KeyHints(t *testing.T) {
 	dir := setupTestDir(t, "target")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 	m.SetSize(80, 24)
 
 	view := m.View()
@@ -432,7 +432,7 @@ func TestHiddenDirsFiltered_ExceptWolfcastle(t *testing.T) {
 	_ = os.Mkdir(filepath.Join(dir, ".wolfcastle"), 0o755)
 	_ = os.Mkdir(filepath.Join(dir, "visible"), 0o755)
 
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 
 	names := entryNames(m.entries)
 	if len(names) != 2 {
@@ -448,7 +448,7 @@ func TestOnlyDirsShown_NoFiles(t *testing.T) {
 	_ = os.Mkdir(filepath.Join(dir, "subdir"), 0o755)
 	_ = os.WriteFile(filepath.Join(dir, "file.txt"), []byte("hello"), 0o644)
 
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 
 	if len(m.entries) != 1 {
 		t.Fatalf("expected 1 dir entry, got %d: %v", len(m.entries), entryNames(m.entries))
@@ -462,7 +462,7 @@ func TestOnlyDirsShown_NoFiles(t *testing.T) {
 
 func TestQuitKey(t *testing.T) {
 	dir := setupTestDir(t, "target")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 
 	_, cmd := m.Update(quitKey())
 	if cmd == nil {
@@ -476,7 +476,7 @@ func TestQuitKey(t *testing.T) {
 
 func TestQuitKey_DuringInit(t *testing.T) {
 	dir := setupTestDir(t, "target")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 	m.initializing = true
 
 	_, cmd := m.Update(quitKey())
@@ -487,7 +487,7 @@ func TestQuitKey_DuringInit(t *testing.T) {
 
 func TestKeysSwallowedDuringInit(t *testing.T) {
 	dir := setupTestDir(t, "aaa", "bbb", "ccc")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 	m.initializing = true
 	startCursor := m.dirCursor
 
@@ -506,7 +506,7 @@ func TestScrolling(t *testing.T) {
 		_ = os.Mkdir(filepath.Join(dir, name), 0o755)
 	}
 
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 	if len(m.entries) != 25 {
 		t.Fatalf("expected 25 entries, got %d", len(m.entries))
 	}
@@ -532,7 +532,7 @@ func TestView_ScrollIndicators(t *testing.T) {
 		_ = os.Mkdir(filepath.Join(dir, name), 0o755)
 	}
 
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 	m.SetSize(80, 40)
 
 	// Jump to bottom so we have "more above"
@@ -547,7 +547,7 @@ func TestView_ScrollIndicators(t *testing.T) {
 
 func TestUnknownMsg_NoOp(t *testing.T) {
 	dir := setupTestDir(t, "target")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 	origCursor := m.dirCursor
 	origDir := m.currentDir
 
@@ -562,7 +562,7 @@ func TestUnknownMsg_NoOp(t *testing.T) {
 
 func TestSetInstances(t *testing.T) {
 	dir := setupTestDir(t, "target")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 
 	entries := []instance.Entry{
 		{PID: 1, Worktree: "/a", Branch: "main"},
@@ -582,7 +582,7 @@ func TestSetInstances_ClampsSessionCursor(t *testing.T) {
 		{PID: 2, Worktree: "/b", Branch: "dev"},
 		{PID: 3, Worktree: "/c", Branch: "fix"},
 	}
-	m := NewWelcomeModel(dir, entries)
+	m := NewModel(dir, entries)
 	m.sessionCursor = 2
 
 	// Reduce to 1 instance; cursor should clamp.
@@ -595,7 +595,7 @@ func TestSetInstances_ClampsSessionCursor(t *testing.T) {
 func TestSetInstances_EmptyList(t *testing.T) {
 	dir := setupTestDir(t, "target")
 	entries := []instance.Entry{{PID: 1, Worktree: "/a", Branch: "main"}}
-	m := NewWelcomeModel(dir, entries)
+	m := NewModel(dir, entries)
 	m.sessionCursor = 0
 
 	m.SetInstances(nil)
@@ -608,7 +608,7 @@ func TestSetInstances_EmptyList(t *testing.T) {
 
 func TestInstancesUpdatedMsg(t *testing.T) {
 	dir := setupTestDir(t, "target")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 
 	entries := []instance.Entry{{PID: 42, Worktree: "/x", Branch: "main"}}
 	m, _ = m.Update(tui.InstancesUpdatedMsg{Instances: entries})
@@ -626,7 +626,7 @@ func tabKey() tea.KeyPressMsg {
 func TestTabSwitchesFocus(t *testing.T) {
 	dir := setupTestDir(t, "target")
 	entries := []instance.Entry{{PID: 1, Worktree: "/a", Branch: "main"}}
-	m := NewWelcomeModel(dir, entries)
+	m := NewModel(dir, entries)
 
 	if m.focus != panelSessions {
 		t.Fatal("expected sessions panel focused initially")
@@ -645,7 +645,7 @@ func TestTabSwitchesFocus(t *testing.T) {
 
 func TestTabIgnoredWithNoInstances(t *testing.T) {
 	dir := setupTestDir(t, "target")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 
 	m, _ = m.Update(tabKey())
 	if m.focus != panelDirs {
@@ -660,7 +660,7 @@ func TestSessionKey_MoveDown(t *testing.T) {
 		{PID: 2, Worktree: "/b", Branch: "b"},
 		{PID: 3, Worktree: "/c", Branch: "c"},
 	}
-	m := NewWelcomeModel(dir, entries)
+	m := NewModel(dir, entries)
 
 	m, _ = m.Update(downKey())
 	if m.sessionCursor != 1 {
@@ -674,7 +674,7 @@ func TestSessionKey_MoveDownClamps(t *testing.T) {
 		{PID: 1, Worktree: "/a", Branch: "a"},
 		{PID: 2, Worktree: "/b", Branch: "b"},
 	}
-	m := NewWelcomeModel(dir, entries)
+	m := NewModel(dir, entries)
 
 	for range 5 {
 		m, _ = m.Update(downKey())
@@ -690,7 +690,7 @@ func TestSessionKey_MoveUp(t *testing.T) {
 		{PID: 1, Worktree: "/a", Branch: "a"},
 		{PID: 2, Worktree: "/b", Branch: "b"},
 	}
-	m := NewWelcomeModel(dir, entries)
+	m := NewModel(dir, entries)
 
 	m, _ = m.Update(downKey())
 	m, _ = m.Update(upKey())
@@ -702,7 +702,7 @@ func TestSessionKey_MoveUp(t *testing.T) {
 func TestSessionKey_MoveUpClampsAtZero(t *testing.T) {
 	dir := setupTestDir(t, "target")
 	entries := []instance.Entry{{PID: 1, Worktree: "/a", Branch: "a"}}
-	m := NewWelcomeModel(dir, entries)
+	m := NewModel(dir, entries)
 
 	m, _ = m.Update(upKey())
 	if m.sessionCursor != 0 {
@@ -717,7 +717,7 @@ func TestSessionKey_Top(t *testing.T) {
 		{PID: 2, Worktree: "/b", Branch: "b"},
 		{PID: 3, Worktree: "/c", Branch: "c"},
 	}
-	m := NewWelcomeModel(dir, entries)
+	m := NewModel(dir, entries)
 	m, _ = m.Update(bottomKey())
 	m, _ = m.Update(topKey())
 
@@ -733,7 +733,7 @@ func TestSessionKey_Bottom(t *testing.T) {
 		{PID: 2, Worktree: "/b", Branch: "b"},
 		{PID: 3, Worktree: "/c", Branch: "c"},
 	}
-	m := NewWelcomeModel(dir, entries)
+	m := NewModel(dir, entries)
 
 	m, _ = m.Update(bottomKey())
 	if m.sessionCursor != 2 {
@@ -743,7 +743,7 @@ func TestSessionKey_Bottom(t *testing.T) {
 
 func TestSessionKey_BottomEmptyList(t *testing.T) {
 	dir := setupTestDir(t, "target")
-	m := NewWelcomeModel(dir, []instance.Entry{})
+	m := NewModel(dir, []instance.Entry{})
 	m.focus = panelSessions
 	m.instances = []instance.Entry{} // empty
 
@@ -758,7 +758,7 @@ func TestSessionKey_EnterConnects(t *testing.T) {
 	entries := []instance.Entry{
 		{PID: 42, Worktree: "/some/path", Branch: "main"},
 	}
-	m := NewWelcomeModel(dir, entries)
+	m := NewModel(dir, entries)
 
 	_, cmd := m.Update(enterKey())
 	if cmd == nil {
@@ -777,7 +777,7 @@ func TestSessionKey_EnterConnects(t *testing.T) {
 func TestSessionKey_Quit(t *testing.T) {
 	dir := setupTestDir(t, "target")
 	entries := []instance.Entry{{PID: 1, Worktree: "/a", Branch: "a"}}
-	m := NewWelcomeModel(dir, entries)
+	m := NewModel(dir, entries)
 
 	_, cmd := m.Update(quitKey())
 	if cmd == nil {
@@ -793,7 +793,7 @@ func TestRenderSessions_ShowsInstances(t *testing.T) {
 		{PID: 100, Worktree: "/path/to/main", Branch: "main"},
 		{PID: 200, Worktree: "/path/to/dev", Branch: "dev"},
 	}
-	m := NewWelcomeModel(dir, entries)
+	m := NewModel(dir, entries)
 	m.SetSize(80, 40)
 
 	view := m.View()
@@ -810,7 +810,7 @@ func TestRenderSessions_DimmedWhenUnfocused(t *testing.T) {
 	entries := []instance.Entry{
 		{PID: 1, Worktree: "/a", Branch: "main"},
 	}
-	m := NewWelcomeModel(dir, entries)
+	m := NewModel(dir, entries)
 	m.SetSize(80, 40)
 
 	// Switch focus to dirs panel
@@ -827,7 +827,7 @@ func TestRenderSessions_DimmedWhenUnfocused(t *testing.T) {
 func TestRenderHints_WithInstances(t *testing.T) {
 	dir := setupTestDir(t, "target")
 	entries := []instance.Entry{{PID: 1, Worktree: "/a", Branch: "a"}}
-	m := NewWelcomeModel(dir, entries)
+	m := NewModel(dir, entries)
 	m.SetSize(80, 40)
 
 	view := m.View()
@@ -838,7 +838,7 @@ func TestRenderHints_WithInstances(t *testing.T) {
 
 func TestRenderHints_WithoutInstances(t *testing.T) {
 	dir := setupTestDir(t, "target")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 	m.SetSize(80, 40)
 
 	view := m.View()
@@ -851,7 +851,7 @@ func TestRenderHints_WithoutInstances(t *testing.T) {
 
 func TestPlace_ZeroDimensions(t *testing.T) {
 	dir := setupTestDir(t, "target")
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 	// Width/height both 0; place should use defaults.
 	m.SetSize(0, 0)
 
@@ -873,7 +873,7 @@ func TestSymlinkToDir_ShowsInList(t *testing.T) {
 		t.Skipf("symlink creation failed: %v", err)
 	}
 
-	m := NewWelcomeModel(dir, nil)
+	m := NewModel(dir, nil)
 	names := entryNames(m.entries)
 	found := false
 	for _, n := range names {
@@ -897,7 +897,7 @@ func TestSymlinkToDir_ShowsInList(t *testing.T) {
 // have to be on disk.
 func TestRunInit_ScaffoldsRealProject(t *testing.T) {
 	tmp := t.TempDir()
-	m := WelcomeModel{currentDir: tmp}
+	m := Model{currentDir: tmp}
 	cmd := m.runInit(tmp)
 	if cmd == nil {
 		t.Fatal("runInit returned nil cmd")
@@ -934,7 +934,7 @@ func TestRunInit_AlreadyInitialized(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(tmp, ".wolfcastle"), 0o755); err != nil {
 		t.Fatalf("setup: %v", err)
 	}
-	m := WelcomeModel{currentDir: tmp}
+	m := Model{currentDir: tmp}
 	msg := m.runInit(tmp)()
 	complete, ok := msg.(tui.InitCompleteMsg)
 	if !ok {

--- a/internal/validate/coverage_test.go
+++ b/internal/validate/coverage_test.go
@@ -226,7 +226,7 @@ func TestFixWithVerification_WithWolfcastleDirArg(t *testing.T) {
 	idxPath := filepath.Join(projDir, "state.json")
 	_ = state.SaveRootIndex(idxPath, idx)
 
-	_, _, err := FixWithVerification(projDir, idxPath, DefaultNodeLoader(projDir), daemon.NewDaemonRepository(wolfDir))
+	_, _, err := FixWithVerification(projDir, idxPath, DefaultNodeLoader(projDir), daemon.NewRepository(wolfDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/validate/engine_coverage_test.go
+++ b/internal/validate/engine_coverage_test.go
@@ -72,7 +72,7 @@ func TestValidateStartup_WithWolfcastleDir(t *testing.T) {
 		Name: "Leaf", Type: state.NodeLeaf, State: state.StatusNotStarted, Address: "leaf",
 	}
 
-	engine := NewEngine(dir, DefaultNodeLoader(dir), daemon.NewDaemonRepository(wolfDir))
+	engine := NewEngine(dir, DefaultNodeLoader(dir), daemon.NewRepository(wolfDir))
 	report := engine.ValidateStartup(idx)
 	if report == nil {
 		t.Fatal("expected non-nil report from ValidateStartup")

--- a/internal/validate/extra_test.go
+++ b/internal/validate/extra_test.go
@@ -209,7 +209,7 @@ func TestValidateAll_DetectsStaleStopFile(t *testing.T) {
 	_ = os.MkdirAll(filepath.Join(wDir, "system"), 0755)
 	_ = os.WriteFile(filepath.Join(wDir, "system", "stop"), []byte(""), 0644)
 
-	engine := NewEngine(dir, DefaultNodeLoader(dir), daemon.NewDaemonRepository(wDir))
+	engine := NewEngine(dir, DefaultNodeLoader(dir), daemon.NewRepository(wDir))
 	report := engine.ValidateAll(idx)
 
 	found := false
@@ -325,7 +325,7 @@ func TestApplyDeterministicFixes_StaleStopFile(t *testing.T) {
 		CanAutoFix: true, FixType: FixDeterministic,
 	}}
 
-	fixes, _, err := ApplyDeterministicFixes(idx, issues, dir, idxPath, daemon.NewDaemonRepository(wDir))
+	fixes, _, err := ApplyDeterministicFixes(idx, issues, dir, idxPath, daemon.NewRepository(wDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/validate/fix_deep_coverage_test.go
+++ b/internal/validate/fix_deep_coverage_test.go
@@ -248,7 +248,7 @@ func TestFixWithVerification_StalePIDFileFix(t *testing.T) {
 	_ = os.WriteFile(filepath.Join(wolfcastleDir, "system", "wolfcastle.pid"), []byte("99999999\n"), 0644)
 	_ = os.WriteFile(filepath.Join(wolfcastleDir, "system", "stop"), []byte(""), 0644)
 
-	fixes, report, err := FixWithVerification(dir, idxPath, DefaultNodeLoader(dir), daemon.NewDaemonRepository(wolfcastleDir))
+	fixes, report, err := FixWithVerification(dir, idxPath, DefaultNodeLoader(dir), daemon.NewRepository(wolfcastleDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/validate/fix_test.go
+++ b/internal/validate/fix_test.go
@@ -796,7 +796,7 @@ func TestFix_StaleStopFile(t *testing.T) {
 		CanAutoFix: true, FixType: FixDeterministic,
 	}}
 
-	fixes, _, err := ApplyDeterministicFixes(idx, issues, dir, idxPath, daemon.NewDaemonRepository(wolfcastleDir))
+	fixes, _, err := ApplyDeterministicFixes(idx, issues, dir, idxPath, daemon.NewRepository(wolfcastleDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -865,7 +865,7 @@ func TestDetect_StaleStopFile(t *testing.T) {
 	stopPath := filepath.Join(wolfcastleDir, "system", "stop")
 	_ = os.WriteFile(stopPath, []byte(""), 0644)
 
-	engine := NewEngine(dir, DefaultNodeLoader(dir), daemon.NewDaemonRepository(wolfcastleDir))
+	engine := NewEngine(dir, DefaultNodeLoader(dir), daemon.NewRepository(wolfcastleDir))
 	report := engine.ValidateAll(idx)
 
 	found := false
@@ -893,7 +893,7 @@ func TestIsDaemonAlive_NoWolfcastleDir(t *testing.T) {
 func TestIsDaemonAlive_NoRegistryEntry(t *testing.T) {
 	t.Parallel()
 	wolfcastleDir := t.TempDir()
-	engine := NewEngine(t.TempDir(), DefaultNodeLoader(t.TempDir()), daemon.NewDaemonRepository(wolfcastleDir))
+	engine := NewEngine(t.TempDir(), DefaultNodeLoader(t.TempDir()), daemon.NewRepository(wolfcastleDir))
 	if engine.isDaemonAlive() {
 		t.Error("expected false when no instance is registered")
 	}
@@ -913,7 +913,7 @@ func TestIsDaemonAlive_LiveProcess(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	engine := NewEngine(t.TempDir(), DefaultNodeLoader(t.TempDir()), daemon.NewDaemonRepository(wolfcastleDir))
+	engine := NewEngine(t.TempDir(), DefaultNodeLoader(t.TempDir()), daemon.NewRepository(wolfcastleDir))
 	if !engine.isDaemonAlive() {
 		t.Error("expected true for our own PID (we are alive)")
 	}
@@ -1117,7 +1117,7 @@ func TestDetect_StaleInProgress(t *testing.T) {
 		Name: "Leaf", Type: state.NodeLeaf, State: state.StatusInProgress, Address: "leaf",
 	}
 
-	engine := NewEngine(dir, DefaultNodeLoader(dir), daemon.NewDaemonRepository(wolfcastleDir))
+	engine := NewEngine(dir, DefaultNodeLoader(dir), daemon.NewRepository(wolfcastleDir))
 	report := engine.ValidateAll(idx)
 
 	found := false


### PR DESCRIPTION
## Summary

- Add comprehensive TUI guide (`docs/humans/the-tui.md`, 380 lines) covering all screens, keybindings, and workflows
- Reframe 6 concept docs and both READMEs to present TUI as the primary interface, CLI as secondary
- Implement missing `d` dashboard key binding (was in help overlay but had no handler)
- Complete help overlay with missing log stream keys (`f`, `T`, `Ctrl+D`, `Ctrl+U`)
- Rename 12 stuttering TUI types (`TreeRow`, `TreeModel`, `DaemonRepository`, `InvokeSimple`, `FooterModel`, `WelcomeModel`, `SearchMatch`, `SearchModel`, `DetailMode`, `DetailModel`, `HeaderModel`, `HelpOverlayModel`)
- Add package and symbol doc comments to all 8 TUI packages (50+ exported symbols)
- Replace raw string keys in `styles.go` with typed `state.Status*` / `state.Audit*` constants
- Split `canSymlink()` into build-tagged `install_symlink_{unix,windows}.go`
- Fix stale counts (ADRs: 101, specs: 45), update AGENTS.md dependency list, correct architecture diagram
- Fix broken `configuration.md#identity` anchor, update TUI spec status to Accepted
- Fix "ten-phase" → "nine-phase" protocol reference

Screenshot placeholders reference `assets/screenshots/*.png` (directory created with `.gitkeep`); images to be captured manually.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `go test -race -count=1 ./...` all 45 packages pass
- [x] Cross-compile: all 5 platform targets build
- [x] Two-pass 13-section audit: all sections pass except §12 coverage (pre-existing, 90.9% vs 93% target)
- [ ] Manual: verify keybinding tables match TUI behavior
- [ ] Manual: capture screenshots for placeholder images