### PR TITLE
feat: TUI design system overhaul

### DIFF
--- a/docs/agents/design-system.md
+++ b/docs/agents/design-system.md
@@ -1,0 +1,202 @@
+# Wolfcastle TUI Design System
+
+## Brand Foundation
+
+The logo is a neon wireframe wolf superimposed on a dark castle. 1980s arcade cabinet energy: black background, geometry traced in electric cyan, magenta accents at the structural joints, yellow-gold teeth and nameplate. The neon-wolf variant adds blue-purple interior glow and orange heat at the jaw.
+
+The TUI should feel like the logo: dark, clean, glowing where it matters. Not a rave. A machine room at 2 AM with one monitor still on.
+
+## Color Palette
+
+### Structural Colors (brand identity)
+
+These define the TUI's visual identity. Used for chrome, borders, headers, and interactive highlights.
+
+| Name | ANSI 256 | Hex | Usage |
+|------|----------|-----|-------|
+| Neon Cyan | 51 | #00FFFF | Primary brand color. Header background, active borders, focused-pane indicator |
+| Deep Cyan | 30 | #008787 | Dimmed variant of primary. Inactive borders, secondary chrome |
+| Magenta | 198 | #FF0087 | Accent. Active tab indicator, selection highlight, search match |
+| Deep Magenta | 125 | #AF005F | Dimmed magenta. Search ancestor path, secondary accent |
+| Gold | 220 | #FFD700 | Tertiary accent. Target mark, daemon "hunting" indicator, emphasis |
+| Charcoal | 234 | #1C1C1C | Dark fill. Header bar background, toast background |
+| Slate | 236 | #303030 | Neutral dark. Alt-row shading, divider lines |
+
+### Status Colors (functional, universal)
+
+These communicate state. Never use them for decoration. They mean what they mean everywhere.
+
+| Name | ANSI 256 | Hex | Meaning |
+|------|----------|-----|---------|
+| Green | 2 | #00FF00 | Complete. Task done, audit passed, daemon confirmed |
+| Yellow | 3 | #FFFF00 | In progress. Active work, pending, yielded |
+| Red | 1 | #FF0000 | Blocked. Failed, error, hard stop |
+| Dim | 245 | #8A8A8A | Not started. Inactive, placeholder, secondary text |
+
+### Text Colors
+
+| Name | ANSI 256 | Hex | Usage |
+|------|----------|-----|-------|
+| Bright | 15 | #FFFFFF | Primary text. Headings, active content |
+| Normal | 252 | #D0D0D0 | Body text. Tree labels, detail content |
+| Muted | 245 | #8A8A8A | Secondary text. Timestamps, hints, footer |
+| Faint | 240 | #585858 | Tertiary text. Debug-level logs, disabled items |
+
+### Background Colors
+
+| Name | ANSI 256 | Hex | Usage |
+|------|----------|-----|-------|
+| Base | terminal default | - | Main content area. Respects user's terminal background |
+| Header | 234 | #1C1C1C | Header bar background (charcoal, barely off-black) |
+| Selection | 23 | #005F5F | Selected row in tree, cursor highlight (dark teal) |
+| Modal | 235 | #262626 | Modal overlay fill |
+| Error | 52 | #340000 | Error bar background |
+
+## Component Specifications
+
+### Header Bar (3 lines max)
+
+```
+[deep blue bg, neon cyan text]
+WOLFCASTLE v0.6.2                    /path/to/project hunting (PID 12345)
+22 nodes: 4● 3◐ 5◯ 10☢                                          1 running
+[wc-tui-test ●] [my-saas-app] [+]
+```
+
+- Background: Charcoal (234)
+- Title "WOLFCASTLE": Neon Cyan (51), bold
+- Version, path, status: Bright (15)
+- Node count glyphs: status colors
+- Tab bar: active tab in Neon Cyan, inactive in Muted, running dot in Green
+- `[+]` hint in Muted
+
+### Tree Panel
+
+```
+[selection bg when selected, default bg otherwise]
+▾ warzone ◐                    (3 tasks)
+  ▾ backend ◐
+    ● api
+  ▶ ◐ auth                    ← target mark in Gold
+    ◯ database
+```
+
+- Normal text: Normal (252)
+- Selected row: Selection bg (23) with Bright text (15)
+- Status glyphs: status colors, consistent everywhere
+- Target mark (▶): Gold (220)
+- Expand/collapse (▾/▸): Muted (245)
+- Task hint counts: Muted (245)
+- Search match: Magenta (198) bg with Bright text
+- Search ancestor: Deep Magenta (125) fg, no bg change
+
+### Focus Indicator
+
+The focused pane gets a left border in Neon Cyan (51). The unfocused pane gets a left border in Slate (236). This replaces the current approach of using the header-red as the selected-row color.
+
+### Detail Panel
+
+- Heading: Bright (15), bold
+- Body text: Normal (252)
+- Labels ("Status:", "Tasks:", "Scope:"): Muted (245)
+- Values: Normal or status-colored as appropriate
+- Breadcrumb timestamps: Muted (245)
+- Links/addresses: Neon Cyan (51)
+
+### Footer Bar
+
+```
+[no background, muted text]
+[q] quit  [Tab] focus  [d] dashboard  [s] start  [<>] tab  [+] new tab  ...
+```
+
+- All text: Muted (245)
+- Keys in brackets: same color, no special highlight
+- Truncates from the right when terminal is narrow
+
+### Log Modal
+
+```
+[modal bg: 235, content bg: filled via canvas]
+TRANSMISSIONS  Level: all (unfiltered)  Trace: all  [following]
+10:54:41 [exec-0482] [tool: Read]
+10:54:42 [exec-0482] [tool result]
+10:54:43 [plan-0012] Planning started...
+```
+
+- Header: Bright (15), bold. Filter labels in Muted, active filter in Gold
+- Timestamps: Muted (245)
+- Trace prefix: Neon Cyan (51)
+- Content: Normal (252) with level-based tinting:
+  - Debug: Faint (240)
+  - Info: no tint
+  - Warn: Yellow (3)
+  - Error: Red (1)
+- Follow indicator: Green for `[following]`, Yellow for `[paused]`
+
+### Inbox Modal
+
+- Item bullets: status-colored (● filed, ○ new)
+- Item text: Normal (252)
+- Filed date: Muted (245)
+- Input bar: Neon Cyan border when active
+
+### Daemon Confirm Modal
+
+- Title ("STOP DAEMON"): Bright, bold
+- Body: Normal
+- `[Enter] Confirm`: Gold (220)
+- `[Esc] Cancel`: Muted (245)
+
+### Tab Picker Modal
+
+- "NEW TAB" title: Bright, bold
+- Directory path: Muted
+- Running sessions (●): Green + Neon Cyan text
+- Directories with .wolfcastle (◆): Gold
+- Plain directories: Muted
+- Selected row: Selection bg (23) with Bright text
+
+### Help Overlay
+
+- Section titles: Neon Cyan (51), bold
+- Key column: Gold (220)
+- Description column: Normal (252)
+- Scrollable, same border treatment as other modals
+
+### Notification Toasts
+
+- Background: Charcoal (234)
+- Text: Bright (15)
+- Border: Neon Cyan (51)
+- Positioned top-right, auto-dismiss
+
+## Principles
+
+1. **Dark by default.** The terminal background is the canvas. The TUI adds color, it doesn't replace the surface.
+
+2. **Status colors are sacred.** Green, yellow, red, and dim gray mean one thing each. They're never used for decoration or branding.
+
+3. **Neon cyan is the brand.** It appears in the header, focused borders, trace prefixes, links, and section titles. It's the "Wolfcastle is here" signal.
+
+4. **Magenta for interaction.** Search highlights, active selections, things the user is doing right now.
+
+5. **Gold for targets.** What the daemon is working on, what the user should confirm, what demands attention.
+
+6. **Less is more.** A wall of color is noise. Most text is Normal (252) on the default background. Color draws the eye to the few things that matter.
+
+7. **No light mode.** Wolfcastle runs at 2 AM. The design assumes a dark terminal. A near-black base background (ANSI 234) fills the alt-screen so the TUI remains readable on light terminals.
+
+8. **Terminal.app has known limitations.** macOS Terminal.app lacks true color support and has BCE (Background Color Erase) rendering quirks that produce faint 1-pixel stripes at border/content boundaries. This is a Terminal.app limitation, not a bug. Use iTerm2, Ghostty, Kitty, or Alacritty for the intended visual experience.
+
+## Migration from Current Palette
+
+| Current | New | Rationale |
+|---------|-----|-----------|
+| Header bg: Dark Red (52) | Charcoal (234) | Matches logo's blue-purple depth; red is reserved for errors |
+| Selection bg: Dark Red (52) | Selection Teal (23) | Red selection conflicts with blocked-status red |
+| Search highlight: Yellow (3) | Magenta (198) | Yellow is for in-progress status, not search |
+| Search ancestor: Dark Olive (58) | Deep Magenta (125) | Olive doesn't exist in the brand palette |
+| Target mark: Bright Yellow (11) | Gold (220) | Richer, more intentional than raw bright yellow |
+| Trace prefix: Cyan (6) | Neon Cyan (51) | Brighter, matches brand primary |
+| Modal title bg: none | Charcoal (234) | Consistent with header |

