### PR TITLE
fix: multi-file log streaming, trace filters, modal backgrounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Directory picker overlay (`+`): shows running daemon sessions at the top, followed by a filesystem browser. Directories with `.wolfcastle/` are highlighted. Selecting a running session opens a tab connected to that daemon. Duplicate directories refocus the existing tab.
 - Tab-scoped daemon control: `s` starts/stops the daemon in the active tab's directory, not the CWD. The daemon modal shows which directory it will affect.
 
+### Bug Fixes
+- Log modal now streams ALL log types (exec, plan, intake, inbox), not just exec. The watcher tracks every uncompressed `.jsonl` file in the log directory.
+- Trace filter (`T` in log modal) matches by category prefix instead of exact trace ID. Expanded cycle: all, exec, plan, inbox, system.
+- Modal overlays (inbox, logs, daemon confirm, new tab picker) have solid dark backgrounds. Cell-level background fill via lipgloss Canvas prevents ANSI resets from punching transparent holes.
+
 ### Breaking Changes
 - Instance tab bar replaced by user-managed tabs. The `<`/`>` keys now switch tabs instead of instances. Digit keys (1-9) for instance selection removed.
 

--- a/internal/logging/category_a_test.go
+++ b/internal/logging/category_a_test.go
@@ -43,7 +43,7 @@ func TestLog_UnmarshalableMapValue(t *testing.T) {
 	logger.Close()
 	entries, _ := os.ReadDir(dir)
 	for _, e := range entries {
-		if isLogFile(e.Name()) {
+		if IsLogFile(e.Name()) {
 			info, _ := e.Info()
 			if info.Size() > 0 {
 				t.Log("log file has some content (timestamp/level injected before marshal error)")

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -263,7 +263,7 @@ func LatestLogFile(logDir string) (string, error) {
 	var allLogs []string
 
 	for _, e := range entries {
-		if e.IsDir() || !isLogFile(e.Name()) {
+		if e.IsDir() || !IsLogFile(e.Name()) {
 			continue
 		}
 		allLogs = append(allLogs, e.Name())
@@ -330,8 +330,8 @@ func parseLogFilename(name string) (iteration int, prefix string, ok bool) {
 	return n, prefix, true
 }
 
-// isLogFile returns true for .jsonl and .jsonl.gz filenames.
-func isLogFile(name string) bool {
+// IsLogFile reports whether name looks like a log filename (.jsonl or .jsonl.gz).
+func IsLogFile(name string) bool {
 	return strings.HasSuffix(name, ".jsonl") || strings.HasSuffix(name, ".jsonl.gz")
 }
 
@@ -349,7 +349,7 @@ func EnforceRetention(logDir string, maxFiles int, maxAgeDays int, opts ...Reten
 	}
 	var logs []os.DirEntry
 	for _, e := range entries {
-		if !e.IsDir() && isLogFile(e.Name()) {
+		if !e.IsDir() && IsLogFile(e.Name()) {
 			logs = append(logs, e)
 		}
 	}
@@ -376,7 +376,7 @@ func EnforceRetention(logDir string, maxFiles int, maxAgeDays int, opts ...Reten
 	entries, _ = os.ReadDir(logDir)
 	logs = nil
 	for _, e := range entries {
-		if !e.IsDir() && isLogFile(e.Name()) {
+		if !e.IsDir() && IsLogFile(e.Name()) {
 			logs = append(logs, e)
 		}
 	}
@@ -497,7 +497,7 @@ func IterationFromDir(logDir string) int {
 	}
 	maxIter := 0
 	for _, e := range entries {
-		if e.IsDir() || !isLogFile(e.Name()) {
+		if e.IsDir() || !IsLogFile(e.Name()) {
 			continue
 		}
 		var n int

--- a/internal/logging/logger_coverage_test.go
+++ b/internal/logging/logger_coverage_test.go
@@ -474,7 +474,7 @@ func TestStartIteration_ClosePreviousBeforeNew(t *testing.T) {
 	entries, _ := os.ReadDir(dir)
 	logCount := 0
 	for _, e := range entries {
-		if isLogFile(e.Name()) {
+		if IsLogFile(e.Name()) {
 			logCount++
 		}
 	}

--- a/internal/logging/logger_deep_coverage_test.go
+++ b/internal/logging/logger_deep_coverage_test.go
@@ -241,7 +241,7 @@ func TestEnforceRetention_UnreadableDirectory(t *testing.T) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// isLogFile
+// IsLogFile
 // ═══════════════════════════════════════════════════════════════════════════
 
 func TestIsLogFile_ExtendedCases(t *testing.T) {
@@ -257,8 +257,8 @@ func TestIsLogFile_ExtendedCases(t *testing.T) {
 		{"something.jsonl.bak", false},
 	}
 	for _, tc := range cases {
-		if got := isLogFile(tc.name); got != tc.expected {
-			t.Errorf("isLogFile(%q) = %v, want %v", tc.name, got, tc.expected)
+		if got := IsLogFile(tc.name); got != tc.expected {
+			t.Errorf("IsLogFile(%q) = %v, want %v", tc.name, got, tc.expected)
 		}
 	}
 }

--- a/internal/logging/logger_errorpath_test.go
+++ b/internal/logging/logger_errorpath_test.go
@@ -130,7 +130,7 @@ func TestEnforceRetention_DeletesByCount(t *testing.T) {
 	entries, _ := os.ReadDir(dir)
 	count := 0
 	for _, e := range entries {
-		if isLogFile(e.Name()) {
+		if IsLogFile(e.Name()) {
 			count++
 		}
 	}

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -901,7 +901,7 @@ func TestMultipleIterations_CreateSeparateFiles(t *testing.T) {
 	}
 }
 
-// ── isLogFile Tests ───────────────────────────────────────────────
+// ── IsLogFile Tests ───────────────────────────────────────────────
 
 func TestIsLogFile(t *testing.T) {
 	t.Parallel()
@@ -917,8 +917,8 @@ func TestIsLogFile(t *testing.T) {
 		{"foo.jsonl.gz", true},
 	}
 	for _, tc := range cases {
-		if got := isLogFile(tc.name); got != tc.want {
-			t.Errorf("isLogFile(%q) = %v, want %v", tc.name, got, tc.want)
+		if got := IsLogFile(tc.name); got != tc.want {
+			t.Errorf("IsLogFile(%q) = %v, want %v", tc.name, got, tc.want)
 		}
 	}
 }
@@ -1610,7 +1610,7 @@ func countLogFiles(dir string) int {
 	entries, _ := os.ReadDir(dir)
 	count := 0
 	for _, e := range entries {
-		if !e.IsDir() && isLogFile(e.Name()) {
+		if !e.IsDir() && IsLogFile(e.Name()) {
 			count++
 		}
 	}

--- a/internal/tui/app/daemon_modal.go
+++ b/internal/tui/app/daemon_modal.go
@@ -106,6 +106,7 @@ func (m DaemonModalModel) View() string {
 	content := title + "\n\n" +
 		lipgloss.NewStyle().Width(innerW).Render(body.String()) +
 		"\n\n" + footer
+	content = fillModalBg(content, innerW)
 
 	box := tui.ModalOverlayStyle.
 		Width(overlayW).

--- a/internal/tui/app/modal.go
+++ b/internal/tui/app/modal.go
@@ -6,9 +6,26 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/dorkusprime/wolfcastle/internal/tui"
 )
+
+// fillModalBg pads every line of content to the given width with the
+// modal overlay background color. This prevents transparent gaps where
+// individually styled spans reset the background.
+func fillModalBg(content string, width int) string {
+	bg := lipgloss.NewStyle().Background(tui.ColorOverlayBg)
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		w := ansi.StringWidth(line)
+		if w < width {
+			line += bg.Render(strings.Repeat(" ", width-w))
+		}
+		lines[i] = line
+	}
+	return strings.Join(lines, "\n")
+}
 
 // ActiveModal tracks which modal overlay (if any) is currently visible.
 // Only one modal can be open at a time; the enum enforces this
@@ -132,9 +149,11 @@ func (m TUIModel) renderNewTabModal(contentHeight int) string {
 		overlayH = contentHeight
 	}
 
+	innerW := overlayW - 6
 	picker := m.tabPicker
-	picker.SetSize(overlayW-6, overlayH-4)
+	picker.SetSize(innerW, overlayH-4)
 	content := picker.View()
+	content = fillModalBg(content, innerW)
 
 	box := tui.ModalOverlayStyle.
 		Width(overlayW).
@@ -178,6 +197,7 @@ func (m TUIModel) renderInboxModal(contentHeight int) string {
 
 	hint := strings.Repeat(" ", 2) + tui.ModalDimStyle.Render("[Esc] Close")
 	content += "\n" + hint
+	content = fillModalBg(content, innerW)
 
 	box := tui.ModalOverlayStyle.
 		Width(overlayW).
@@ -221,6 +241,7 @@ func (m TUIModel) renderLogModal(contentHeight int) string {
 
 	hint := strings.Repeat(" ", 2) + tui.ModalDimStyle.Render("[Esc] Close")
 	content += "\n" + hint
+	content = fillModalBg(content, innerW)
 
 	box := tui.ModalOverlayStyle.
 		Width(overlayW).

--- a/internal/tui/app/modal.go
+++ b/internal/tui/app/modal.go
@@ -6,25 +6,44 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
-	"github.com/charmbracelet/x/ansi"
+	uv "github.com/charmbracelet/ultraviolet"
 
 	"github.com/dorkusprime/wolfcastle/internal/tui"
 )
 
-// fillModalBg pads every line of content to the given width with the
-// modal overlay background color. This prevents transparent gaps where
-// individually styled spans reset the background.
+// fillModalBg stamps the overlay background color onto every cell of
+// the rendered content that doesn't already have an explicit background.
+// This operates at the cell level (via lipgloss Canvas + ultraviolet),
+// so ANSI resets between styled spans no longer punch transparent holes.
 func fillModalBg(content string, width int) string {
-	bg := lipgloss.NewStyle().Background(tui.ColorOverlayBg)
 	lines := strings.Split(content, "\n")
-	for i, line := range lines {
-		w := ansi.StringWidth(line)
-		if w < width {
-			line += bg.Render(strings.Repeat(" ", width-w))
-		}
-		lines[i] = line
+	height := len(lines)
+	if height == 0 || width == 0 {
+		return content
 	}
-	return strings.Join(lines, "\n")
+
+	canvas := lipgloss.NewCanvas(width, height)
+	ss := uv.NewStyledString(content)
+	canvas.Compose(ss)
+
+	bg := tui.ColorOverlayBg
+	bounds := canvas.Bounds()
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			c := canvas.CellAt(x, y)
+			if c == nil {
+				canvas.SetCell(x, y, &uv.Cell{
+					Content: " ",
+					Width:   1,
+					Style:   uv.Style{Bg: bg},
+				})
+			} else if c.Style.Bg == nil {
+				c.Style.Bg = bg
+			}
+		}
+	}
+
+	return canvas.Render()
 }
 
 // ActiveModal tracks which modal overlay (if any) is currently visible.

--- a/internal/tui/detail/logview.go
+++ b/internal/tui/detail/logview.go
@@ -471,11 +471,34 @@ func (m LogViewModel) levelMatches(rec logrender.Record) bool {
 }
 
 // traceMatches returns true if the record passes the current trace filter.
+// Trace IDs look like "exec-0002", "intake-10001", or "inbox-init-10003".
+// The filter matches on the trace category, not the full ID.
 func (m LogViewModel) traceMatches(rec logrender.Record) bool {
 	if m.traceFilter == "all" {
 		return true
 	}
-	return rec.Trace == m.traceFilter
+	cat := traceCategory(rec.Trace)
+	return cat == m.traceFilter
+}
+
+// traceCategory extracts the category from a trace ID. "exec-0002" yields
+// "exec", "inbox-init-10003" yields "inbox", "intake-10001" yields "inbox"
+// (intake is the inbox processing stage).
+func traceCategory(trace string) string {
+	switch {
+	case strings.HasPrefix(trace, "exec"):
+		return "exec"
+	case strings.HasPrefix(trace, "plan"):
+		return "plan"
+	case strings.HasPrefix(trace, "intake"), strings.HasPrefix(trace, "inbox"):
+		return "inbox"
+	case strings.HasPrefix(trace, "heal"):
+		return "system"
+	case strings.HasPrefix(trace, "shutdown"), strings.HasPrefix(trace, "crash"):
+		return "system"
+	default:
+		return "other"
+	}
 }
 
 func levelOrd(level string) int {
@@ -505,7 +528,7 @@ func (m *LogViewModel) cycleLevelFilter() {
 	m.levelFilter = "all"
 }
 
-var traceCycle = []string{"all", "exec", "intake"}
+var traceCycle = []string{"all", "exec", "plan", "inbox", "system"}
 
 func (m *LogViewModel) cycleTraceFilter() {
 	for i, v := range traceCycle {

--- a/internal/tui/detail/logview_test.go
+++ b/internal/tui/detail/logview_test.go
@@ -200,7 +200,7 @@ func TestKey_T_CycleTraceFilter(t *testing.T) {
 	m := NewLogViewModel()
 	m.SetSize(80, 24)
 
-	expected := []string{"exec", "intake", "all"}
+	expected := []string{"exec", "plan", "inbox", "system", "all"}
 	for _, want := range expected {
 		m, _ = m.Update(keyPress('T'))
 		if m.traceFilter != want {

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -100,16 +100,20 @@ var (
 	ModalOverlayStyle = lipgloss.NewStyle().
 				Background(ColorOverlayBg).
 				Border(lipgloss.RoundedBorder()).
-				BorderForeground(ColorDimWhite)
+				BorderForeground(ColorDimWhite).
+				BorderBackground(ColorOverlayBg)
 
 	ModalTitleStyle = lipgloss.NewStyle().
+			Background(ColorOverlayBg).
 			Foreground(ColorWhite).
 			Bold(true)
 
 	ModalDimStyle = lipgloss.NewStyle().
+			Background(ColorOverlayBg).
 			Foreground(ColorDimWhite)
 
 	ModalAccentStyle = lipgloss.NewStyle().
+				Background(ColorOverlayBg).
 				Foreground(ColorYellow)
 )
 

--- a/internal/tui/watcher.go
+++ b/internal/tui/watcher.go
@@ -30,8 +30,8 @@ type Watcher struct {
 	watcher     *fsnotify.Watcher
 	store       *state.Store
 	logDir      string
-	logFile     string
-	logOffset   int64
+	logFile     string    // latest log file (for NewLogFileMsg)
+	logOffset   int64     // deprecated: use logFiles map instead
 	instanceDir string
 	debounce    *time.Timer
 	maxSlide    *time.Timer
@@ -56,11 +56,24 @@ type Watcher struct {
 	// (decomposition, planning passes, etc).
 	subscribed map[string]bool
 
+	// Multi-file log tracking. Each uncompressed .jsonl in the log
+	// directory gets its own entry so exec, plan, intake, and inbox
+	// logs are all read and streamed to the TUI.
+	logFiles map[string]*logFileState
+
 	// polling state
 	indexMtime    time.Time
 	instanceMtime time.Time
-	logFileSize   int64
-	lineBuf       string // incomplete trailing line from last read
+	logFileSize   int64     // deprecated: use logFiles map
+	lineBuf       string    // deprecated: use logFiles map
+}
+
+// logFileState tracks read progress for a single log file.
+type logFileState struct {
+	path    string
+	offset  int64
+	size    int64
+	lineBuf string // incomplete trailing line from last read
 }
 
 // NewWatcher creates a Watcher that will observe the given store's state
@@ -78,6 +91,7 @@ func NewWatcher(store *state.Store, logDir, instanceDir string, events chan<- te
 		useFsnotify: true,
 		subscribed:  make(map[string]bool),
 		nodeMtimes:  make(map[string]time.Time),
+		logFiles:    make(map[string]*logFileState),
 	}
 }
 
@@ -153,61 +167,55 @@ func (w *Watcher) Start() error {
 // historical context the user sees on first switch.
 const defaultLogTailLines = 500
 
-// LoadInitialLogTail reads the last maxLines from the currently
-// seeded w.logFile and emits them as a LogLinesMsg via the events
-// channel, then advances w.logOffset to the end of file so the next
-// incremental read produces only new content.
-//
-// Skips files ending in .jsonl.gz; the live exec log is always the
-// plain .jsonl (rotated archives are .gz). If the latest file is
-// gz-only because the daemon has stopped between iterations, we
-// emit nothing rather than feeding gzipped binary into the
-// LogViewModel's NDJSON parser.
+// LoadInitialLogTail reads the tail of ALL uncompressed log files in
+// the log directory, merges them, trims to maxLines, and emits a
+// LogLinesMsg. It also seeds the logFiles map with current offsets so
+// subsequent pollLogFiles calls only read new content.
 func (w *Watcher) LoadInitialLogTail(maxLines int) {
-	w.mu.Lock()
-	logFile := w.logFile
-	w.mu.Unlock()
-
-	if logFile == "" || strings.HasSuffix(logFile, ".gz") {
+	if w.logDir == "" {
 		return
 	}
-
-	f, err := os.Open(logFile)
-	if err != nil {
-		return
-	}
-	defer func() { _ = f.Close() }()
-
-	info, err := f.Stat()
+	entries, err := os.ReadDir(w.logDir)
 	if err != nil {
 		return
 	}
 
-	// Read every complete line from the file. For multi-megabyte
-	// logs this is wasteful but the daemon's per-iteration log
-	// files cap out around a few hundred KB in practice. If that
-	// ever becomes a real concern, replace this with a backwards
-	// chunked read that stops once it has gathered maxLines.
-	scanner := bufio.NewScanner(f)
-	// Allow long NDJSON lines that contain embedded prompts.
-	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
-	var lines []string
-	for scanner.Scan() {
-		lines = append(lines, scanner.Text())
+	var allLines []string
+	for _, e := range entries {
+		if e.IsDir() || !logging.IsLogFile(e.Name()) || strings.HasSuffix(e.Name(), ".gz") {
+			continue
+		}
+		fullPath := filepath.Join(w.logDir, e.Name())
+
+		f, err := os.Open(fullPath)
+		if err != nil {
+			continue
+		}
+		info, _ := f.Stat()
+		scanner := bufio.NewScanner(f)
+		scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+		for scanner.Scan() {
+			allLines = append(allLines, scanner.Text())
+		}
+		_ = f.Close()
+
+		// Seed the logFiles map so pollLogFiles starts from EOF.
+		if info != nil {
+			w.logFiles[fullPath] = &logFileState{
+				path:   fullPath,
+				offset: info.Size(),
+				size:   info.Size(),
+			}
+		}
 	}
 
 	// Trim to the last maxLines.
-	if maxLines > 0 && len(lines) > maxLines {
-		lines = lines[len(lines)-maxLines:]
+	if maxLines > 0 && len(allLines) > maxLines {
+		allLines = allLines[len(allLines)-maxLines:]
 	}
 
-	w.mu.Lock()
-	w.logOffset = info.Size()
-	w.lineBuf = ""
-	w.mu.Unlock()
-
-	if len(lines) > 0 {
-		w.emit(LogLinesMsg{Lines: lines})
+	if len(allLines) > 0 {
+		w.emit(LogLinesMsg{Lines: allLines})
 	}
 }
 
@@ -461,29 +469,9 @@ func (w *Watcher) pollTick() {
 		}
 	}
 
-	// Check for new log files.
+	// Scan all uncompressed log files for new content.
 	if w.logDir != "" {
-		if latest, err := logging.LatestLogFile(w.logDir); err == nil && latest != w.logFile {
-			w.mu.Lock()
-			w.logFile = latest
-			w.logOffset = 0
-			w.logFileSize = 0
-			w.lineBuf = ""
-			w.mu.Unlock()
-			w.emit(NewLogFileMsg{Path: latest})
-		}
-	}
-
-	// Check current log file size.
-	if w.logFile != "" {
-		if info, err := os.Stat(w.logFile); err == nil {
-			if info.Size() != w.logFileSize {
-				w.logFileSize = info.Size()
-				if lines := w.readNewLogLines(); len(lines) > 0 {
-					w.emit(LogLinesMsg{Lines: lines})
-				}
-			}
-		}
+		w.pollLogFiles()
 	}
 	// Check subscribed node state files for changes.
 	w.mu.Lock()
@@ -634,9 +622,108 @@ func (w *Watcher) Stop() {
 	}
 }
 
+// pollLogFiles scans the log directory for all uncompressed .jsonl files,
+// discovers new ones, reads new content from any that grew, and emits
+// a single LogLinesMsg with all new lines. This replaces the old
+// single-file approach so exec, plan, intake, and inbox logs all stream.
+func (w *Watcher) pollLogFiles() {
+	entries, err := os.ReadDir(w.logDir)
+	if err != nil {
+		return
+	}
+
+	// Discover new files.
+	for _, e := range entries {
+		if e.IsDir() || !logging.IsLogFile(e.Name()) || strings.HasSuffix(e.Name(), ".gz") {
+			continue
+		}
+		fullPath := filepath.Join(w.logDir, e.Name())
+		if _, tracked := w.logFiles[fullPath]; !tracked {
+			w.logFiles[fullPath] = &logFileState{path: fullPath}
+		}
+	}
+
+	// Remove files that were compressed or deleted.
+	for path := range w.logFiles {
+		if _, err := os.Stat(path); err != nil {
+			delete(w.logFiles, path)
+		}
+	}
+
+	// Read new content from each tracked file.
+	var allLines []string
+	for _, fs := range w.logFiles {
+		info, err := os.Stat(fs.path)
+		if err != nil {
+			continue
+		}
+		if info.Size() == fs.size {
+			continue
+		}
+		fs.size = info.Size()
+		lines := readFromLogFile(fs)
+		allLines = append(allLines, lines...)
+	}
+
+	if len(allLines) > 0 {
+		w.emit(LogLinesMsg{Lines: allLines})
+	}
+
+	// Track the "latest" file for NewLogFileMsg (used by the log view
+	// header to show the current iteration number).
+	if latest, err := logging.LatestLogFile(w.logDir); err == nil && latest != w.logFile {
+		w.logFile = latest
+		w.emit(NewLogFileMsg{Path: latest})
+	}
+}
+
+// readFromLogFile reads new content from a tracked log file starting at
+// the stored offset. Returns only complete lines; incomplete trailing
+// data is buffered for the next read.
+func readFromLogFile(fs *logFileState) []string {
+	f, err := os.Open(fs.path)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := f.Seek(fs.offset, io.SeekStart); err != nil {
+		return nil
+	}
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	var lines []string
+	var bytesRead int64
+	buf := fs.lineBuf
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		bytesRead += int64(len(scanner.Bytes())) + 1
+		lines = append(lines, buf+line)
+		buf = ""
+	}
+
+	newOffset := fs.offset + bytesRead
+
+	// Check for trailing incomplete line.
+	if info, err := f.Stat(); err == nil && info.Size() > newOffset {
+		trailing := make([]byte, info.Size()-newOffset)
+		if _, err := f.ReadAt(trailing, newOffset); err == nil {
+			buf = string(trailing)
+			newOffset = info.Size()
+		}
+	}
+
+	fs.offset = newOffset
+	fs.lineBuf = buf
+	return lines
+}
+
 // readNewLogLines reads from logOffset to EOF in the current log file and
 // returns only complete lines. Any trailing incomplete line is buffered
 // internally for the next read.
+// Deprecated: use pollLogFiles instead. Kept for LoadInitialLogTail.
 func (w *Watcher) readNewLogLines() []string {
 	w.mu.Lock()
 	logFile := w.logFile

--- a/internal/tui/watcher.go
+++ b/internal/tui/watcher.go
@@ -30,8 +30,8 @@ type Watcher struct {
 	watcher     *fsnotify.Watcher
 	store       *state.Store
 	logDir      string
-	logFile     string    // latest log file (for NewLogFileMsg)
-	logOffset   int64     // deprecated: use logFiles map instead
+	logFile     string // latest log file (for NewLogFileMsg)
+	logOffset   int64  // deprecated: use logFiles map instead
 	instanceDir string
 	debounce    *time.Timer
 	maxSlide    *time.Timer
@@ -64,8 +64,8 @@ type Watcher struct {
 	// polling state
 	indexMtime    time.Time
 	instanceMtime time.Time
-	logFileSize   int64     // deprecated: use logFiles map
-	lineBuf       string    // deprecated: use logFiles map
+	logFileSize   int64  // deprecated: use logFiles map
+	lineBuf       string // deprecated: use logFiles map
 }
 
 // logFileState tracks read progress for a single log file.

--- a/internal/tui/watcher_test.go
+++ b/internal/tui/watcher_test.go
@@ -599,8 +599,12 @@ func TestStartPolling_SeedsFields(t *testing.T) {
 	if w.logFile == "" {
 		t.Fatal("expected logFile to be seeded")
 	}
-	if w.logOffset == 0 {
-		t.Fatal("expected logOffset to be seeded with file size")
+	if len(w.logFiles) == 0 {
+		t.Fatal("expected logFiles map to be seeded")
+	}
+	// The seeded file should have its offset at EOF.
+	if fs, ok := w.logFiles[logFile]; !ok || fs.offset == 0 {
+		t.Fatal("expected logFiles entry to be seeded with file size")
 	}
 }
 
@@ -777,9 +781,14 @@ func TestPollTick_DeliversLogLinesThroughChannel(t *testing.T) {
 	events, next := drainEvents(t)
 	w := NewWatcher(store, logDir, "", events)
 	w.logFile = logFile
+	// Seed the logFiles map at current file size so pollLogFiles
+	// only reads content appended AFTER this point.
 	if info, err := os.Stat(logFile); err == nil {
-		w.logOffset = info.Size()
-		w.logFileSize = info.Size()
+		w.logFiles[logFile] = &logFileState{
+			path:   logFile,
+			offset: info.Size(),
+			size:   info.Size(),
+		}
 	}
 
 	// Append more bytes to the log file, simulating the daemon writing


### PR DESCRIPTION
## Summary

- **Log streaming**: Watcher now tracks ALL uncompressed `.jsonl` files, not just the latest exec. Plan, intake, and inbox logs stream to the TUI log modal.
- **Trace filter**: `T` key cycles through `all → exec → plan → inbox → system`. Matches by category prefix, not exact trace ID.
- **Modal backgrounds**: Cell-level background fill via lipgloss Canvas + ultraviolet. ANSI resets between styled spans no longer punch transparent holes in modal overlays.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/tui/... ./internal/logging/... ./internal/logrender/...`
- [x] Manual: log modal shows exec, intake, inbox logs; trace filter works; modal backgrounds are solid