### PR TITLE
chore: audit fixes (SSOT, voice, error wrapping)

### DIFF
--- a/docs/humans/config-reference.md
+++ b/docs/humans/config-reference.md
@@ -662,7 +662,7 @@ Configures the structural validation and repair command (see ADR-025). The `wolf
 
 ## unblock
 
-Configures the unblock workflow (see ADR-028). The `wolfcastle unblock` command helps resolve blocked tasks by analyzing the blocking condition and suggesting remediation.
+Configures the unblock workflow (see ADR-028). The `wolfcastle unblock` command resolves blocked tasks by analyzing the blocking condition and suggesting remediation.
 
 ### unblock.model
 

--- a/docs/humans/parallel-execution.md
+++ b/docs/humans/parallel-execution.md
@@ -51,4 +51,4 @@ On daemon startup, `selfHeal` cleans up stale scope locks left by a previous cra
 
 Parallel mode is most effective when your project tree has multiple independent leaf nodes with non-overlapping scope. A project with three modules that each touch different directories will see near-linear speedup at `max_workers: 3`.
 
-It is less useful when tasks frequently overlap in scope, since the yield-and-retry overhead can approach serial execution time. The yield tracking in the TUI dashboard and `wolfcastle status` helps you diagnose this: if you see the same tasks yielding repeatedly, consider restructuring the task tree to reduce file contention.
+It is less useful when tasks frequently overlap in scope, since the yield-and-retry overhead can approach serial execution time. The yield tracking in the TUI dashboard and `wolfcastle status` shows you this directly: if the same tasks keep yielding repeatedly, consider restructuring the task tree to reduce file contention.

--- a/docs/humans/the-tui.md
+++ b/docs/humans/the-tui.md
@@ -16,7 +16,7 @@ The TUI opens in one of three states depending on the project directory:
 | **Cold** | `.wolfcastle/` exists, no daemon | Tree pane, dashboard (static), daemon controls |
 | **Welcome** | No `.wolfcastle/` directory | Session browser and directory navigator |
 
-If you run `wolfcastle` inside an initialized project with a running daemon, you land in the live view immediately. If the daemon isn't running, you get the same layout but static, with the option to start one. Outside any project, the welcome screen helps you find or create one.
+If you run `wolfcastle` inside an initialized project with a running daemon, you land in the live view immediately. If the daemon isn't running, you get the same layout but static, with the option to start one. Outside any project, the welcome screen lets you find or create one.
 
 ## The Welcome Screen
 

--- a/docs/specs/tui-v01/README.md
+++ b/docs/specs/tui-v01/README.md
@@ -4,9 +4,9 @@ The full spec lives at `../2026-04-06T01-00Z-tui-v01.md` (2,179 lines). These fi
 
 ## Reading Order
 
-1. **`common.md`** (1,027 lines) — Read first. Contains summary, dependencies, entry states, layout, data sources, real-time update strategy, Bubbletea architecture, performance, package structure, voice, and error handling.
+1. **`common.md`** (1,027 lines): read first. Contains summary, dependencies, entry states, layout, data sources, real-time update strategy, Bubbletea architecture, performance, package structure, voice, and error handling.
 
-2. **`phase1.md`** through **`phase5.md`** — Read the phase you're implementing. Each phase document includes models, messages, key bindings, rendering, and test cases.
+2. **`phase1.md`** through **`phase5.md`**: read the phase you're implementing. Each phase document includes models, messages, key bindings, rendering, and test cases.
 
 ## For Build Sessions
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	charm.land/lipgloss/v2 v2.0.2
 	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/x/ansi v0.11.6
+	github.com/charmbracelet/x/exp/teatest/v2 v2.0.0-20260406091427-a791e22d5143
 	github.com/chzyer/readline v1.5.1
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/spf13/cobra v1.10.2
@@ -19,7 +20,6 @@ require (
 	github.com/charmbracelet/colorprofile v0.4.2 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260205113103-524a6607adb8 // indirect
 	github.com/charmbracelet/x/exp/golden v0.0.0-20251109135125-8916d276318f // indirect
-	github.com/charmbracelet/x/exp/teatest/v2 v2.0.0-20260406091427-a791e22d5143 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect

--- a/internal/daemon/planning.go
+++ b/internal/daemon/planning.go
@@ -221,7 +221,7 @@ func (d *Daemon) runPlanningPass(ctx context.Context, nodeAddr string, ns *state
 	if err != nil {
 		_ = d.Logger.Log(map[string]any{"type": "planning_error", "error": err.Error()})
 		d.Logger.Close()
-		return err
+		return fmt.Errorf("planning invocation for %s: %w", nodeAddr, err)
 	}
 
 	_ = d.Logger.Log(map[string]any{

--- a/internal/project/scaffold_service.go
+++ b/internal/project/scaffold_service.go
@@ -130,7 +130,7 @@ func (s *ScaffoldService) Init(identity *config.Identity) error {
 		return fmt.Errorf("scaffold: marshaling root index: %w", err)
 	}
 	idxData = append(idxData, '\n')
-	if err := os.WriteFile(filepath.Join(nsDir, "state.json"), idxData, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(nsDir, state.StateFileName), idxData, 0644); err != nil {
 		return fmt.Errorf("scaffold: writing root index: %w", err)
 	}
 

--- a/internal/state/io.go
+++ b/internal/state/io.go
@@ -8,6 +8,9 @@ import (
 	"github.com/dorkusprime/wolfcastle/internal/fsutil"
 )
 
+// StateFileName is the canonical filename for node and root-index state files.
+const StateFileName = "state.json"
+
 // LoadRootIndex reads the root state.json for an engineer namespace.
 func LoadRootIndex(path string) (*RootIndex, error) {
 	data, err := os.ReadFile(path)

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -248,11 +248,11 @@ func (s *Store) nodePath(addr string) (string, error) {
 			return "", fmt.Errorf("invalid address segment %q in %q", p, addr)
 		}
 	}
-	return filepath.Join(s.dir, filepath.Join(parts...), "state.json"), nil
+	return filepath.Join(s.dir, filepath.Join(parts...), StateFileName), nil
 }
 
 func (s *Store) indexPath() string {
-	return filepath.Join(s.dir, "state.json")
+	return filepath.Join(s.dir, StateFileName)
 }
 
 func (s *Store) inboxPath() string {

--- a/internal/validate/engine.go
+++ b/internal/validate/engine.go
@@ -62,7 +62,7 @@ func DefaultNodeLoader(projectsDir string) NodeLoader {
 		if err != nil {
 			return nil, err
 		}
-		return state.LoadNodeState(filepath.Join(projectsDir, filepath.Join(a.Parts...), "state.json"))
+		return state.LoadNodeState(filepath.Join(projectsDir, filepath.Join(a.Parts...), state.StateFileName))
 	}
 }
 
@@ -76,7 +76,7 @@ func RecoveringNodeLoader(projectsDir string, onRecover func(addr string, report
 		if err != nil {
 			return nil, err
 		}
-		statePath := filepath.Join(projectsDir, filepath.Join(a.Parts...), "state.json")
+		statePath := filepath.Join(projectsDir, filepath.Join(a.Parts...), state.StateFileName)
 
 		// Try normal load first.
 		ns, loadErr := state.LoadNodeState(statePath)

--- a/internal/validate/fix.go
+++ b/internal/validate/fix.go
@@ -124,7 +124,7 @@ func ApplyDeterministicFixesRepo(
 		if err != nil {
 			return nil, "", err
 		}
-		statePath := filepath.Join(projectsDir, filepath.Join(a.Parts...), "state.json")
+		statePath := filepath.Join(projectsDir, filepath.Join(a.Parts...), state.StateFileName)
 		if cached, ok := modifiedStates[statePath]; ok {
 			return cached, statePath, nil
 		}

--- a/internal/validate/model_fix.go
+++ b/internal/validate/model_fix.go
@@ -64,7 +64,7 @@ func TryModelAssistedFix(ctx context.Context, invoker invoke.Invoker, model conf
 	if err != nil {
 		return false, err
 	}
-	statePath := filepath.Join(projectsDir, filepath.Join(a.Parts...), "state.json")
+	statePath := filepath.Join(projectsDir, filepath.Join(a.Parts...), state.StateFileName)
 	ns, err := state.LoadNodeState(statePath)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
## Summary

Full 13-section audit results. 8 sections clean, 5 had findings. All fixable issues resolved in this PR.

- **§7 SSOT**: Extracted `state.StateFileName` constant, replaced 6 hardcoded `"state.json"` literals across validate/, project/, and state/ packages
- **§2 Go Practices**: Wrapped bare error return in `planning.go:runPlanningPass` with context
- **§8 Voice**: Replaced "helps" with direct phrasing in 3 doc files, replaced em dashes with colons in tui-v01/README.md
- **§10 CI/CD**: `go mod tidy` promoted teatest/v2 from indirect to direct dependency

### Sections with no findings
§1 Correctness, §3 Error Handling, §4 Security, §5 Architecture, §6 Documentation, §9 Testing, §11 Cross-Platform, §13 Usability

### Out of scope (tracked separately)
§12 Coverage gaps in fsutil (54.5%), tui/clipboard (75%), tui/app (81.2%)

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/state/... ./internal/daemon/... ./internal/validate/... ./internal/pipeline/... ./internal/project/...`
- [x] `gofmt -l .` (clean)
- [x] `go test -race ./internal/daemon/` (3 consecutive clean runs)