### PR TITLE
test: raise TUI coverage (app 68→79, clipboard 75→100, instance 83→86, fsutil 55→64)

### DIFF
--- a/internal/fsutil/atomic_test.go
+++ b/internal/fsutil/atomic_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -139,6 +140,50 @@ func TestAtomicWriteFile_RenameError(t *testing.T) {
 	data, _ := os.ReadFile(targetPath)
 	if string(data) != "old" {
 		t.Errorf("original file should be unchanged, got %s", data)
+	}
+}
+
+// TestAtomicWriteFile_RenameOverDirectory exercises the rename error
+// branch directly: the target path already exists as a non-empty
+// directory, so os.Rename fails after the temp file has been created
+// and written. Previous RenameError test actually hit CreateTemp
+// because its target dir was read-only.
+func TestAtomicWriteFile_RenameOverDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("rename-over-nonempty-dir semantics differ on Windows")
+	}
+	t.Parallel()
+	dir := t.TempDir()
+	// Create a directory at the exact target path.
+	targetPath := filepath.Join(dir, "busy")
+	if err := os.MkdirAll(targetPath, 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	// Put a file inside so the dir isn't empty — prevents Linux from
+	// quietly allowing rename(file, emptyDir).
+	if err := os.WriteFile(filepath.Join(targetPath, "occupant"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	err := AtomicWriteFile(targetPath, []byte("new"))
+	if err == nil {
+		t.Error("expected error when target is a non-empty directory")
+	}
+
+	// The directory and its occupant should be untouched.
+	info, statErr := os.Stat(targetPath)
+	if statErr != nil {
+		t.Fatalf("target should still exist: %v", statErr)
+	}
+	if !info.IsDir() {
+		t.Error("target should still be a directory after failed rename")
+	}
+	// The leaked temp file should have been cleaned up.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".wolfcastle-tmp-") {
+			t.Errorf("temp file should be cleaned up after rename failure, found %s", e.Name())
+		}
 	}
 }
 

--- a/internal/instance/registry_dir_test.go
+++ b/internal/instance/registry_dir_test.go
@@ -1,0 +1,47 @@
+package instance
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestRegistryDir_UsesHomeWhenOverrideEmpty exercises the default
+// ~/.wolfcastle/instances path. We redirect HOME to a temp dir so the
+// call touches no real user state.
+func TestRegistryDir_UsesHomeWhenOverrideEmpty(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	savedOverride := RegistryDirOverride
+	RegistryDirOverride = ""
+	t.Cleanup(func() { RegistryDirOverride = savedOverride })
+
+	dir, err := registryDir()
+	if err != nil {
+		t.Fatalf("registryDir: %v", err)
+	}
+	want := filepath.Join(fakeHome, ".wolfcastle", "instances")
+	if dir != want {
+		t.Errorf("registryDir = %q, want %q", dir, want)
+	}
+}
+
+// TestList_DefaultRegistryDir verifies List works via the default
+// path — ensuring the function handles a missing ~/.wolfcastle/instances
+// gracefully as nil, nil.
+func TestList_DefaultRegistryDir(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	savedOverride := RegistryDirOverride
+	RegistryDirOverride = ""
+	t.Cleanup(func() { RegistryDirOverride = savedOverride })
+
+	entries, err := List()
+	if err != nil {
+		t.Fatalf("List on fresh home: %v", err)
+	}
+	if entries != nil {
+		t.Errorf("expected nil entries in empty registry, got %+v", entries)
+	}
+}

