### PR TITLE
fix: TUI freezes when launched from outside project directory

### DIFF
--- a/internal/tui/app/app.go
+++ b/internal/tui/app/app.go
@@ -155,13 +155,19 @@ func (m TUIModel) Init() tea.Cmd {
 
 	cmds = append(cmds, m.detectEntryState())
 
+	// Always start the poll chain and watcher event drain, even when
+	// store is nil (no .wolfcastle in CWD). Without the poller, the
+	// 2-second state refresh never begins after instance auto-discovery.
+	// Without the drain, watcher events from a post-switch watcher
+	// pile up in the channel and never reach the model (no log
+	// streaming, no per-node updates).
+	cmds = append(cmds, m.startPoller(), waitForWatcherEvent(m.watcherEvents))
+
 	if m.store != nil {
 		m.header.SetLoading(true)
 		cmds = append(cmds,
 			m.startWatcher(),
-			m.startPoller(),
 			m.loadInitialState(),
-			waitForWatcherEvent(m.watcherEvents),
 		)
 	}
 
@@ -1540,9 +1546,12 @@ func newWatcherFor(store *state.Store, repo *daemon.Repository, events chan tea.
 		instanceDir = dir
 	}
 	w := tui.NewWatcher(store, logDir, instanceDir, events)
-	if err := w.Start(); err != nil {
-		w.StartPolling()
-	}
+	_ = w.Start() // best-effort fsnotify for instant reactivity
+	// Always start polling regardless of fsnotify status. macOS
+	// kqueue silently drops events for certain paths (/tmp, etc.).
+	// Polling checks mtimes before emitting, so duplicate events
+	// from both mechanisms are harmless.
+	w.StartPolling()
 	_ = w.EagerPrefetchAndSubscribe()
 	return w
 }

--- a/internal/tui/watcher.go
+++ b/internal/tui/watcher.go
@@ -501,7 +501,7 @@ func (w *Watcher) pollTick() {
 		if err != nil {
 			continue
 		}
-		if prev, ok := w.nodeMtimes[addr]; ok && info.ModTime() == prev {
+		if prev, ok := w.nodeMtimes[addr]; ok && info.ModTime().Equal(prev) {
 			continue
 		}
 		w.nodeMtimes[addr] = info.ModTime()

--- a/internal/tui/watcher.go
+++ b/internal/tui/watcher.go
@@ -41,6 +41,11 @@ type Watcher struct {
 	mu          sync.Mutex
 	useFsnotify bool
 
+	// nodeMtimes tracks the last-seen mtime for each subscribed
+	// node's state.json, used by pollTick to detect changes when
+	// fsnotify events don't arrive.
+	nodeMtimes map[string]time.Time
+
 	// subscribed tracks which leaf addresses already have an
 	// fsnotify subscription via AddNodeWatch + an initial cache
 	// load via NodeUpdatedMsg. EagerPrefetchAndSubscribe consults
@@ -72,6 +77,7 @@ func NewWatcher(store *state.Store, logDir, instanceDir string, events chan<- te
 		done:        make(chan struct{}),
 		useFsnotify: true,
 		subscribed:  make(map[string]bool),
+		nodeMtimes:  make(map[string]time.Time),
 	}
 }
 
@@ -479,11 +485,32 @@ func (w *Watcher) pollTick() {
 			}
 		}
 	}
-	// PollTickMsg is owned by the model's own tea.Tick scheduler; the
-	// watcher does not emit it. The model uses tea.Tick to drive
-	// detect-entry-state and pollState refreshes on a fixed cadence
-	// regardless of whether filesystem activity triggered a watcher
-	// event.
+	// Check subscribed node state files for changes.
+	w.mu.Lock()
+	addrs := make([]string, 0, len(w.subscribed))
+	for addr := range w.subscribed {
+		addrs = append(addrs, addr)
+	}
+	w.mu.Unlock()
+	for _, addr := range addrs {
+		p, err := w.store.NodePath(addr)
+		if err != nil {
+			continue
+		}
+		info, err := os.Stat(p)
+		if err != nil {
+			continue
+		}
+		if prev, ok := w.nodeMtimes[addr]; ok && info.ModTime() == prev {
+			continue
+		}
+		w.nodeMtimes[addr] = info.ModTime()
+		node, err := w.store.ReadNode(addr)
+		if err != nil {
+			continue
+		}
+		w.emit(NodeUpdatedMsg{Address: addr, Node: node})
+	}
 }
 
 // AddNodeWatch adds an fsnotify watch on a specific node's state.json,

--- a/internal/tui/watcher_test.go
+++ b/internal/tui/watcher_test.go
@@ -823,6 +823,103 @@ func TestPollTick_DeliversLogLinesThroughChannel(t *testing.T) {
 	}
 }
 