--- a/internal/tui/app/app.go
+++ b/internal/tui/app/app.go
@@ -938,6 +938,11 @@ func (m TUIModel) View() tea.View {
 	// runtime layout changes (tab bar appearance, error bar visibility).
 	m.propagateSize()
 	rendered := m.renderLayout()
+	// Fill the entire alt-screen with a dark background so the TUI
+	// is readable on light terminals and transparent terminals show
+	// through slightly. Uses cell-level fill (same approach as modal
+	// backgrounds) so ANSI resets don't punch through.
+	rendered = fillBaseBg(rendered, m.width, m.height)
 	v := tea.NewView(rendered)
 	v.AltScreen = true
 	v.WindowTitle = "WOLFCASTLE"

--- a/internal/tui/app/app_test.go
+++ b/internal/tui/app/app_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/dorkusprime/wolfcastle/internal/instance"
 	"github.com/dorkusprime/wolfcastle/internal/state"
@@ -366,8 +367,11 @@ func TestRenderLayoutNormalTerminal(t *testing.T) {
 	if out == "" {
 		t.Error("renderLayout should produce non-empty output")
 	}
-	// Should contain the header (version string) and footer.
-	if !strings.Contains(out, "WOLFCASTLE") {
+	// Should contain the header title. The gradient renderer wraps each
+	// character in individual ANSI sequences, so we strip escapes before
+	// checking for the literal string.
+	stripped := ansi.Strip(out)
+	if !strings.Contains(stripped, "WOLFCASTLE") {
 		t.Error("layout should contain header with WOLFCASTLE title")
 	}
 }

--- a/internal/tui/app/modal.go
+++ b/internal/tui/app/modal.go
@@ -46,6 +46,39 @@ func fillModalBg(content string, width int) string {
 	return canvas.Render()
 }
 
+// fillBaseBg stamps the base background (near-black) onto every cell
+// of the full-screen view that doesn't already have a background.
+// This ensures the TUI is readable on light terminals without
+// breaking transparency on dark ones.
+func fillBaseBg(content string, width, height int) string {
+	if height == 0 || width == 0 {
+		return content
+	}
+
+	canvas := lipgloss.NewCanvas(width, height)
+	ss := uv.NewStyledString(content)
+	canvas.Compose(ss)
+
+	bg := tui.ColorBaseBg
+	bounds := canvas.Bounds()
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			c := canvas.CellAt(x, y)
+			if c == nil {
+				canvas.SetCell(x, y, &uv.Cell{
+					Content: " ",
+					Width:   1,
+					Style:   uv.Style{Bg: bg},
+				})
+			} else if c.Style.Bg == nil {
+				c.Style.Bg = bg
+			}
+		}
+	}
+
+	return canvas.Render()
+}
+
 // ActiveModal tracks which modal overlay (if any) is currently visible.
 // Only one modal can be open at a time; the enum enforces this
 // structurally rather than relying on runtime checks.