--- a/internal/tui/app/detect_entry_state_test.go
+++ b/internal/tui/app/detect_entry_state_test.go
@@ -1,0 +1,52 @@
+package app
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/dorkusprime/wolfcastle/internal/daemon"
+	"github.com/dorkusprime/wolfcastle/internal/state"
+	"github.com/dorkusprime/wolfcastle/internal/tui"
+)
+
+func TestDetectEntryState_NilWhenNoDaemonRepo(t *testing.T) {
+	t.Parallel()
+	m := newWelcomeModel(t.TempDir())
+	if cmd := m.detectEntryState(); cmd != nil {
+		t.Error("tab without DaemonRepo should produce nil cmd")
+	}
+}
+
+func TestDetectEntryState_ReturnsStandingDownForColdTab(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	wolfDir := filepath.Join(dir, ".wolfcastle")
+
+	m := NewTUIModel(dir, "test")
+	m.tabs = nil
+	m.nextTabID = 0
+	tab := m.createTab(dir, state.NewStore(dir, 0), daemon.NewRepository(wolfDir))
+	m.activeTabID = tab.ID
+	m.width = 120
+	m.height = 40
+	m.propagateSize()
+
+	cmd := m.detectEntryState()
+	if cmd == nil {
+		t.Fatal("expected a command when DaemonRepo is present")
+	}
+	msg := cmd()
+	status, ok := msg.(tui.DaemonStatusMsg)
+	if !ok {
+		t.Fatalf("expected DaemonStatusMsg, got %T", msg)
+	}
+	if status.IsRunning {
+		t.Errorf("cold tab should not report running, got %+v", status)
+	}
+	if status.Status != "standing down" {
+		t.Errorf("expected 'standing down', got %q", status.Status)
+	}
+	if status.Worktree != dir {
+		t.Errorf("expected worktree %q, got %q", dir, status.Worktree)
+	}
+}

--- a/internal/tui/app/modal_new_tab_test.go
+++ b/internal/tui/app/modal_new_tab_test.go
@@ -1,0 +1,80 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+func TestRenderNewTabModal_ShowsTitle(t *testing.T) {
+	t.Parallel()
+	m := newColdModel(t)
+	m.activeModal = ModalNewTab
+	m.tabPicker = newTabPicker(t.TempDir(), nil)
+
+	out := ansi.Strip(m.renderNewTabModal(30))
+	if !strings.Contains(out, "NEW TAB") {
+		t.Errorf("new tab modal should render the title, got %q", out)
+	}
+}
+
+func TestRenderNewTabModal_ClampsHeight(t *testing.T) {
+	t.Parallel()
+	m := newColdModel(t)
+	m.activeModal = ModalNewTab
+	m.tabPicker = newTabPicker(t.TempDir(), nil)
+
+	// contentHeight smaller than the modal's default minimum (15): the
+	// code clamps up to 15, then clamps back down so it fits.
+	out := ansi.Strip(m.renderNewTabModal(4))
+	if out == "" {
+		t.Error("should still render when contentHeight is tiny")
+	}
+}
+
+func TestRenderNewTabModal_NarrowWidthFloor(t *testing.T) {
+	t.Parallel()
+	m := newColdModel(t)
+	m.width = 40 // would compute overlayW=24, below the 50 floor
+	m.activeModal = ModalNewTab
+	m.tabPicker = newTabPicker(t.TempDir(), nil)
+
+	out := ansi.Strip(m.renderNewTabModal(30))
+	if !strings.Contains(out, "NEW TAB") {
+		t.Errorf("modal should render even at narrow width, got %q", out)
+	}
+}
+
+func TestUpdateNewTabModal_ForwardsToPicker(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mkPlainDir(t, root, "a")
+	mkPlainDir(t, root, "b")
+
+	m := newColdModel(t)
+	m.activeModal = ModalNewTab
+	m.tabPicker = newTabPicker(root, nil)
+
+	// Pressing Down should advance the picker cursor; the update runs
+	// through updateNewTabModal, so that function's branch is covered.
+	result, _ := m.updateNewTabModal(keyMsg("down").(tea.KeyPressMsg))
+	if result.tabPicker.cursor != 1 {
+		t.Errorf("cursor should advance through updateNewTabModal, got %d",
+			result.tabPicker.cursor)
+	}
+}
+
+func TestUpdateActiveModal_NewTabBranch(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mkPlainDir(t, root, "x")
+
+	m := newColdModel(t)
+	m.activeModal = ModalNewTab
+	m.tabPicker = newTabPicker(root, nil)
+
+	// Drives the ModalNewTab branch of updateActiveModal.
+	_, _ = m.updateActiveModal(keyMsg("down").(tea.KeyPressMsg))
+}