+func TestPollTick_DetectsNodeStateChange(t *testing.T) {
+	dir := t.TempDir()
+	store := state.NewStore(dir, time.Second)
+
+	// Create index with one leaf.
+	if err := store.MutateIndex(func(idx *state.RootIndex) error {
+		idx.Root = []string{"proj"}
+		idx.Nodes["proj"] = state.IndexEntry{
+			Name: "proj", Type: state.NodeLeaf, State: state.StatusNotStarted, Address: "proj",
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write per-node state file.
+	ns := state.NewNodeState("proj", "proj", state.NodeLeaf)
+	ns.Tasks = []state.Task{
+		{ID: "task-0001", Title: "do something", State: state.StatusNotStarted},
+	}
+	p, _ := store.NodePath("proj")
+	_ = os.MkdirAll(filepath.Dir(p), 0o755)
+	if err := state.SaveNodeState(p, ns); err != nil {
+		t.Fatal(err)
+	}
+
+	events, next := drainEvents(t)
+	w := NewWatcher(store, "", "", events)
+	// Mark "proj" as subscribed so pollTick checks it.
+	w.subscribed["proj"] = true
+	// Seed index mtime so pollTick doesn't emit a StateUpdatedMsg
+	// that fills the channel before we check for NodeUpdatedMsg.
+	if info, err := os.Stat(store.IndexPath()); err == nil {
+		w.indexMtime = info.ModTime()
+	}
+
+	// First tick: seeds the mtime, emits NodeUpdatedMsg.
+	w.pollTick()
+	found := false
+	for i := 0; i < 8 && !found; i++ {
+		got := next()
+		envelope, ok := got.(WatcherMsg)
+		if !ok {
+			break
+		}
+		if n, ok := envelope.Inner.(NodeUpdatedMsg); ok && n.Address == "proj" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("first pollTick should emit NodeUpdatedMsg for newly-seen node")
+	}
+
+	// Second tick without changes: no new NodeUpdatedMsg.
+	w.pollTick()
+	// Drain: check for spurious NodeUpdatedMsg.
+	for {
+		select {
+		case got := <-events:
+			envelope, ok := got.(WatcherMsg)
+			if !ok {
+				continue
+			}
+			if n, ok := envelope.Inner.(NodeUpdatedMsg); ok && n.Address == "proj" {
+				t.Fatal("pollTick should not re-emit NodeUpdatedMsg when mtime unchanged")
+			}
+		default:
+			goto drained
+		}
+	}
+drained:
+
+	// Mutate the node state and tick again.
+	_ = store.MutateNode("proj", func(ns *state.NodeState) error {
+		ns.Tasks[0].State = state.StatusInProgress
+		return nil
+	})
+	w.pollTick()
+	found = false
+	for i := 0; i < 8 && !found; i++ {
+		got := next()
+		envelope, ok := got.(WatcherMsg)
+		if !ok {
+			break
+		}
+		if n, ok := envelope.Inner.(NodeUpdatedMsg); ok && n.Address == "proj" {
+			if n.Node.Tasks[0].State != state.StatusInProgress {
+				t.Errorf("expected in_progress, got %s", n.Node.Tasks[0].State)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("pollTick should emit NodeUpdatedMsg after node state changed")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // EagerPrefetchAndSubscribe — covers the cache-freshness fix
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The TUI worked fine when launched from inside a project directory (where `.wolfcastle/` exists), but froze when launched from any other directory and auto-connecting to a running daemon via instance discovery. Three independent failures combined:

1. **Poll chain never started**: `Init()` only called `startPoller()` when `store != nil`. After instance switch provided a store, the 2-second refresh tick never began. Tree loaded once, then froze.

2. **Watcher events never drained**: `waitForWatcherEvent` was only scheduled when `store != nil`. After instance switch created a new watcher, `LogLinesMsg` and `NodeUpdatedMsg` events piled up in the channel unread. Logs showed "No transmissions."

3. **Per-node updates relied solely on fsnotify**: macOS kqueue silently drops events for certain paths. No polling fallback existed for node-level state, so task states were stale even when the watcher was running.

**Fixes:**
- Start poller and watcher event drain unconditionally in `Init()`
- Always run watcher polling alongside fsnotify
- Add per-node mtime polling in `pollTick` for subscribed nodes

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/tui/...` (all 11 packages pass)
- [x] Manual: launch TUI from empty `/tmp/wc-no-config/`, auto-connects to daemon in `/tmp/wc-tui-test/`
- [x] Tree updates live (orchestrator state, task states)
- [x] Log modal streams content
- [x] Works from project directory (no regression)