### PR TITLE
v0.6.5: welcome screen opens existing projects from dir browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.5
+
+### Bug Fixes
+- Welcome screen: pressing Enter on a subdirectory that already contains `.wolfcastle` now opens a session there instead of descending into its filesystem. Enter on the `.wolfcastle` entry itself opens the current directory as a project. Both paths route through the existing init-is-a-no-op branch, so the app/tab wiring stays in one place.
+- Project directories in the welcome browser are badged with a gold `◆` and their selected-row hint reads `[Enter to open]`, so a fresh-start user browsing the filesystem can spot and open existing projects without guessing.
+
 ## 0.6.4
 
 ### Features

--- a/internal/tui/welcome/model.go
+++ b/internal/tui/welcome/model.go
@@ -241,10 +241,20 @@ func (m Model) handleEnter(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 	if m.dirCursor >= 0 && m.dirCursor < len(m.entries) {
 		entry := m.entries[m.dirCursor]
 		if entry.Name() == ".wolfcastle" {
-			// .wolfcastle is not navigable. Use I to init.
-			return m, nil
+			// Opening the .wolfcastle entry itself opens a session
+			// rooted at the current directory. startInit's runInit
+			// detects the existing scaffold and resolves as an
+			// immediate success, which routes through the same
+			// InitCompleteMsg handler the fresh-init path uses.
+			return m.startInit()
 		}
 		child := filepath.Join(m.currentDir, entry.Name())
+		// If the child is already a wolfcastle project, open a
+		// session there instead of descending into its filesystem.
+		if hasWolfcastle(child) {
+			m.currentDir = child
+			return m.startInit()
+		}
 		m.currentDir = child
 		m.dirCursor = 0
 		m.scrollTop = 0
@@ -253,6 +263,12 @@ func (m Model) handleEnter(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 	}
 
 	return m, nil
+}
+
+// hasWolfcastle reports whether dir contains a .wolfcastle directory.
+func hasWolfcastle(dir string) bool {
+	info, err := os.Stat(filepath.Join(dir, ".wolfcastle"))
+	return err == nil && info.IsDir()
 }
 
 func (m Model) startInit() (Model, tea.Cmd) {
@@ -472,10 +488,12 @@ func (m Model) renderDirBrowser() string {
 			b.WriteString("\n")
 		}
 
+		projectStyle := lipgloss.NewStyle().Foreground(tui.ColorGold)
 		for i, entry := range visible {
 			idx := m.scrollTop + i
 			isLast := idx == len(m.entries)-1
 			name := entry.Name()
+			isProject := entry.Name() != ".wolfcastle" && hasWolfcastle(filepath.Join(m.currentDir, name))
 
 			connector := "├── "
 			if isLast {
@@ -486,12 +504,23 @@ func (m Model) renderDirBrowser() string {
 				marker := pathStyle.Render("▸ ")
 				dirName := selectedStyle.Render(name + "/")
 				hint := ""
-				if name == ".wolfcastle" {
-					hint = subtitleStyle.Render("  [Enter to init]")
+				switch {
+				case name == ".wolfcastle":
+					hint = subtitleStyle.Render("  [Enter to open]")
+				case isProject:
+					hint = subtitleStyle.Render("  [Enter to open]")
 				}
 				b.WriteString(connectorStyle.Render(connector) + marker + dirName + hint)
 			} else {
-				b.WriteString(connectorStyle.Render(connector) + normalStyle.Render(name+"/"))
+				style := normalStyle
+				if isProject {
+					style = projectStyle
+				}
+				suffix := ""
+				if isProject {
+					suffix = subtitleStyle.Render(" ◆")
+				}
+				b.WriteString(connectorStyle.Render(connector) + style.Render(name+"/") + suffix)
 			}
 			b.WriteString("\n")
 		}

--- a/internal/tui/welcome/model_test.go
+++ b/internal/tui/welcome/model_test.go
@@ -227,7 +227,7 @@ func TestInitKey_StartsInitInCurrentDir(t *testing.T) {
 	}
 }
 
-func TestEnterOnDotWolfcastle_DoesNotInit(t *testing.T) {
+func TestEnterOnDotWolfcastle_OpensCurrentDir(t *testing.T) {
 	dir := setupTestDir(t, ".wolfcastle")
 
 	m := NewModel(dir, nil)
@@ -238,9 +238,63 @@ func TestEnterOnDotWolfcastle_DoesNotInit(t *testing.T) {
 		}
 	}
 
+	m, cmd := m.Update(enterKey())
+	if !m.initializing {
+		t.Fatal("Enter on .wolfcastle should open a session (via init no-op) in the current dir")
+	}
+	if cmd == nil {
+		t.Fatal("expected a command to kick off the open sequence")
+	}
+}
+
+func TestEnterOnProjectDir_OpensThatDir(t *testing.T) {
+	parent := t.TempDir()
+	child := filepath.Join(parent, "my-project")
+	if err := os.MkdirAll(filepath.Join(child, ".wolfcastle"), 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	m := NewModel(parent, nil)
+	for i, e := range m.entries {
+		if e.Name() == "my-project" {
+			m.dirCursor = i
+			break
+		}
+	}
+
+	m, cmd := m.Update(enterKey())
+	if !m.initializing {
+		t.Fatal("Enter on a project dir should open a session")
+	}
+	if m.currentDir != child {
+		t.Fatalf("currentDir should move into the project, got %q", m.currentDir)
+	}
+	if cmd == nil {
+		t.Fatal("expected a command")
+	}
+}
+
+func TestEnterOnNonProjectDir_Descends(t *testing.T) {
+	parent := t.TempDir()
+	child := filepath.Join(parent, "plain")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	m := NewModel(parent, nil)
+	for i, e := range m.entries {
+		if e.Name() == "plain" {
+			m.dirCursor = i
+			break
+		}
+	}
+
 	m, _ = m.Update(enterKey())
 	if m.initializing {
-		t.Fatal("Enter on .wolfcastle should not trigger init, use I")
+		t.Fatal("Enter on a non-project dir should descend, not init")
+	}
+	if m.currentDir != child {
+		t.Fatalf("currentDir should descend into child, got %q", m.currentDir)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Enter on a directory containing \`.wolfcastle\` now opens a session there instead of descending.
- Enter on the \`.wolfcastle\` entry itself opens the current directory as a project (used to no-op).
- Project dirs in the browser are badged with a gold \`◆\` suffix and tinted gold; selected-row hint reads \`[Enter to open]\`.

## Test plan
- [x] \`go test ./...\`
- [x] New tests: \`TestEnterOnDotWolfcastle_OpensCurrentDir\`, \`TestEnterOnProjectDir_OpensThatDir\`, \`TestEnterOnNonProjectDir_Descends\`.
- [ ] Manual: open wolfcastle from a cold directory, browse into a sibling project, confirm Enter opens it.