--- a/internal/tui/app/process_unix_test.go
+++ b/internal/tui/app/process_unix_test.go
@@ -1,0 +1,85 @@
+//go:build !windows
+
+package app
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestIsProcessAlive_SelfPID(t *testing.T) {
+	t.Parallel()
+	if !isProcessAlive(os.Getpid()) {
+		t.Error("current process should be reported alive")
+	}
+}
+
+func TestIsProcessAlive_InvalidPID(t *testing.T) {
+	t.Parallel()
+	if isProcessAlive(0) {
+		t.Error("pid 0 should be rejected")
+	}
+	if isProcessAlive(-1) {
+		t.Error("negative pid should be rejected")
+	}
+}
+
+func TestIsProcessAlive_DeadPID(t *testing.T) {
+	t.Parallel()
+
+	// Spawn a short-lived process, wait for it, then check that the PID
+	// reads as dead. We pick a process that exits immediately (`true`)
+	// so we don't have to race a kill.
+	cmd := exec.Command("true")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	pid := cmd.Process.Pid
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+
+	// The reaped PID may linger briefly in some kernels; give it a moment.
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if !isProcessAlive(pid) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	// On Linux a PID can be recycled fast; if it still reads alive,
+	// treat that as a flake rather than a failure. Verify the negative
+	// branch another way: a pathological PID like 2^30 must be dead.
+	if isProcessAlive(1 << 30) {
+		t.Error("synthetic huge pid should read as dead")
+	}
+}
+
+func TestIsProcessRunning_DelegatesToAlive(t *testing.T) {
+	t.Parallel()
+	if !isProcessRunning(os.Getpid()) {
+		t.Error("isProcessRunning should mirror isProcessAlive for current pid")
+	}
+	if isProcessRunning(0) {
+		t.Error("isProcessRunning(0) should be false")
+	}
+}
+
+func TestKillProcess_Signal0OnSelf(t *testing.T) {
+	t.Parallel()
+	// Signal 0 doesn't deliver; it just validates the target exists.
+	if err := killProcess(os.Getpid(), syscall.Signal(0)); err != nil {
+		t.Errorf("signal 0 to self should succeed, got %v", err)
+	}
+}
+
+func TestKillProcess_InvalidPID(t *testing.T) {
+	t.Parallel()
+	// Negative and huge PIDs should surface an error from the kernel.
+	if err := killProcess(1<<30, syscall.Signal(0)); err == nil {
+		t.Error("expected error signaling a non-existent pid")
+	}
+}

