### PR TITLE
feat: exploratory quality review in orchestrator audit

### DIFF
--- a/docs/specs/2026-04-12T00-00Z-audit-overhaul.md
+++ b/docs/specs/2026-04-12T00-00Z-audit-overhaul.md
@@ -1,0 +1,156 @@
+# Audit System Overhaul: Exploratory Review + Knowledge Pipeline
+
+## Status
+Draft
+
+## Problem
+
+The daemon-driven audit verifies compliance: did each task deliver what it promised? It checks deliverables against acceptance criteria, runs the test suite, runs the linter. If the contract is met, the audit passes.
+
+What it cannot do is find issues nobody thought to check for. A task that introduces stuttering type names, dead code, stale documentation, missing error handling, or architectural drift will pass the audit as long as its acceptance criteria are met. The audit verifies the plan. It doesn't question the plan.
+
+A human-supervised audit session (or the `/audit` skill) asks a fundamentally different question: "what's wrong with this code?" without reference to any task's deliverables. It finds quality issues that no task was assigned to prevent. The daemon audit has no equivalent capability.
+
+The knowledge system compounds this gap. Audit findings from manual sessions don't flow back into the automated pipeline. A human finds "this codebase uses typed constants, not raw strings" and fixes it, but nothing prevents the next agent from reintroducing raw strings because the daemon audit doesn't know to check.
+
+## Design
+
+### Exploratory review at the orchestrator level
+
+The orchestrator audit (`plan-review.md`) already runs when all children complete. It already uses the heavy model. It already has the wide view: all children, all deliverables, all scope. It is the natural place for an exploratory quality review.
+
+Add an exploratory phase to plan-review.md between the existing verification (phase C) and the decision (phase D). The new phase asks: "what quality issues exist in the code these children produced, beyond what the acceptance criteria cover?"
+
+The exploratory review is unconstrained by task deliverables. It reads all files in scope, not just deliverables. It looks for:
+
+- Naming inconsistencies (stuttering, casing violations, convention drift)
+- Dead code (unused functions, unreferenced files, stale imports)
+- Missing or inaccurate documentation
+- Error handling gaps (unchecked errors, missing context wrapping)
+- Architectural violations (circular dependencies, wrong-layer access, leaked abstractions)
+- Test gaps (uncovered code paths, tests that test implementation rather than behavior)
+- Security issues (injection vectors, hardcoded secrets, unsafe deserialization)
+- Performance concerns (unbounded allocations, missing context cancellation, goroutine leaks)
+
+The review is not a checklist. The model uses its judgment to identify what matters in the specific codebase it's looking at. The knowledge system provides accumulated context (see below), but the review is free to find issues the knowledge system hasn't seen before.
+
+### Remediation through new leaves
+
+When the exploratory review finds issues, the orchestrator creates a new leaf under itself with tasks scoped to the findings. Each task targets specific files and issues from the review, with a task class appropriate to the work (e.g., `coding/go` for Go fixes, `refactor` for structural changes).
+
+The orchestrator emits WOLFCASTLE_CONTINUE instead of WOLFCASTLE_COMPLETE, signaling that new work exists. The daemon processes the remediation leaf: its tasks execute, its leaf audit runs (compliance check on the fixes), and the orchestrator re-enters plan-review when the leaf completes.
+
+The second orchestrator review sees:
+- The original children (unchanged, already complete)
+- The remediation leaf (newly complete)
+- The previous review's breadcrumbs and findings
+
+It verifies the remediation addressed the findings and runs another exploratory pass. If clean, it emits WOLFCASTLE_COMPLETE. If not, it creates another remediation leaf. The loop converges because each pass has less to find.
+
+A depth limit prevents infinite loops. The orchestrator tracks how many remediation passes it has created via a counter in its audit state. After `max_review_passes` (default 3), the orchestrator completes regardless, logging any remaining findings as informational breadcrumbs rather than creating more work.
+
+### Knowledge pipeline: findings become persistent checks
+
+When the exploratory review finds a pattern violation (e.g., "raw string literals used for state values instead of typed constants"), the finding should persist as a knowledge entry so future audits check for it automatically.
+
+The flow:
+
+1. Orchestrator exploratory review finds "3 files use raw string `"not_started"` instead of `state.StatusNotStarted`"
+2. Orchestrator creates remediation task to fix the instances
+3. Orchestrator also writes a knowledge entry: `wolfcastle knowledge add "State status values must use typed constants from internal/state/types.go, never raw string literals. Found and fixed in v0.6.0 audit."`
+4. Future execution tasks see this knowledge entry in their context and avoid the pattern
+5. Future leaf audits see this knowledge entry (already implemented, #182) and verify compliance
+6. Future orchestrator reviews see this knowledge entry and can verify codebase-wide compliance
+
+The knowledge system becomes the project's accumulating immune system: each infection the audit fights teaches the system to recognize the next one.
+
+### Changes to plan-review.md
+
+Add phase C.5 between existing phases C and D:
+
+```markdown
+### C.5 Exploratory Quality Review
+
+Step back from the acceptance criteria and deliverables. Read the actual code 
+these children produced. Ask: what quality issues exist that nobody checked for?
+
+Review all files in scope, not just deliverables. Look for problems that 
+acceptance criteria wouldn't catch: naming violations, dead code, missing error 
+handling, test gaps, documentation drift, architectural issues, security 
+concerns. Use your judgment. The knowledge entries below describe patterns this 
+project has encountered before; verify those, but don't limit yourself to them.
+
+For each finding:
+1. Record it as a breadcrumb with location and description
+2. Assess whether it warrants a remediation task or is informational
+
+If findings warrant remediation:
+1. Create a new leaf: `wolfcastle project create --node <your-node>/<remediation-slug>`
+2. Add tasks targeting the specific files and issues
+3. Write a knowledge entry for any pattern-level finding that future work should 
+   avoid: `wolfcastle knowledge add "<description of the pattern to avoid>"`
+4. Emit WOLFCASTLE_CONTINUE
+
+If findings are informational only (cosmetic, low-impact, or would require 
+disproportionate effort to fix), record them as breadcrumbs and proceed to 
+phase D.
+```
+
+### Changes to execute.md (leaf audit)
+
+No changes to the leaf audit procedure. It remains a compliance check. The exploratory review happens at the orchestrator level where the model has the full feature context.
+
+Knowledge entries are already injected into audit context (#182). As the knowledge system grows from orchestrator findings, leaf audits automatically gain new verification criteria without prompt changes.
+
+### Configuration
+
+```json
+{
+  "planning": {
+    "max_review_passes": 3
+  }
+}
+```
+
+Default 3. Set to 1 for a single exploratory pass with no remediation loop. Set to 0 to disable exploratory review entirely (existing behavior).
+
+### Review pass tracking
+
+The orchestrator's `NodeState` gains a `review_pass` integer field (default 0). Each time plan-review creates remediation work and emits WOLFCASTLE_CONTINUE, the daemon increments `review_pass`. The prompt template includes the current pass number so the model knows where it is in the loop. At `max_review_passes`, the prompt instructs the model to log remaining findings as breadcrumbs and emit WOLFCASTLE_COMPLETE.
+
+### Orchestrator review visibility
+
+The TUI has no indication that a planning pass (including the review) is running. Leaf tasks show `→` in the tree and update the dashboard's "Current target" field. Orchestrator planning passes are invisible: the model runs, the orchestrator sits there, and the user sees nothing happening.
+
+The daemon already writes `current_node` to the activity file during execution. During planning passes, it should do the same: write the orchestrator's address and the planning trigger ("completion_review", "initial", "remediate") to the activity file. The TUI already reads this file and displays the current target.
+
+Additionally, the daemon should log a structured `planning_start` event that the TUI's log stream can display, so the user sees "reviewing warzone/backend (completion_review)" in the activity feed.
+
+Changes:
+1. In `runPlanningPass`, write `current_node` and `current_task` (set to the planning trigger, e.g., "completion_review") to the daemon activity file before invoking the model. Clear them after.
+2. The TUI dashboard already reads the activity file and displays "Current: warzone/backend/auth/task-1". During planning, it would show "Current: warzone/backend (completion_review)".
+3. The header status remains "hunting" (unchanged).
+
+## What this does NOT change
+
+- **Leaf audit procedure**: unchanged. Compliance check against deliverables.
+- **Model tiers**: planning already uses heavy. No new stages or models.
+- **Daemon loop**: the orchestrator already emits WOLFCASTLE_CONTINUE when it creates work. The daemon already re-enters plan-review when the new work completes. No loop changes needed.
+- **State machine**: creating a new leaf under an orchestrator is already supported. The orchestrator transitions back to in_progress when it has incomplete children. No state changes needed.
+
+## Implementation sequence
+
+1. Add `review_pass` field to `NodeState` and `max_review_passes` to `PlanningConfig`
+2. Update plan-review.md with phase C.5 (exploratory review)
+3. Update the daemon's planning pass to increment `review_pass` on WOLFCASTLE_CONTINUE and inject the counter into prompt context
+4. Update the daemon's planning pass to switch to a "final review" prompt variant when `review_pass >= max_review_passes`
+5. Write `current_node` and planning trigger to the daemon activity file during `runPlanningPass` so the TUI shows orchestrator review activity
+6. Test with a project that has known quality issues and verify the loop finds, remediates, and converges
+
+## Verification
+
+1. Create a project with intentional quality issues (raw string literals, dead code, stuttering names, missing error handling)
+2. Run the daemon and verify the orchestrator review finds the issues, creates remediation leaves, and the fixes land
+3. Verify the knowledge entries are created and appear in future audit contexts
+4. Verify the loop terminates at `max_review_passes`
+5. Verify that a clean project completes in one pass with no remediation

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,7 @@ func Defaults() *Config {
 				MaxChildren:     10,
 				MaxTasksPerLeaf: 8,
 				MaxReplans:      3,
+				MaxReviewPasses: 3,
 			},
 			StageOrder: []string{"intake", "execute"},
 			Stages: map[string]PipelineStage{

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -49,6 +49,7 @@ type PlanningConfig struct {
 	MaxChildren     int    `json:"max_children,omitempty"`
 	MaxTasksPerLeaf int    `json:"max_tasks_per_leaf,omitempty"`
 	MaxReplans      int    `json:"max_replans,omitempty"`
+	MaxReviewPasses int    `json:"max_review_passes,omitempty"`
 }
 
 // PipelineStage defines a single pipeline stage.

--- a/internal/daemon/planning.go
+++ b/internal/daemon/planning.go
@@ -172,6 +172,14 @@ func (d *Daemon) runPlanningPass(ctx context.Context, nodeAddr string, ns *state
 	// Select the planning prompt variant
 	promptFile := selectPlanningPrompt(trigger)
 
+	// Ensure max review passes is set from config for context rendering.
+	if ns.MaxReviewPasses == 0 {
+		ns.MaxReviewPasses = d.Config.Pipeline.Planning.MaxReviewPasses
+	}
+
+	// Write activity so the TUI shows what the daemon is working on.
+	d.writeActivity(nodeAddr, trigger)
+
 	// Build planning context
 	planCtx := pipeline.BuildPlanningContext(nodeAddr, ns, trigger)
 
@@ -291,6 +299,11 @@ func (d *Daemon) runPlanningPass(ctx context.Context, nodeAddr string, ns *state
 		_ = d.Store.MutateNode(nodeAddr, func(ns *state.NodeState) error {
 			ns.NeedsPlanning = false
 			ns.PlanningTrigger = ""
+			// Track review passes for completion_review so the exploratory
+			// review loop converges at max_review_passes.
+			if trigger == "completion_review" {
+				ns.ReviewPass++
+			}
 			return nil
 		})
 

--- a/internal/daemon/planning_test.go
+++ b/internal/daemon/planning_test.go
@@ -903,3 +903,37 @@ func TestParseOverlapMarkers_BadAddress(t *testing.T) {
 	output := `OVERLAP: "some work" overlaps with Ghost (nonexistent-node)`
 	d.parseOverlapMarkers(output)
 }
+
+func TestSelectPlanningPrompt_CompletionReview(t *testing.T) {
+	t.Parallel()
+	got := selectPlanningPrompt("completion_review")
+	if got != "stages/plan-review.md" {
+		t.Errorf("expected stages/plan-review.md, got %q", got)
+	}
+}
+
+func TestMaxReviewPassesDefault(t *testing.T) {
+	t.Parallel()
+	cfg := config.Defaults()
+	if cfg.Pipeline.Planning.MaxReviewPasses != 3 {
+		t.Errorf("expected default MaxReviewPasses 3, got %d", cfg.Pipeline.Planning.MaxReviewPasses)
+	}
+}
+
+func TestWriteActivityDuringPlanning(t *testing.T) {
+	t.Parallel()
+	d := testDaemon(t)
+
+	d.writeActivity("warzone/backend", "completion_review")
+
+	activity := LoadDaemonActivity(d.WolfcastleDir)
+	if activity == nil {
+		t.Fatal("expected activity file to exist")
+	}
+	if activity.CurrentNode != "warzone/backend" {
+		t.Errorf("expected current_node warzone/backend, got %q", activity.CurrentNode)
+	}
+	if activity.CurrentTask != "completion_review" {
+		t.Errorf("expected current_task completion_review, got %q", activity.CurrentTask)
+	}
+}

--- a/internal/pipeline/planning_context.go
+++ b/internal/pipeline/planning_context.go
@@ -29,6 +29,13 @@ func BuildPlanningContext(nodeAddr string, ns *state.NodeState, trigger string) 
 	if ns.TotalReplans > 0 {
 		fmt.Fprintf(&b, "**Remediation Attempt:** %d of %d\n", ns.TotalReplans, maxReplans)
 	}
+	if ns.ReviewPass > 0 || trigger == "completion_review" {
+		maxReview := ns.MaxReviewPasses
+		if maxReview == 0 {
+			maxReview = 3
+		}
+		fmt.Fprintf(&b, "**Review Pass:** %d of %d\n", ns.ReviewPass, maxReview)
+	}
 	b.WriteString("\n")
 
 	// Scope (never truncated)

--- a/internal/pipeline/planning_context_test.go
+++ b/internal/pipeline/planning_context_test.go
@@ -251,3 +251,47 @@ func TestBuildPlanningContext_EmptyState(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildPlanningContext_ReviewPass(t *testing.T) {
+	ns := state.NewNodeState("orch-010", "Review Test", state.NodeOrchestrator)
+	ns.ReviewPass = 2
+	ns.MaxReviewPasses = 3
+
+	ctx := BuildPlanningContext("project/orch-010", ns, "completion_review")
+
+	if !strings.Contains(ctx, "**Review Pass:** 2 of 3") {
+		t.Error("context should include review pass counter for completion_review trigger")
+	}
+}
+
+func TestBuildPlanningContext_ReviewPass_ZeroOmitted(t *testing.T) {
+	ns := state.NewNodeState("orch-011", "Initial Plan", state.NodeOrchestrator)
+
+	ctx := BuildPlanningContext("project/orch-011", ns, "initial")
+
+	if strings.Contains(ctx, "Review Pass") {
+		t.Error("context should not include review pass for non-completion triggers with zero passes")
+	}
+}
+
+func TestBuildPlanningContext_ReviewPass_ShownOnFirstCompletionReview(t *testing.T) {
+	ns := state.NewNodeState("orch-012", "First Review", state.NodeOrchestrator)
+	ns.MaxReviewPasses = 3
+
+	ctx := BuildPlanningContext("project/orch-012", ns, "completion_review")
+
+	if !strings.Contains(ctx, "**Review Pass:** 0 of 3") {
+		t.Error("context should show review pass on first completion_review even when pass is 0")
+	}
+}
+
+func TestBuildPlanningContext_ReviewPass_DefaultMax(t *testing.T) {
+	ns := state.NewNodeState("orch-013", "Default Max", state.NodeOrchestrator)
+	// MaxReviewPasses not set (0), should default to 3.
+
+	ctx := BuildPlanningContext("project/orch-013", ns, "completion_review")
+
+	if !strings.Contains(ctx, "**Review Pass:** 0 of 3") {
+		t.Error("context should default to 3 max review passes")
+	}
+}

--- a/internal/project/templates/prompts/stages/plan-review.md
+++ b/internal/project/templates/prompts/stages/plan-review.md
@@ -42,26 +42,65 @@ When children produce or modify files in more than one language stack (e.g., Pyt
 #### Inbox item completeness
 When the orchestrator was created from an inbox item containing a numbered list of sub-items, verify each sub-item was addressed by at least one child's deliverables. Explicitly check off each sub-item. Flag any that were missed as gaps.
 
-### D. Decide
-If all success criteria are met, no unaddressed action items remain, and no gaps exist, this orchestrator's work is done.
+### D. Exploratory Quality Review
 
-If gaps or action items remain:
+Step back from the acceptance criteria and deliverables. Read the actual code these children produced. The question is no longer "did the tasks deliver what they promised?" but "what quality issues exist that nobody checked for?"
+
+Read all files in scope, not just deliverables. Look for problems that acceptance criteria wouldn't catch:
+
+- Naming inconsistencies (stuttering, casing violations, convention drift)
+- Dead code (unused functions, unreferenced files, stale imports)
+- Missing or inaccurate documentation
+- Error handling gaps (unchecked errors, missing context wrapping)
+- Architectural violations (circular dependencies, wrong-layer access, leaked abstractions)
+- Test gaps (untested code paths, tests that verify implementation instead of behavior)
+- Security issues (injection vectors, hardcoded secrets, unsafe deserialization)
+- Performance concerns (unbounded allocations, missing context cancellation, goroutine leaks)
+
+The knowledge entries below describe patterns this project has encountered before. Verify those, but do not limit yourself to them. Use your judgment. The value of this phase is finding what nobody thought to check.
+
+For each finding, record it as a breadcrumb with location and description:
+```
+wolfcastle audit breadcrumb --node <your-node> "Quality finding: <file:line> <description>"
+```
+
+Check the **Review Pass** counter in the iteration context above. If it equals the maximum (shown in the context), this is the final pass: record any remaining findings as informational breadcrumbs and proceed to phase E. Do not create remediation work on the final pass.
+
+If findings warrant remediation (and this is not the final pass):
+1. Create a new leaf under this orchestrator for the remediation work. Name it with the review pass number for traceability:
+   ```
+   wolfcastle project create --node <your-node>/quality-remediation-<pass-number>
+   ```
+2. Add tasks targeting the specific files and issues. Assign appropriate task classes.
+3. For any pattern-level finding that future work should avoid, write a knowledge entry:
+   ```
+   wolfcastle knowledge add "<description of the pattern to avoid and why>"
+   ```
+4. Proceed to phase F and emit WOLFCASTLE_CONTINUE.
+
+If no findings warrant remediation, proceed to phase E.
+
+### E. Decide
+If all success criteria are met, no unaddressed action items remain, and the exploratory review found nothing requiring remediation, this orchestrator's work is done.
+
+If gaps or action items from phases B or C remain:
 - Create new leaves with `wolfcastle project create` and add tasks with `wolfcastle task add`. Do NOT add tasks to child orchestrators or grandchildren. Assign a task class to every new task using `--class` with the most specific key from `wolfcastle config show task_classes`. Each task gets one class; if a task would need multiple classes, split it into separate tasks.
 - Update success criteria if the scope has evolved: `wolfcastle orchestrator criteria --node <your-node> "updated criterion"`.
 
-### E. Record
+### F. Record
 Write a planning breadcrumb:
 ```
-wolfcastle audit breadcrumb --node <your-node> "Completion review: [PASS|gaps found]. [details]."
+wolfcastle audit breadcrumb --node <your-node> "Completion review: [PASS|gaps found|quality issues found]. [details]."
 ```
 
-### F. Signal
+### G. Signal
 Emit WOLFCASTLE_COMPLETE if all criteria are met and no new work was created.
 Emit WOLFCASTLE_CONTINUE if new work was created (the orchestrator transitions back to active and will be reviewed again when the new work finishes).
 
 ## Rules
 
-- Do not write application code.
+- Do not write application code. Create tasks for others to execute.
 - Be honest about gaps. A premature COMPLETE is worse than creating additional work.
-- WOLFCASTLE_CONTINUE means "I found gaps and created work to fix them." The daemon will process the new work and re-invoke this review when it's done.
+- WOLFCASTLE_CONTINUE means "I found issues and created work to fix them." The daemon will process the new work and re-invoke this review when it's done.
 - Always emit exactly one terminal marker: WOLFCASTLE_COMPLETE or WOLFCASTLE_CONTINUE.
+- Knowledge entries are permanent. Write them for patterns, not for one-off fixes. "State values must use typed constants" is a good knowledge entry. "Fixed a typo in line 42" is not.

--- a/internal/state/types.go
+++ b/internal/state/types.go
@@ -112,6 +112,8 @@ type NodeState struct {
 	TotalReplans    int            `json:"total_replans,omitempty"` // cumulative replan count across all triggers
 	MaxReplans      int            `json:"max_replans,omitempty"`
 	PlanningHistory []PlanningPass `json:"planning_history,omitempty"`
+	ReviewPass      int            `json:"review_pass,omitempty"`
+	MaxReviewPasses int            `json:"max_review_passes,omitempty"`
 	// Common
 	Audit AuditState     `json:"audit"`
 	AARs  map[string]AAR `json:"aars,omitempty"`


### PR DESCRIPTION
## Summary

- Add exploratory review phase (D) to orchestrator completion review (`plan-review.md`)
- After verifying deliverables and integration, the model reads all code in scope looking for quality issues: naming violations, dead code, error handling gaps, test gaps, architectural drift, security issues
- When issues warrant remediation, creates a new leaf with fix tasks and emits WOLFCASTLE_CONTINUE
- `review_pass` counter on NodeState tracks iterations; `max_review_passes` (default 3) in PlanningConfig controls convergence
- Knowledge entries from remediation persist as future audit criteria
- Daemon writes activity file during planning passes for TUI visibility

## Files changed

- `internal/state/types.go`: add `ReviewPass`, `MaxReviewPasses` to NodeState
- `internal/config/types.go`, `config.go`: add `MaxReviewPasses` to PlanningConfig (default 3)
- `internal/project/templates/prompts/stages/plan-review.md`: add phase D (exploratory review)
- `internal/daemon/planning.go`: increment review_pass on CONTINUE, write activity during planning
- `internal/pipeline/planning_context.go`: include review pass counter in context
- Tests for all new behavior

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt` clean
- [x] `go test -race -count=1 ./...` all packages pass (45/45)
- [x] Planning context includes review pass for completion_review trigger
- [x] Planning context omits review pass for other triggers
- [x] Default max_review_passes is 3
- [x] Activity file written during planning with node and trigger