--- a/internal/tui/app/tab_picker.go
+++ b/internal/tui/app/tab_picker.go
@@ -210,8 +210,8 @@ func (m TabPickerModel) View() string {
 
 		if selected {
 			line = lipgloss.NewStyle().
-				Background(tui.ColorDarkRed).
-				Foreground(lipgloss.Color("255")).
+				Background(tui.ColorSelection).
+				Foreground(tui.ColorWhite).
 				Bold(true).
 				Width(m.width - 4).
 				Render(line)

--- a/internal/tui/detail/inbox.go
+++ b/internal/tui/detail/inbox.go
@@ -292,7 +292,7 @@ func (m InboxModel) renderItem(idx int) string {
 	if selected && m.focused {
 		selStyle := lipgloss.NewStyle().
 			Foreground(tui.ColorWhite).
-			Background(tui.ColorDarkGray).
+			Background(tui.ColorSelection).
 			Bold(true)
 		return selStyle.Render(line)
 	}

--- a/internal/tui/detail/logview.go
+++ b/internal/tui/detail/logview.go
@@ -314,7 +314,7 @@ func (m LogViewModel) renderLine(rec logrender.Record) string {
 
 	// Trace prefix
 	if rec.Trace != "" {
-		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Render(
+		b.WriteString(lipgloss.NewStyle().Foreground(tui.ColorNeonCyan).Render(
 			fmt.Sprintf("[%s]", rec.Trace),
 		))
 		b.WriteByte(' ')
@@ -451,7 +451,7 @@ func truncate(s string, max int) string {
 func applyLevelTint(level, s string) string {
 	switch level {
 	case "debug":
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render(s)
+		return lipgloss.NewStyle().Foreground(tui.ColorDimGray).Render(s)
 	case "warn":
 		return lipgloss.NewStyle().Foreground(tui.ColorYellow).Render(s)
 	case "error":

--- a/internal/tui/header/model.go
+++ b/internal/tui/header/model.go
@@ -49,7 +49,7 @@ type SpinnerTickMsg struct{}
 // ---------------------------------------------------------------------------
 
 var (
-	headerBg  color.Color = lipgloss.Color("52")  // dark red
+	headerBg  color.Color = lipgloss.Color("23") // deep teal
 	headerFg  color.Color = lipgloss.Color("15")  // white
 	clrGreen  color.Color = lipgloss.Color("2")   // ● complete
 	clrYellow color.Color = lipgloss.Color("3")   // ◐ in_progress
@@ -222,7 +222,8 @@ func (m Model) View() string {
 	}
 
 	version := strings.TrimPrefix(m.version, "v")
-	title := boldStyle.Render(fmt.Sprintf("WOLFCASTLE v%s", version))
+	title := renderGradientTitle("WOLFCASTLE", headerBg) +
+		barStyle.Render(fmt.Sprintf(" v%s", version))
 
 	// Build right side of line 1: optional spinner, daemon status, instance badge.
 	rightParts := []string{}
@@ -355,7 +356,7 @@ func (m Model) renderTabBar(base, bold lipgloss.Style, width int) string {
 
 	activeStyle := lipgloss.NewStyle().
 		Background(headerBg).
-		Foreground(headerFg).
+		Foreground(lipgloss.Color("51")). // neon cyan (matches tui.ColorNeonCyan)
 		Bold(true)
 
 	dotStyle := lipgloss.NewStyle().
@@ -400,6 +401,28 @@ func (m Model) renderTabBar(base, bold lipgloss.Style, width int) string {
 	}
 
 	return composeLine(base, left, right, width)
+}
+
+// renderGradientTitle renders each character of the title with a
+// gradient from neon cyan through magenta to gold, matching the
+// Wolfcastle neon-wolf logo palette.
+func renderGradientTitle(text string, bg color.Color) string {
+	// ANSI 256 colors stepping through cyan → purple → magenta → gold.
+	// 10 stops for "WOLFCASTLE"; interpolated for other lengths.
+	gradient := []string{"51", "44", "135", "170", "205", "211", "214", "220", "220", "226"}
+
+	var b strings.Builder
+	runes := []rune(text)
+	for i, r := range runes {
+		// Map character position to gradient index.
+		idx := i * (len(gradient) - 1) / max(len(runes)-1, 1)
+		style := lipgloss.NewStyle().
+			Background(bg).
+			Foreground(lipgloss.Color(gradient[idx])).
+			Bold(true)
+		b.WriteString(style.Render(string(r)))
+	}
+	return b.String()
 }
 
 // pluralize appends "s" when count != 1.

--- a/internal/tui/header/model.go
+++ b/internal/tui/header/model.go
@@ -49,7 +49,7 @@ type SpinnerTickMsg struct{}
 // ---------------------------------------------------------------------------
 
 var (
-	headerBg  color.Color = lipgloss.Color("23") // deep teal
+	headerBg  color.Color = lipgloss.Color("23")  // deep teal
 	headerFg  color.Color = lipgloss.Color("15")  // white
 	clrGreen  color.Color = lipgloss.Color("2")   // ● complete
 	clrYellow color.Color = lipgloss.Color("3")   // ◐ in_progress

--- a/internal/tui/help/model.go
+++ b/internal/tui/help/model.go
@@ -173,15 +173,21 @@ func (m *Model) buildContent() {
 		},
 	}
 
+	sectionStyle := lipgloss.NewStyle().Foreground(tui.ColorNeonCyan).Bold(true)
+	keyStyle := lipgloss.NewStyle().Foreground(tui.ColorGold)
+	descStyle := lipgloss.NewStyle().Foreground(tui.ColorLightGray)
+
 	var b strings.Builder
 	for i, sec := range sections {
 		if i > 0 {
 			b.WriteString("\n")
 		}
-		b.WriteString(sec.title)
+		b.WriteString(sectionStyle.Render(sec.title))
 		b.WriteString("\n")
 		for _, kb := range sec.bindings {
-			fmt.Fprintf(&b, "  %-12s%s\n", kb.key, kb.desc)
+			b.WriteString(fmt.Sprintf("  %s%s\n",
+				keyStyle.Render(fmt.Sprintf("%-12s", kb.key)),
+				descStyle.Render(kb.desc)))
 		}
 	}
 

--- a/internal/tui/help/model.go
+++ b/internal/tui/help/model.go
@@ -185,9 +185,9 @@ func (m *Model) buildContent() {
 		b.WriteString(sectionStyle.Render(sec.title))
 		b.WriteString("\n")
 		for _, kb := range sec.bindings {
-			b.WriteString(fmt.Sprintf("  %s%s\n",
+			fmt.Fprintf(&b, "  %s%s\n",
 				keyStyle.Render(fmt.Sprintf("%-12s", kb.key)),
-				descStyle.Render(kb.desc)))
+				descStyle.Render(kb.desc))
 		}
 	}
 

--- a/internal/tui/notify/model.go
+++ b/internal/tui/notify/model.go
@@ -8,6 +8,8 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+
+	"github.com/dorkusprime/wolfcastle/internal/tui"
 )
 
 const (
@@ -120,11 +122,11 @@ func (m NotificationModel) View() string {
 	}
 
 	toastStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("15")).
-		Background(lipgloss.Color("236")).
+		Foreground(tui.ColorWhite).
+		Background(tui.ColorCharcoal).
 		BorderLeft(true).
 		BorderStyle(lipgloss.ThickBorder()).
-		BorderForeground(lipgloss.Color("1")).
+		BorderForeground(tui.ColorNeonCyan).
 		PaddingLeft(1).
 		PaddingRight(1).
 		MaxWidth(maxWidth)

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -11,29 +11,51 @@ import (
 	"github.com/dorkusprime/wolfcastle/internal/state"
 )
 
-// Color palette constants
+// Color palette constants.
+//
+// Structural colors carry the brand (neon cyan, magenta, gold, deep blue).
+// Status colors (green, yellow, red, dim) are functional and universal.
+// See docs/agents/design-system.md for the full rationale.
 var (
-	ColorWhite     = lipgloss.Color("15")
-	ColorDimWhite  = lipgloss.Color("245")
-	ColorLightGray = lipgloss.Color("252")
-	ColorDarkGray  = lipgloss.Color("236")
-	ColorDimGray   = lipgloss.Color("240")
-	ColorOverlayBg = lipgloss.Color("235")
-	ColorDarkRed   = lipgloss.Color("52")
-	ColorRed       = lipgloss.Color("1")
-	ColorGreen     = lipgloss.Color("2")
-	ColorYellow    = lipgloss.Color("3")
+	// Text
+	ColorWhite     = lipgloss.Color("15")  // bright: headings, active content
+	ColorDimWhite  = lipgloss.Color("245") // muted: timestamps, hints, footer
+	ColorLightGray = lipgloss.Color("252") // normal: body text, tree labels
+	ColorDimGray   = lipgloss.Color("240") // faint: debug logs, disabled items
+
+	// Brand
+	ColorNeonCyan    = lipgloss.Color("51")  // primary brand: header title, focused border, trace prefix
+	ColorDeepCyan    = lipgloss.Color("30")  // dimmed primary: inactive borders, secondary chrome
+	ColorMagenta     = lipgloss.Color("198") // accent: search match, active selection
+	ColorDeepMagenta = lipgloss.Color("125") // dimmed accent: search ancestor path
+	ColorGold        = lipgloss.Color("220") // target: daemon focus, confirm button, target mark
+
+	// Backgrounds
+	ColorBaseBg    = lipgloss.Color("234") // full-screen base (near-black, ANSI 256 for Terminal.app compat)
+	ColorCharcoal  = lipgloss.Color("234") // header bg, toast bg (barely off-black)
+	ColorSelection = lipgloss.Color("23")  // selected row in tree (dark teal)
+	ColorOverlayBg = lipgloss.Color("235") // modal overlay fill
+	ColorSlate     = lipgloss.Color("236") // neutral dark: dividers, alt-rows
+	ColorDarkRed   = lipgloss.Color("52")  // error bar bg only
+
+	// Status (functional, never decorative)
+	ColorRed    = lipgloss.Color("1") // blocked, error
+	ColorGreen  = lipgloss.Color("2") // complete, passed
+	ColorYellow = lipgloss.Color("3") // in progress, pending
+
+	// Legacy alias (kept for grep-ability during migration)
+	ColorDarkGray = ColorSlate
 )
 
 // Header styles
 var (
 	HeaderStyle = lipgloss.NewStyle().
 			Foreground(ColorWhite).
-			Background(ColorDarkRed)
+			Background(ColorCharcoal)
 
 	HeaderBoldStyle = lipgloss.NewStyle().
-			Foreground(ColorWhite).
-			Background(ColorDarkRed).
+			Foreground(ColorNeonCyan).
+			Background(ColorCharcoal).
 			Bold(true)
 )
 
@@ -41,14 +63,14 @@ var (
 var (
 	TreeSelectedStyle = lipgloss.NewStyle().
 				Foreground(ColorWhite).
-				Background(ColorDarkGray).
+				Background(ColorSelection).
 				Bold(true)
 
 	TreeNormalStyle = lipgloss.NewStyle().
 			Foreground(ColorLightGray)
 
 	TreeSearchHighlight = lipgloss.NewStyle().
-				Background(ColorYellow)
+				Background(ColorMagenta)
 )
 
 // Footer styles
@@ -74,33 +96,38 @@ var (
 // Border styles
 var (
 	FocusedBorderStyle = lipgloss.NewStyle().
+				Background(ColorBaseBg).
 				Border(lipgloss.RoundedBorder()).
-				BorderForeground(ColorRed)
+				BorderForeground(ColorNeonCyan).
+				BorderBackground(ColorBaseBg)
 
 	UnfocusedBorderStyle = lipgloss.NewStyle().
+				Background(ColorBaseBg).
 				Border(lipgloss.RoundedBorder()).
-				BorderForeground(ColorDimGray)
+				BorderForeground(ColorSlate).
+				BorderBackground(ColorBaseBg)
 )
 
 // Spinner style
 var SpinnerStyle = lipgloss.NewStyle().
-	Foreground(ColorYellow)
+	Foreground(ColorNeonCyan)
 
 // Overlay styles (shared by help and modals)
 var (
 	HelpOverlayStyle = lipgloss.NewStyle().
 				Background(ColorOverlayBg).
 				Border(lipgloss.RoundedBorder()).
-				BorderForeground(ColorDimWhite)
+				BorderForeground(ColorDeepCyan).
+				BorderBackground(ColorOverlayBg)
 
 	HelpTitleStyle = lipgloss.NewStyle().
-			Foreground(ColorWhite).
+			Foreground(ColorNeonCyan).
 			Bold(true)
 
 	ModalOverlayStyle = lipgloss.NewStyle().
 				Background(ColorOverlayBg).
 				Border(lipgloss.RoundedBorder()).
-				BorderForeground(ColorDimWhite).
+				BorderForeground(ColorDeepCyan).
 				BorderBackground(ColorOverlayBg)
 
 	ModalTitleStyle = lipgloss.NewStyle().
@@ -114,12 +141,12 @@ var (
 
 	ModalAccentStyle = lipgloss.NewStyle().
 				Background(ColorOverlayBg).
-				Foreground(ColorYellow)
+				Foreground(ColorGold)
 )
 
 // Current target indicator
 var TargetIndicatorStyle = lipgloss.NewStyle().
-	Foreground(ColorYellow).
+	Foreground(ColorGold).
 	Bold(true)
 
 // StatusGlyph pairs a Unicode glyph with its display color.

--- a/internal/tui/tree/render.go
+++ b/internal/tui/tree/render.go
@@ -184,29 +184,6 @@ func renderNodeRow(row Row, width int, selected bool, isCurrentTarget bool, lite
 	return styleNormal.Width(width).Render(colored)
 }
 
-// renderNodeRowWithBg renders a node row with a solid background
-// color (used for both literal-match and ancestor-of-match
-// highlights). The two cases differ only in the bg/fg pair, so the
-// shared layout/padding logic lives here.
-func renderNodeRowWithBg(row Row, width int, indent, marker, name string, isCurrentTarget bool, bgColor, fgColor color.Color) string {
-	bg := lipgloss.NewStyle().Background(bgColor).Foreground(fgColor)
-	var target string
-	if isCurrentTarget {
-		target = bg.Bold(true).Render("▶ ")
-	}
-	glyph := statusGlyphOnBg(row.Status, bgColor)
-	var hint string
-	if row.TaskHint != "" {
-		hint = bg.Render(" " + row.TaskHint)
-	}
-	text := bg.Render(indent+marker+" ") + target + bg.Render(name+" ") + glyph + hint
-	used := lipgloss.Width(text)
-	if used < width {
-		text += bg.Render(strings.Repeat(" ", width-used))
-	}
-	return text
-}
-
 // renderNodeRowWithFg renders a node row with a colored foreground
 // (no background change). Used for search highlighting to avoid
 // the visual clutter of background-colored blocks.
@@ -278,19 +255,6 @@ func renderTaskRow(row Row, width int, selected bool, literalHit, ancestorHit bo
 }
 
 // renderTaskRowWithBg renders a task row with a solid background
-// for both literal-match and ancestor-of-match highlight cases.
-// The two differ only in the bg/fg pair.
-func renderTaskRowWithBg(row Row, width int, indent, taskID, title string, bgColor, fgColor color.Color) string {
-	glyph := taskStatusGlyphOnBg(row.Status, bgColor)
-	bg := lipgloss.NewStyle().Background(bgColor).Foreground(fgColor)
-	text := bg.Render(indent) + glyph + bg.Render(" "+taskID+": "+title)
-	used := lipgloss.Width(text)
-	if used < width {
-		text += bg.Render(strings.Repeat(" ", width-used))
-	}
-	return text
-}
-
 // View renders the visible portion of the tree as a single string.
 func (m Model) View() string {
 	if len(m.flatList) == 0 {

--- a/internal/tui/tree/render.go
+++ b/internal/tui/tree/render.go
@@ -12,19 +12,19 @@ import (
 
 // Colors and styles for the tree view.
 var (
-	colorSelected    = lipgloss.Color("52")  // dark red background (matches header)
+	colorSelected    = lipgloss.Color("23")  // dark teal (selection)
 	colorNormal      = lipgloss.Color("252") // light gray text
 	colorGreen       = lipgloss.Color("2")
 	colorYellow      = lipgloss.Color("3")
 	colorRed         = lipgloss.Color("1")
 	colorDim         = lipgloss.Color("240")
-	colorTargetMark  = lipgloss.Color("11") // bright yellow
-	colorSearchMatch = lipgloss.Color("3")  // yellow background for search hits
+	colorTargetMark  = lipgloss.Color("220") // gold
+	colorSearchMatch = lipgloss.Color("220") // gold foreground for search hits
 	// Muted version of colorSearchMatch used for rows that are on the
 	// path to a hidden literal match. Reads as related-but-secondary
 	// at a glance so the user can follow the trail without confusing
 	// ancestor markers for direct hits.
-	colorSearchAncestor = lipgloss.Color("58") // dark olive
+	colorSearchAncestor = lipgloss.Color("94") // dark gold foreground (muted)
 
 	styleNormal = lipgloss.NewStyle().Foreground(colorNormal)
 )
@@ -55,7 +55,7 @@ func statusGlyphOnBg(s state.NodeStatus, bg color.Color) string {
 	case state.StatusBlocked:
 		return st.Foreground(colorRed).Render("☢")
 	default:
-		return st.Foreground(lipgloss.Color("250")).Render("◯")
+		return st.Foreground(lipgloss.Color("245")).Render("◯")
 	}
 }
 
@@ -135,7 +135,7 @@ func renderNodeRow(row Row, width int, selected bool, isCurrentTarget bool, lite
 	name := truncate(row.Name, maxName)
 
 	if selected {
-		bg := lipgloss.NewStyle().Background(colorSelected).Foreground(lipgloss.Color("255")).Bold(true)
+		bg := lipgloss.NewStyle().Background(colorSelected).Foreground(lipgloss.Color("15")).Bold(true)
 		var target string
 		if isCurrentTarget {
 			target = lipgloss.NewStyle().
@@ -149,7 +149,7 @@ func renderNodeRow(row Row, width int, selected bool, isCurrentTarget bool, lite
 		if row.TaskHint != "" {
 			hint = lipgloss.NewStyle().
 				Background(colorSelected).
-				Foreground(lipgloss.Color("250")).
+				Foreground(lipgloss.Color("245")).
 				Render(" " + row.TaskHint)
 		}
 		text := bg.Render(indent+marker+" ") + target + bg.Render(name+" ") + glyph + hint
@@ -161,11 +161,13 @@ func renderNodeRow(row Row, width int, selected bool, isCurrentTarget bool, lite
 	}
 
 	// Literal match wins over ancestor when both are set.
+	// Search results use foreground color changes (not backgrounds)
+	// to avoid visual clutter from highlighted blocks.
 	if literalHit {
-		return renderNodeRowWithBg(row, width, indent, marker, name, isCurrentTarget, colorSearchMatch, lipgloss.Color("0"))
+		return renderNodeRowWithFg(row, width, indent, marker, name, isCurrentTarget, colorSearchMatch)
 	}
 	if ancestorHit {
-		return renderNodeRowWithBg(row, width, indent, marker, name, isCurrentTarget, colorSearchAncestor, lipgloss.Color("253"))
+		return renderNodeRowWithFg(row, width, indent, marker, name, isCurrentTarget, colorSearchAncestor)
 	}
 
 	// Unselected: apply per-element coloring on top of styleNormal.
@@ -205,6 +207,32 @@ func renderNodeRowWithBg(row Row, width int, indent, marker, name string, isCurr
 	return text
 }
 
+// renderNodeRowWithFg renders a node row with a colored foreground
+// (no background change). Used for search highlighting to avoid
+// the visual clutter of background-colored blocks.
+func renderNodeRowWithFg(row Row, width int, indent, marker, name string, isCurrentTarget bool, fgColor color.Color) string {
+	fg := lipgloss.NewStyle().Foreground(fgColor)
+	var coloredTarget string
+	if isCurrentTarget {
+		coloredTarget = lipgloss.NewStyle().Foreground(colorTargetMark).Bold(true).Render("▶ ")
+	}
+	coloredGlyph := statusGlyph(row.Status)
+	var coloredHint string
+	if row.TaskHint != "" {
+		coloredHint = " " + fg.Render(row.TaskHint)
+	}
+	colored := fmt.Sprintf("%s%s %s%s %s%s", indent, fg.Render(marker), coloredTarget, fg.Bold(true).Render(name), coloredGlyph, coloredHint)
+	return styleNormal.Width(width).Render(colored)
+}
+
+// renderTaskRowWithFg renders a task row with a colored foreground.
+func renderTaskRowWithFg(row Row, width int, indent, taskID, title string, fgColor color.Color) string {
+	fg := lipgloss.NewStyle().Foreground(fgColor)
+	glyph := taskStatusGlyph(row.Status)
+	line := fmt.Sprintf("%s%s %s: %s", indent, glyph, fg.Render(taskID), fg.Bold(true).Render(title))
+	return styleNormal.Width(width).Render(line)
+}
+
 func renderTaskRow(row Row, width int, selected bool, literalHit, ancestorHit bool) string {
 	indent := strings.Repeat("  ", row.Depth)
 
@@ -228,7 +256,7 @@ func renderTaskRow(row Row, width int, selected bool, literalHit, ancestorHit bo
 		// the wolfcastle status screen.
 		glyph := taskStatusGlyphOnBg(row.Status, colorSelected)
 		// Build the line: pad before/after glyph with the selected background.
-		bg := lipgloss.NewStyle().Background(colorSelected).Foreground(lipgloss.Color("255")).Bold(true)
+		bg := lipgloss.NewStyle().Background(colorSelected).Foreground(lipgloss.Color("15")).Bold(true)
 		text := bg.Render(indent) + glyph + bg.Render(" "+taskID+": "+title)
 		// Fill remaining width with selected background.
 		used := lipgloss.Width(text)
@@ -237,12 +265,11 @@ func renderTaskRow(row Row, width int, selected bool, literalHit, ancestorHit bo
 		}
 		return text
 	}
-	// Literal match wins over ancestor when both are set.
 	if literalHit {
-		return renderTaskRowWithBg(row, width, indent, taskID, title, colorSearchMatch, lipgloss.Color("0"))
+		return renderTaskRowWithFg(row, width, indent, taskID, title, colorSearchMatch)
 	}
 	if ancestorHit {
-		return renderTaskRowWithBg(row, width, indent, taskID, title, colorSearchAncestor, lipgloss.Color("253"))
+		return renderTaskRowWithFg(row, width, indent, taskID, title, colorSearchAncestor)
 	}
 
 	glyph := taskStatusGlyph(row.Status)

--- a/internal/tui/welcome/model.go
+++ b/internal/tui/welcome/model.go
@@ -339,9 +339,9 @@ func (m *Model) scrollIntoCursor() {
 // ---------------------------------------------------------------------------
 // View renders the welcome screen with session and directory panels.
 func (m Model) View() string {
-	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(tui.ColorWhite)
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(tui.ColorNeonCyan)
 	subtitleStyle := lipgloss.NewStyle().Foreground(tui.ColorDimWhite)
-	spinnerStyle := lipgloss.NewStyle().Foreground(tui.ColorYellow)
+	spinnerStyle := lipgloss.NewStyle().Foreground(tui.ColorNeonCyan)
 
 	var b strings.Builder
 
@@ -366,8 +366,10 @@ func (m Model) View() string {
 	}
 
 	panelBase := lipgloss.NewStyle().
+		Background(tui.ColorBaseBg).
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(tui.ColorDimGray).
+		BorderForeground(tui.ColorDeepCyan).
+		BorderBackground(tui.ColorBaseBg).
 		Padding(0, 1).
 		Width(innerWidth)
 
@@ -375,7 +377,7 @@ func (m Model) View() string {
 	if len(m.instances) > 0 {
 		sessionsStyle := panelBase
 		if m.focus == panelSessions {
-			sessionsStyle = sessionsStyle.BorderForeground(tui.ColorRed)
+			sessionsStyle = sessionsStyle.BorderForeground(tui.ColorNeonCyan)
 		}
 		b.WriteString(sessionsStyle.Render(m.renderSessions()))
 		b.WriteString("\n")
@@ -384,7 +386,7 @@ func (m Model) View() string {
 	// Directory browser panel
 	dirStyle := panelBase
 	if m.focus == panelDirs {
-		dirStyle = dirStyle.BorderForeground(tui.ColorRed)
+		dirStyle = dirStyle.BorderForeground(tui.ColorNeonCyan)
 	}
 	b.WriteString(dirStyle.Render(m.renderDirBrowser()))
 
@@ -407,7 +409,7 @@ func (m Model) View() string {
 
 func (m Model) renderSessions() string {
 	headingStyle := lipgloss.NewStyle().Bold(true).Foreground(tui.ColorWhite)
-	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(tui.ColorWhite).Background(tui.ColorDarkGray)
+	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(tui.ColorWhite).Background(tui.ColorSelection)
 	normalStyle := lipgloss.NewStyle().Foreground(tui.ColorLightGray)
 	dimStyle := lipgloss.NewStyle().Foreground(tui.ColorDimWhite)
 	activeMarker := lipgloss.NewStyle().Foreground(tui.ColorGreen).Render("●")
@@ -443,7 +445,7 @@ func (m Model) renderSessions() string {
 func (m Model) renderDirBrowser() string {
 	headingStyle := lipgloss.NewStyle().Bold(true).Foreground(tui.ColorWhite)
 	subtitleStyle := lipgloss.NewStyle().Foreground(tui.ColorDimWhite)
-	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(tui.ColorWhite).Background(tui.ColorDarkGray)
+	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(tui.ColorWhite).Background(tui.ColorSelection)
 	normalStyle := lipgloss.NewStyle().Foreground(tui.ColorLightGray)
 	pathStyle := lipgloss.NewStyle().Foreground(tui.ColorWhite).Bold(true)
 	dimStyle := lipgloss.NewStyle().Foreground(tui.ColorDimWhite)


### PR DESCRIPTION
## Summary

New color palette derived from the neon-wolf logo. Gradient title, cyan/magenta/gold brand colors, near-black base background for light-terminal compat.

- **Header**: deep teal bg, gradient "WOLFCASTLE" (cyan → purple → magenta → gold)
- **Borders**: cyan focused, slate unfocused
- **Selection**: dark teal rows instead of red
- **Search**: gold foreground for matches, dark gold for ancestors
- **Spinner/toasts/traces**: neon cyan
- **Help overlay**: cyan section titles, gold key hints
- **Welcome screen**: cyan title, cyan spinner, design-system-consistent panels
- **Base background**: ANSI 234 fills alt-screen via cell-level canvas
- **Design system doc**: `docs/agents/design-system.md` with full palette, component specs, and Terminal.app limitations

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/tui/...` (all 11 packages pass)
- [x] Manual: tested in iTerm2 (perfect) and Terminal.app (functional, documented BCE stripe limitation)