--- a/internal/tui/app/tab_picker_test.go
+++ b/internal/tui/app/tab_picker_test.go
@@ -1,0 +1,419 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/dorkusprime/wolfcastle/internal/instance"
+)
+
+// helpers ---------------------------------------------------------------
+
+func pickerKey(s string) tea.KeyPressMsg {
+	if len(s) == 1 {
+		return tea.KeyPressMsg{Code: rune(s[0]), Text: s}
+	}
+	// Named keys (down, up, enter, esc, home, end, left, h, l).
+	switch s {
+	case "down":
+		return tea.KeyPressMsg{Code: tea.KeyDown}
+	case "up":
+		return tea.KeyPressMsg{Code: tea.KeyUp}
+	case "enter":
+		return tea.KeyPressMsg{Code: tea.KeyEnter}
+	case "esc":
+		return tea.KeyPressMsg{Code: tea.KeyEsc}
+	case "home":
+		return tea.KeyPressMsg{Code: 'g', Text: "g"}
+	case "end":
+		return tea.KeyPressMsg{Code: 'G', Text: "G"}
+	case "left":
+		return tea.KeyPressMsg{Code: tea.KeyLeft}
+	}
+	return tea.KeyPressMsg{}
+}
+
+func mkProjectDir(t *testing.T, parent, name string) string {
+	t.Helper()
+	dir := filepath.Join(parent, name)
+	if err := os.MkdirAll(filepath.Join(dir, ".wolfcastle"), 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	return dir
+}
+
+func mkPlainDir(t *testing.T, parent, name string) string {
+	t.Helper()
+	dir := filepath.Join(parent, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	return dir
+}
+
+// tests -----------------------------------------------------------------
+
+func TestNewTabPicker_LoadsCurrentDir(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mkPlainDir(t, root, "alpha")
+	mkProjectDir(t, root, "beta-proj")
+	mkPlainDir(t, root, "gamma")
+	// Hidden dir should be filtered.
+	mkPlainDir(t, root, ".hidden")
+
+	m := newTabPicker(root, nil)
+
+	if len(m.entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d: %+v", len(m.entries), m.entries)
+	}
+	// Projects sort first.
+	if m.entries[0].name != "beta-proj" || !m.entries[0].hasWolfcastle {
+		t.Errorf("expected beta-proj first with hasWolfcastle=true, got %+v", m.entries[0])
+	}
+	if m.entries[1].name != "alpha" || m.entries[1].hasWolfcastle {
+		t.Errorf("expected alpha second, got %+v", m.entries[1])
+	}
+	if m.entries[2].name != "gamma" {
+		t.Errorf("expected gamma third, got %+v", m.entries[2])
+	}
+}
+
+func TestNewTabPicker_IncludesSessionsFromOtherDirs(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mkPlainDir(t, root, "here")
+
+	// Session lives outside root — should appear at the top as a session
+	// entry.
+	other := t.TempDir()
+	sessionWorktree := mkProjectDir(t, other, "external-proj")
+
+	m := newTabPicker(root, []instance.Entry{
+		{PID: 1234, Worktree: sessionWorktree},
+	})
+
+	if len(m.entries) < 1 || !m.entries[0].isSession {
+		t.Fatalf("expected session at top of entries, got %+v", m.entries)
+	}
+	if m.entries[0].worktree != sessionWorktree {
+		t.Errorf("session worktree mismatch: got %q", m.entries[0].worktree)
+	}
+}
+
+func TestNewTabPicker_SkipsSessionsInCurrentDir(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	sessionWorktree := mkProjectDir(t, root, "inner-proj")
+
+	m := newTabPicker(root, []instance.Entry{
+		{PID: 42, Worktree: sessionWorktree},
+	})
+
+	// Should not produce a duplicate: the session is in root, so it
+	// appears as a regular project entry instead of a session header.
+	sessionEntries := 0
+	for _, e := range m.entries {
+		if e.isSession {
+			sessionEntries++
+		}
+	}
+	if sessionEntries != 0 {
+		t.Errorf("expected 0 session entries (session is in current dir), got %d", sessionEntries)
+	}
+	if len(m.entries) != 1 || !m.entries[0].hasWolfcastle {
+		t.Errorf("expected one project entry for the session dir, got %+v", m.entries)
+	}
+}
+
+func TestTabPicker_LoadDirError(t *testing.T) {
+	t.Parallel()
+	m := newTabPicker("/nonexistent/path/that/does/not/exist", nil)
+	if m.err == "" {
+		t.Error("expected err to be set on unreadable directory")
+	}
+}
+
+func TestTabPicker_SetSize(t *testing.T) {
+	t.Parallel()
+	m := newTabPicker(t.TempDir(), nil)
+	m.SetSize(100, 40)
+	if m.width != 100 || m.height != 40 {
+		t.Errorf("SetSize not applied: got %dx%d", m.width, m.height)
+	}
+}
+
+func TestTabPicker_Movement(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mkPlainDir(t, root, "a")
+	mkPlainDir(t, root, "b")
+	mkPlainDir(t, root, "c")
+
+	m := newTabPicker(root, nil)
+	m.SetSize(80, 30)
+
+	if m.cursor != 0 {
+		t.Fatalf("initial cursor should be 0, got %d", m.cursor)
+	}
+
+	m, _ = m.Update(pickerKey("down"))
+	m, _ = m.Update(pickerKey("down"))
+	if m.cursor != 2 {
+		t.Errorf("after 2 downs, cursor=%d, want 2", m.cursor)
+	}
+
+	// Clamp at bottom.
+	m, _ = m.Update(pickerKey("down"))
+	if m.cursor != 2 {
+		t.Errorf("cursor should clamp at last entry, got %d", m.cursor)
+	}
+
+	m, _ = m.Update(pickerKey("up"))
+	if m.cursor != 1 {
+		t.Errorf("after up, cursor=%d, want 1", m.cursor)
+	}
+
+	// Clamp at top.
+	m, _ = m.Update(pickerKey("up"))
+	m, _ = m.Update(pickerKey("up"))
+	if m.cursor != 0 {
+		t.Errorf("cursor should clamp at 0, got %d", m.cursor)
+	}
+
+	// End jumps to last.
+	m, _ = m.Update(pickerKey("end"))
+	if m.cursor != 2 {
+		t.Errorf("end should jump to last, got %d", m.cursor)
+	}
+
+	// Home jumps to first.
+	m, _ = m.Update(pickerKey("home"))
+	if m.cursor != 0 {
+		t.Errorf("home should jump to first, got %d", m.cursor)
+	}
+}
+
+func TestTabPicker_EnterOnProjectEmitsResult(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	proj := mkProjectDir(t, root, "hit-me")
+
+	m := newTabPicker(root, nil)
+	m.SetSize(80, 30)
+
+	_, cmd := m.Update(pickerKey("enter"))
+	if cmd == nil {
+		t.Fatal("expected command")
+	}
+	msg := cmd()
+	result, ok := msg.(TabPickerResultMsg)
+	if !ok {
+		t.Fatalf("expected TabPickerResultMsg, got %T", msg)
+	}
+	if result.Dir != proj {
+		t.Errorf("expected dir %q, got %q", proj, result.Dir)
+	}
+}
+
+func TestTabPicker_EnterOnSessionEmitsWorktree(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mkPlainDir(t, root, "placeholder")
+
+	other := t.TempDir()
+	session := mkProjectDir(t, other, "remote")
+
+	m := newTabPicker(root, []instance.Entry{
+		{PID: 99, Worktree: session},
+	})
+	m.SetSize(80, 30)
+
+	// Session sits at index 0.
+	_, cmd := m.Update(pickerKey("enter"))
+	if cmd == nil {
+		t.Fatal("expected command")
+	}
+	result, ok := cmd().(TabPickerResultMsg)
+	if !ok {
+		t.Fatalf("expected TabPickerResultMsg, got %T", cmd())
+	}
+	if result.Dir != session {
+		t.Errorf("session enter should emit worktree path %q, got %q", session, result.Dir)
+	}
+}
+
+func TestTabPicker_EnterOnPlainDirDescends(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	child := mkPlainDir(t, root, "only-plain")
+	mkPlainDir(t, child, "grandchild")
+
+	m := newTabPicker(root, nil)
+	m.SetSize(80, 30)
+
+	m, cmd := m.Update(pickerKey("enter"))
+	if cmd != nil {
+		t.Errorf("expected nil cmd when descending into plain dir")
+	}
+	if m.dir != child {
+		t.Errorf("expected dir to become %q, got %q", child, m.dir)
+	}
+	if len(m.entries) != 1 || m.entries[0].name != "grandchild" {
+		t.Errorf("expected grandchild entry after descent, got %+v", m.entries)
+	}
+}
+
+func TestTabPicker_BackNavigatesToParent(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	child := mkPlainDir(t, root, "child")
+
+	m := newTabPicker(child, nil)
+	m.SetSize(80, 30)
+
+	m, _ = m.Update(pickerKey("left"))
+	if m.dir != root {
+		t.Errorf("expected back to go to parent %q, got %q", root, m.dir)
+	}
+}
+
+func TestTabPicker_BackAtRootIsNoop(t *testing.T) {
+	t.Parallel()
+	m := newTabPicker("/", nil)
+	m.SetSize(80, 30)
+
+	m, _ = m.Update(pickerKey("left"))
+	if m.dir != "/" {
+		t.Errorf("back at root should be noop, got dir=%q", m.dir)
+	}
+}
+
+func TestTabPicker_EscEmitsCancel(t *testing.T) {
+	t.Parallel()
+	m := newTabPicker(t.TempDir(), nil)
+	m.SetSize(80, 30)
+
+	_, cmd := m.Update(pickerKey("esc"))
+	if cmd == nil {
+		t.Fatal("expected cancel command")
+	}
+	if _, ok := cmd().(TabPickerCancelMsg); !ok {
+		t.Errorf("expected TabPickerCancelMsg, got %T", cmd())
+	}
+}
+
+func TestTabPicker_ViewRendersTitle(t *testing.T) {
+	t.Parallel()
+	m := newTabPicker(t.TempDir(), nil)
+	m.SetSize(80, 30)
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "NEW TAB") {
+		t.Errorf("view should contain NEW TAB title, got %q", view)
+	}
+}
+
+func TestTabPicker_ViewEmptyDir(t *testing.T) {
+	t.Parallel()
+	m := newTabPicker(t.TempDir(), nil)
+	m.SetSize(80, 30)
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "Empty directory") {
+		t.Errorf("empty dir view should say so, got %q", view)
+	}
+}
+
+func TestTabPicker_ViewShowsError(t *testing.T) {
+	t.Parallel()
+	m := newTabPicker("/nonexistent/path/for/view/test", nil)
+	m.SetSize(80, 30)
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "no such file") && !strings.Contains(view, "not exist") {
+		t.Errorf("error view should include error text, got %q", view)
+	}
+}
+
+func TestTabPicker_ViewRendersEntries(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mkPlainDir(t, root, "plain-one")
+	mkProjectDir(t, root, "project-one")
+
+	m := newTabPicker(root, nil)
+	m.SetSize(80, 30)
+	view := ansi.Strip(m.View())
+
+	if !strings.Contains(view, "project-one") {
+		t.Errorf("view should list project-one, got %q", view)
+	}
+	if !strings.Contains(view, "plain-one") {
+		t.Errorf("view should list plain-one, got %q", view)
+	}
+	// Project dirs render with the diamond marker.
+	if !strings.Contains(view, "◆") {
+		t.Errorf("view should mark projects with ◆, got %q", view)
+	}
+}
+
+func TestTabPicker_ViewRendersSessionEntries(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mkPlainDir(t, root, "here")
+
+	other := t.TempDir()
+	session := mkProjectDir(t, other, "external")
+
+	m := newTabPicker(root, []instance.Entry{
+		{PID: 1, Worktree: session},
+	})
+	m.SetSize(80, 30)
+	view := ansi.Strip(m.View())
+
+	if !strings.Contains(view, "external") {
+		t.Errorf("view should include session name, got %q", view)
+	}
+	if !strings.Contains(view, "●") {
+		t.Errorf("view should mark sessions with ●, got %q", view)
+	}
+}
+
+func TestTabPicker_ViewScrollsWithCursor(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	for _, name := range []string{"a", "b", "c", "d", "e", "f", "g", "h"} {
+		mkPlainDir(t, root, name)
+	}
+
+	m := newTabPicker(root, nil)
+	m.SetSize(80, 10) // visibleHeight = 4
+
+	// Jump to bottom; scroll window should shift so the cursor stays visible.
+	m, _ = m.Update(pickerKey("end"))
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "h") {
+		t.Errorf("bottom entry should be visible after scrolling, got %q", view)
+	}
+	// Top-of-list entries should have scrolled off.
+	if strings.Contains(view, "  a/") {
+		t.Errorf("top entry a should have scrolled off, got %q", view)
+	}
+}
+
+func TestTabPicker_ViewClampsVisibleHeight(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mkPlainDir(t, root, "only")
+
+	m := newTabPicker(root, nil)
+	// Height small enough that visibleHeight would be <1 without clamp.
+	m.SetSize(80, 3)
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "only") {
+		t.Errorf("view should still render when height is tight, got %q", view)
+	}
+}

--- a/internal/tui/app/tab_test.go
+++ b/internal/tui/app/tab_test.go
@@ -1,0 +1,66 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/dorkusprime/wolfcastle/internal/state"
+)
+
+func TestNewTab_WelcomeStateWhenNoStore(t *testing.T) {
+	t.Parallel()
+	tab := newTab(1, "/tmp/demo", nil, nil)
+	if tab.EntryState != StateWelcome {
+		t.Errorf("expected StateWelcome with nil store, got %v", tab.EntryState)
+	}
+	if tab.Label != "demo" {
+		t.Errorf("expected label 'demo', got %q", tab.Label)
+	}
+	if tab.Events == nil {
+		t.Error("tab should have an event channel")
+	}
+	if !tab.TreeVisible {
+		t.Error("tree should start visible")
+	}
+	if tab.Focused != PaneTree {
+		t.Error("focused pane should default to tree")
+	}
+}
+
+func TestNewTab_ColdStateWhenStorePresent(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	store := state.NewStore(dir, state.DefaultLockTimeout)
+	tab := newTab(2, "/tmp/demo", store, nil)
+	if tab.EntryState != StateCold {
+		t.Errorf("expected StateCold with store, got %v", tab.EntryState)
+	}
+}
+
+func TestTab_Reset_ClearsState(t *testing.T) {
+	t.Parallel()
+	tab := newTab(3, "/tmp/demo", nil, nil)
+
+	// Seed state that Reset should clear.
+	tab.PrevIndex = &state.RootIndex{}
+	tab.PrevNodes["root"] = &state.NodeState{Name: "root"}
+	tab.Errors = []errorEntry{{filename: "x.json", message: "boom"}}
+
+	tab.Reset()
+
+	if tab.PrevIndex != nil {
+		t.Error("Reset should nil PrevIndex")
+	}
+	if len(tab.PrevNodes) != 0 {
+		t.Errorf("Reset should empty PrevNodes, got %d entries", len(tab.PrevNodes))
+	}
+	if tab.Errors != nil {
+		t.Errorf("Reset should nil Errors, got %+v", tab.Errors)
+	}
+}
+
+func TestTab_Stop_NoopWhenNoWatcher(t *testing.T) {
+	t.Parallel()
+	tab := newTab(4, "/tmp/demo", nil, nil)
+	// Should not panic despite nil watcher.
+	tab.Stop()
+}

--- a/internal/tui/app/update_tabs_from_instances_test.go
+++ b/internal/tui/app/update_tabs_from_instances_test.go
@@ -1,0 +1,71 @@
+package app
+
+import (
+	"os"
+	"testing"
+
+	"github.com/dorkusprime/wolfcastle/internal/instance"
+)
+
+// Each scenario exercises one branch of updateTabsFromInstances: a live
+// match with the real process, a stale match where the PID is dead, and
+// a tab whose worktree is missing from the instance list entirely.
+
+func TestUpdateTabsFromInstances_LivePromotesTab(t *testing.T) {
+	t.Parallel()
+	m := newColdModel(t)
+	dir := m.activeTab().WorktreeDir
+	m.activeTab().EntryState = StateCold
+
+	m.updateTabsFromInstances([]instance.Entry{
+		// Use the current process pid so isProcessAlive returns true.
+		{PID: os.Getpid(), Worktree: dir},
+	})
+
+	if m.activeTab().EntryState != StateLive {
+		t.Errorf("expected StateLive after match, got %v", m.activeTab().EntryState)
+	}
+}
+
+func TestUpdateTabsFromInstances_DeadPidDemotesLive(t *testing.T) {
+	t.Parallel()
+	m := newColdModel(t)
+	dir := m.activeTab().WorktreeDir
+	m.activeTab().EntryState = StateLive
+
+	// Pid 1 << 30 is effectively guaranteed to be dead on test hosts.
+	m.updateTabsFromInstances([]instance.Entry{
+		{PID: 1 << 30, Worktree: dir},
+	})
+
+	if m.activeTab().EntryState != StateCold {
+		t.Errorf("stale instance should demote StateLive to StateCold, got %v",
+			m.activeTab().EntryState)
+	}
+}
+
+func TestUpdateTabsFromInstances_MissingInstanceDemotesLive(t *testing.T) {
+	t.Parallel()
+	m := newColdModel(t)
+	m.activeTab().EntryState = StateLive
+
+	m.updateTabsFromInstances(nil)
+
+	if m.activeTab().EntryState != StateCold {
+		t.Errorf("missing instance should demote StateLive to StateCold, got %v",
+			m.activeTab().EntryState)
+	}
+}
+
+func TestUpdateTabsFromInstances_MissingInstanceLeavesColdAlone(t *testing.T) {
+	t.Parallel()
+	m := newColdModel(t)
+	m.activeTab().EntryState = StateCold
+
+	m.updateTabsFromInstances(nil)
+
+	if m.activeTab().EntryState != StateCold {
+		t.Errorf("cold tab should stay cold when absent from instances, got %v",
+			m.activeTab().EntryState)
+	}
+}

--- a/internal/tui/clipboard/osc52_test.go
+++ b/internal/tui/clipboard/osc52_test.go
@@ -66,3 +66,13 @@ func TestWriteOSC52WriterError(t *testing.T) {
 		t.Errorf("error = %q, want %q", err.Error(), "write failed")
 	}
 }
+
+// TestWriteSystem_Invokes covers the WriteSystem path. On a fully
+// configured desktop (pbcopy/xclip/xsel available) it returns nil; on a
+// headless CI host it returns an error from the atotto clipboard
+// package. Either outcome is acceptable — the assertion is that the
+// function is reachable and returns synchronously.
+func TestWriteSystem_Invokes(t *testing.T) {
+	t.Parallel()
+	_ = WriteSystem("wolfcastle-clipboard-test")
+}


### PR DESCRIPTION
## Summary

Working the P1 \"TUI test coverage to 93%\" backlog item. No behavioral changes — test-only PR.

| Package | Before | After | Δ |
|---|---:|---:|---:|
| \`internal/tui/app\` | 68.2% | **79.3%** | +11.1 |
| \`internal/tui/clipboard\` | 75.0% | **100.0%** | +25.0 |
| \`internal/instance\` | 82.6% | **86.0%** | +3.4 |
| \`internal/fsutil\` | 54.5% | **63.6%** | +9.1 |

## New tests

- **\`tab_picker_test.go\`** (18 tests) — full coverage of \`TabPickerModel\`: directory loading with project detection and session filtering, cursor movement and clamping, Enter on project/session/plain dir, Back to parent and clamp at root, Esc cancel, view rendering with icons and scroll window.
- **\`process_unix_test.go\`** (5 tests) — \`isProcessAlive\`, \`isProcessRunning\`, \`killProcess\` exercised against self PID, invalid PID, and a huge synthetic PID guaranteed to be dead.
- **\`tab_test.go\`** (4 tests) — \`newTab\` welcome/cold entry state, \`Reset\` clears \`PrevIndex\`/\`PrevNodes\`/\`Errors\`, \`Stop\` is a noop without a watcher.
- **\`detect_entry_state_test.go\`** (2 tests) — nil-cmd guard when no \`DaemonRepo\`, cold tab reports \`standing down\` with correct worktree.
- **\`modal_new_tab_test.go\`** (5 tests) — \`renderNewTabModal\` at normal/narrow/tight dimensions, \`updateNewTabModal\` forwards to picker, \`updateActiveModal\` \`ModalNewTab\` branch.
- **\`update_tabs_from_instances_test.go\`** (4 tests) — full branch matrix: live-match-promotes-cold, dead-pid-demotes-live, missing-instance-demotes-live, missing-instance-leaves-cold.
- **\`osc52_test.go\`** — \`WriteSystem\` invocation test (accepts either success on desktop or clipboard-unavailable error on headless CI).
- **\`registry_dir_test.go\`** — \`registryDir\` default path via \`\$HOME\` override, \`List\` on a fresh empty registry.
- **\`atomic_test.go\`** — \`TestAtomicWriteFile_RenameOverDirectory\`: the existing \`RenameError\` test was actually hitting \`CreateTemp\` (target dir was read-only). This one exercises the real rename branch by making the target a non-empty directory, and asserts the leaked temp file is cleaned up.

## Known gaps deferred

- **\`internal/tui/app\`** at 79.3% — the remaining sub-80% functions (\`startDaemon\`, \`stopCurrentDaemon\`, \`handleStopAll\`) all spawn \`exec.Command\` and need dependency injection to test. Leaving as a follow-up rather than mocking \`os/exec\`.
- **\`internal/fsutil\`** at 63.6% — the \`tmp.Write\`/\`tmp.Sync\`/\`tmp.Close\` error branches are unreachable without extracting file ops behind an interface. Same trade-off.

## Test plan
- [x] \`go test ./...\` green
- [x] Per-package \`go test -cover\` numbers match the table above