### PR TITLE
v0.6.6: parallel workers log execution content; retention respects active workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.6.6
+
+### Bug Fixes
+- **Parallel mode: worker execution content is captured on disk.** `runIteration` and every helper it calls (`handleYieldMarker`, `handleBlockedMarker`, `handleCompleteMarker`, `handleFailure`, `autoCompleteDecomposedParents`, `createRemediationSubtasks`, `maybeWriteAuditReport`, `invokeWithRetry`, `propagateState`) now take an explicit `*logging.Logger`. Sequential callers pass `d.Logger`; parallel workers pass their own child logger. Before this change, `d.Logger` had no active file during worker invocations, so every `d.Logger.Log(...)` call inside `runIteration` hit the "no active iteration" guard and was silently dropped. Parallel daemon runs produced 170-byte stub files containing one `iteration_start` record and nothing else; the TUI's log modal was dark.
+- **Worker log filenames are unique per task address.** The child logger's prefix now includes the slugified node path (`worker-<slug(nodeAddr)>-<taskID>`), so three concurrent workers with the same `task-0001` on different leaves write to three distinct files instead of stomping the same `0001-worker-task-0001-{ts}.jsonl` inode.
+- **Retention respects active workers.** `EnforceRetention` now sorts log files by mtime (not by filename) and applies a 30-second quiet window to compression, count-delete, and age-delete. Previously, worker filenames starting with `0001-` sorted alphabetically before parent daemon files (`0519-heal`, `10497-intake`), so count-based retention treated brand-new worker files as the oldest and deleted them first. And even before that, compression was unlinking files while sibling workers still held the inode open.
+- **Silent-drop canary.** `logging.Logger.Log` now writes a diagnostic line to stderr and increments a global counter when called without an active iteration file. Exposed as `logging.DroppedRecords()`. A healthy daemon should always return 0; any non-zero value means a code path is logging to an uninitialized Logger (the class of bug that hid the parallel logger problem for months behind `_ =` error discards).
+
+### Quality
+- Worker trace IDs are compact: `worker-<leaf-basename>-<taskID>-<iter>` instead of the full slugified node path. The filename stays long for uniqueness, but the log view's `[trace]` column is readable again.
+- The TUI log modal's trace filter cycle gains a `worker` category so you can isolate parallel worker output with `T`. `traceCategory` recognizes `worker-*` prefixes.
+
 ## 0.6.5
 
 ### Bug Fixes

--- a/internal/daemon/audit_complete_gaps_test.go
+++ b/internal/daemon/audit_complete_gaps_test.go
@@ -64,7 +64,7 @@ func TestRunIteration_AuditCompleteWithOpenGaps_CreatesRemediation(t *testing.T)
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "audit-gaps-node", TaskID: "audit-0001", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	if err != nil {
 		t.Fatalf("runIteration error: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestRunIteration_AuditCompleteNoOpenGaps_Succeeds(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "audit-clean-node", TaskID: "audit-0001", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	if err != nil {
 		t.Fatalf("runIteration error: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestRunIteration_NonAuditCompleteWithOpenGaps_Succeeds(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "noaudit-gaps-node", TaskID: "task-0001", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	if err != nil {
 		t.Fatalf("runIteration error: %v", err)
 	}

--- a/internal/daemon/category_a_test.go
+++ b/internal/daemon/category_a_test.go
@@ -147,7 +147,7 @@ func TestRunIteration_InvokeErrorReturnsError(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "invoke-fail-node", TaskID: "task-0001", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	if err == nil {
 		t.Fatal("expected error from failed invocation")
 	}
@@ -179,7 +179,7 @@ func TestRunIteration_DecompThreshold_SetsNeedsDecomposition(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "decomp-node", TaskID: "task-0001", Found: true}
-	_ = d.runIteration(context.Background(), nav, idx)
+	_ = d.runIteration(context.Background(), d.Logger, nav, idx)
 
 	projDir := d.Store.Dir()
 	var ns state.NodeState
@@ -238,7 +238,7 @@ func TestRunIteration_DecompAtMaxDepth_TaskAutoBlocked(t *testing.T) {
 	writePromptFile(t, d.WolfcastleDir, "stages/execute.md")
 
 	nav := &state.NavigationResult{NodeAddress: "maxdepth-node", TaskID: "task-0001", Found: true}
-	_ = d.runIteration(context.Background(), nav, idx)
+	_ = d.runIteration(context.Background(), d.Logger, nav, idx)
 
 	data, err := os.ReadFile(filepath.Join(projDir, "maxdepth-node", "state.json"))
 	if err != nil {
@@ -288,7 +288,7 @@ func TestRunIteration_HardCapReached_TaskAutoBlocked(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "hardcap-node", TaskID: "task-0001", Found: true}
-	_ = d.runIteration(context.Background(), nav, idx)
+	_ = d.runIteration(context.Background(), d.Logger, nav, idx)
 
 	projDir := d.Store.Dir()
 	data, err := os.ReadFile(filepath.Join(projDir, "hardcap-node", "state.json"))
@@ -339,7 +339,7 @@ func TestRunIteration_NoTerminalMarker_FailureIncremented(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "nonterminal-node", TaskID: "task-0001", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	if err != nil {
 		t.Logf("runIteration error (may be acceptable): %v", err)
 	}
@@ -364,7 +364,7 @@ func TestPropagateState_EmptyParentAddr_LoadNodeError(t *testing.T) {
 		Address: "child", Parent: "",
 	}
 
-	err := d.propagateState("child", state.StatusInProgress, idx)
+	err := d.propagateState(d.Logger, "child", state.StatusInProgress, idx)
 	if err != nil {
 		if !strings.Contains(err.Error(), "parsing address") {
 			t.Logf("propagateState error: %v", err)
@@ -402,7 +402,7 @@ func TestPropagateState_SaveNodeCallbackExercised(t *testing.T) {
 	childNS := state.NewNodeState("sv-child", "Child", state.NodeLeaf)
 	writeJSON(t, filepath.Join(projDir, "sv-parent", "sv-child", "state.json"), childNS)
 
-	err := d.propagateState("sv-parent/sv-child", state.StatusInProgress, idx)
+	err := d.propagateState(d.Logger, "sv-parent/sv-child", state.StatusInProgress, idx)
 	if err != nil {
 		t.Logf("propagateState error (may be expected): %v", err)
 	}
@@ -423,7 +423,7 @@ func TestInvokeWithRetry_PreCancelledContext(t *testing.T) {
 	cancel()
 
 	model := config.ModelDef{Command: "/nonexistent/binary", Args: []string{}}
-	_, err := d.invokeWithRetry(ctx, model, "test prompt", d.RepoDir, d.Logger.AssistantWriter(), "test")
+	_, err := d.invokeWithRetry(ctx, d.Logger, model, "test prompt", d.RepoDir, d.Logger.AssistantWriter(), "test")
 	if err == nil {
 		t.Fatal("expected error when context is already cancelled")
 	}
@@ -450,7 +450,7 @@ func TestInvokeWithRetry_CancelDuringBackoff(t *testing.T) {
 	}()
 
 	model := config.ModelDef{Command: "/nonexistent/binary", Args: []string{}}
-	_, err := d.invokeWithRetry(ctx, model, "test prompt", d.RepoDir, d.Logger.AssistantWriter(), "test")
+	_, err := d.invokeWithRetry(ctx, d.Logger, model, "test prompt", d.RepoDir, d.Logger.AssistantWriter(), "test")
 	if err == nil {
 		t.Fatal("expected error when context cancelled during backoff")
 	}

--- a/internal/daemon/coverage_gaps_test.go
+++ b/internal/daemon/coverage_gaps_test.go
@@ -214,7 +214,7 @@ func TestPropagateState_InvalidParentAddress(t *testing.T) {
 	}
 	writeJSON(t, filepath.Join(projDir, "valid-child", "state.json"), childNS)
 
-	err := d.propagateState("valid-child", state.StatusComplete, idx)
+	err := d.propagateState(d.Logger, "valid-child", state.StatusComplete, idx)
 	if err == nil {
 		t.Error("expected error when parent address is invalid for ParseAddress")
 	}
@@ -257,7 +257,7 @@ func TestPropagateState_SaveRootIndexFailure(t *testing.T) {
 	_ = os.Remove(stateFile)
 	_ = os.MkdirAll(stateFile, 0755) // create a directory where the file should be
 
-	err := d.propagateState("parent/child", state.StatusComplete, idx)
+	err := d.propagateState(d.Logger, "parent/child", state.StatusComplete, idx)
 	if err == nil {
 		t.Error("expected error when SaveRootIndex fails")
 	}

--- a/internal/daemon/coverage_test.go
+++ b/internal/daemon/coverage_test.go
@@ -168,7 +168,7 @@ func TestPropagateState_MissingRootIndex(t *testing.T) {
 	}
 	// Don't write the root index to disk. SaveRootIndex will be attempted
 	// but the projects dir exists, so propagateState should still attempt to save.
-	err := d.propagateState("node-a", state.StatusInProgress, idx)
+	err := d.propagateState(d.Logger, "node-a", state.StatusInProgress, idx)
 	// This should succeed as it only needs to save the index
 	if err != nil {
 		t.Logf("propagateState returned error (acceptable): %v", err)
@@ -207,7 +207,7 @@ func TestPropagateState_DeepHierarchy(t *testing.T) {
 	cNS.State = state.StatusComplete
 	writeJSON(t, filepath.Join(projDir, "a", "b", "c", "state.json"), cNS)
 
-	if err := d.propagateState("a/b/c", state.StatusComplete, idx); err != nil {
+	if err := d.propagateState(d.Logger, "a/b/c", state.StatusComplete, idx); err != nil {
 		t.Fatalf("propagateState error: %v", err)
 	}
 
@@ -271,7 +271,7 @@ func TestRunIteration_IntakeStageSkipped(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "my-node", TaskID: "task-0001", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	// Intake is skipped in the iteration loop; only execute runs
 	_ = err
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -329,7 +329,7 @@ func (d *Daemon) selfHeal() error {
 				if e, ok := idx.Nodes[addr]; ok && e.State != updatedNS.State {
 					e.State = updatedNS.State
 					idx.Nodes[addr] = e
-					_ = d.propagateState(addr, updatedNS.State, idx)
+					_ = d.propagateState(d.Logger, addr, updatedNS.State, idx)
 				}
 			}
 		}
@@ -830,7 +830,7 @@ execute:
 	_ = d.Logger.LogIterationStart("execute", navResult.NodeAddress)
 
 	// Run pipeline stages
-	err = d.runIteration(ctx, navResult, idx)
+	err = d.runIteration(ctx, d.Logger, navResult, idx)
 	d.Logger.Close()
 
 	if err != nil {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -486,7 +486,7 @@ func TestCreateRemediationSubtasks_AuditWithGaps(t *testing.T) {
 	ns2.Audit = ns.Audit
 	writeJSON(t, nsPath, ns2)
 
-	created := d.createRemediationSubtasks("my-node", "audit")
+	created := d.createRemediationSubtasks(d.Logger, "my-node", "audit")
 	if created != 2 {
 		t.Fatalf("expected 2 subtasks (only open gaps), got %d", created)
 	}
@@ -526,7 +526,7 @@ func TestCreateRemediationSubtasks_NonAuditReturnsZero(t *testing.T) {
 		{ID: "task-0001", State: state.StatusBlocked, BlockedReason: "stuck"},
 	})
 
-	created := d.createRemediationSubtasks("my-node", "task-0001")
+	created := d.createRemediationSubtasks(d.Logger, "my-node", "task-0001")
 	if created != 0 {
 		t.Errorf("non-audit task should not create subtasks, got %d", created)
 	}
@@ -538,7 +538,7 @@ func TestCreateRemediationSubtasks_AuditNoGapsReturnsZero(t *testing.T) {
 		{ID: "audit", State: state.StatusBlocked, IsAudit: true},
 	})
 
-	created := d.createRemediationSubtasks("my-node", "audit")
+	created := d.createRemediationSubtasks(d.Logger, "my-node", "audit")
 	if created != 0 {
 		t.Errorf("audit without gaps should not create subtasks, got %d", created)
 	}
@@ -722,7 +722,7 @@ func TestRunIteration_ClaimTask(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "my-node", TaskID: "task-0001", Found: true}
-	if err := d.runIteration(context.Background(), nav, idx); err != nil {
+	if err := d.runIteration(context.Background(), d.Logger, nav, idx); err != nil {
 		t.Fatalf("runIteration error: %v", err)
 	}
 
@@ -759,7 +759,7 @@ func TestRunIteration_TerminalMarkers(t *testing.T) {
 
 			idx, _ := d.Store.ReadIndex()
 			nav := &state.NavigationResult{NodeAddress: "my-node", TaskID: "task-0001", Found: true}
-			if err := d.runIteration(context.Background(), nav, idx); err != nil {
+			if err := d.runIteration(context.Background(), d.Logger, nav, idx); err != nil {
 				t.Fatalf("runIteration should succeed with terminal marker: %v", err)
 			}
 		})
@@ -779,7 +779,7 @@ func TestRunIteration_NoTerminalMarker_IncrFailure(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "my-node", TaskID: "task-0001", Found: true}
-	if err := d.runIteration(context.Background(), nav, idx); err != nil {
+	if err := d.runIteration(context.Background(), d.Logger, nav, idx); err != nil {
 		t.Fatalf("runIteration error: %v", err)
 	}
 
@@ -812,7 +812,7 @@ func TestRunIteration_DecompositionThreshold(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "my-node", TaskID: "task-0001", Found: true}
-	_ = d.runIteration(context.Background(), nav, idx)
+	_ = d.runIteration(context.Background(), d.Logger, nav, idx)
 
 	addr, _ := tree.ParseAddress("my-node")
 	ns, _ := state.LoadNodeState(filepath.Join(d.Store.Dir(), filepath.Join(addr.Parts...), "state.json"))
@@ -856,7 +856,7 @@ func TestRunIteration_DecompAtMaxDepth_AutoBlocks(t *testing.T) {
 
 	idx2, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "my-node", TaskID: "task-0001", Found: true}
-	_ = d.runIteration(context.Background(), nav, idx2)
+	_ = d.runIteration(context.Background(), d.Logger, nav, idx2)
 
 	addr, _ := tree.ParseAddress("my-node")
 	ns2, _ := state.LoadNodeState(filepath.Join(projDir, filepath.Join(addr.Parts...), "state.json"))
@@ -889,7 +889,7 @@ func TestRunIteration_HardCap_AutoBlocks(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "my-node", TaskID: "task-0001", Found: true}
-	_ = d.runIteration(context.Background(), nav, idx)
+	_ = d.runIteration(context.Background(), d.Logger, nav, idx)
 
 	addr, _ := tree.ParseAddress("my-node")
 	ns, _ := state.LoadNodeState(filepath.Join(d.Store.Dir(), filepath.Join(addr.Parts...), "state.json"))
@@ -923,7 +923,7 @@ func TestRunIteration_ModelNotFound(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "my-node", TaskID: "task-0001", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	if err == nil || !strings.Contains(err.Error(), "model") {
 		t.Errorf("expected model-not-found error, got: %v", err)
 	}
@@ -946,7 +946,7 @@ func TestRunIteration_DisabledStageSkipped(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "my-node", TaskID: "task-0001", Found: true}
-	if err := d.runIteration(context.Background(), nav, idx); err != nil {
+	if err := d.runIteration(context.Background(), d.Logger, nav, idx); err != nil {
 		t.Fatalf("runIteration error: %v", err)
 	}
 }
@@ -969,7 +969,7 @@ func TestRunIteration_IntakeStageSkippedInPipeline(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "my-node", TaskID: "task-0001", Found: true}
-	if err := d.runIteration(context.Background(), nav, idx); err != nil {
+	if err := d.runIteration(context.Background(), d.Logger, nav, idx); err != nil {
 		t.Fatalf("runIteration error: %v", err)
 	}
 }
@@ -987,7 +987,7 @@ func TestRunIteration_InvocationTimeout(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "my-node", TaskID: "task-0001", Found: true}
-	if err := d.runIteration(context.Background(), nav, idx); err != nil {
+	if err := d.runIteration(context.Background(), d.Logger, nav, idx); err != nil {
 		t.Fatalf("runIteration error: %v", err)
 	}
 }
@@ -1005,7 +1005,7 @@ func TestRunIteration_ZeroInvocationTimeout(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "my-node", TaskID: "task-0001", Found: true}
-	if err := d.runIteration(context.Background(), nav, idx); err != nil {
+	if err := d.runIteration(context.Background(), d.Logger, nav, idx); err != nil {
 		t.Fatalf("runIteration error: %v", err)
 	}
 }
@@ -1115,7 +1115,7 @@ func TestInvokeWithRetry_SuccessFirstTry(t *testing.T) {
 	defer d.Logger.Close()
 
 	model := config.ModelDef{Command: "echo", Args: []string{"hello"}}
-	result, err := d.invokeWithRetry(context.Background(), model, "prompt", d.RepoDir, d.Logger.AssistantWriter(), "test")
+	result, err := d.invokeWithRetry(context.Background(), d.Logger, model, "prompt", d.RepoDir, d.Logger.AssistantWriter(), "test")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1131,7 +1131,7 @@ func TestInvokeWithRetry_MaxRetriesExceeded(t *testing.T) {
 	defer d.Logger.Close()
 
 	model := config.ModelDef{Command: "nonexistent-command-xyz", Args: []string{}}
-	_, err := d.invokeWithRetry(context.Background(), model, "prompt", d.RepoDir, d.Logger.AssistantWriter(), "test")
+	_, err := d.invokeWithRetry(context.Background(), d.Logger, model, "prompt", d.RepoDir, d.Logger.AssistantWriter(), "test")
 	if err == nil {
 		t.Fatal("expected error for nonexistent command")
 	}
@@ -1147,7 +1147,7 @@ func TestInvokeWithRetry_ContextCancelled(t *testing.T) {
 	cancel()
 
 	model := config.ModelDef{Command: "nonexistent-command-xyz", Args: []string{}}
-	_, err := d.invokeWithRetry(ctx, model, "prompt", d.RepoDir, nil, "test")
+	_, err := d.invokeWithRetry(ctx, d.Logger, model, "prompt", d.RepoDir, nil, "test")
 	if err == nil {
 		t.Fatal("expected error for cancelled context")
 	}
@@ -1161,7 +1161,7 @@ func TestInvokeWithRetry_BackoffCaps(t *testing.T) {
 
 	model := config.ModelDef{Command: "nonexistent-cmd-backoff", Args: []string{}}
 	start := time.Now()
-	_, _ = d.invokeWithRetry(context.Background(), model, "", d.RepoDir, nil, "test")
+	_, _ = d.invokeWithRetry(context.Background(), d.Logger, model, "", d.RepoDir, nil, "test")
 	elapsed := time.Since(start)
 	// With 0s delays and 2 retries, should finish very quickly
 	if elapsed > 5*time.Second {
@@ -1175,7 +1175,7 @@ func TestInvokeWithRetry_NilLogWriter(t *testing.T) {
 	defer d.Logger.Close()
 
 	model := config.ModelDef{Command: "echo", Args: []string{"hello"}}
-	result, err := d.invokeWithRetry(context.Background(), model, "prompt", d.RepoDir, nil, "test")
+	result, err := d.invokeWithRetry(context.Background(), d.Logger, model, "prompt", d.RepoDir, nil, "test")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1482,7 +1482,7 @@ func TestPropagateState(t *testing.T) {
 	childNS.State = state.StatusInProgress
 	writeJSON(t, filepath.Join(projDir, "parent", "child", "state.json"), childNS)
 
-	if err := d.propagateState("parent/child", state.StatusInProgress, idx); err != nil {
+	if err := d.propagateState(d.Logger, "parent/child", state.StatusInProgress, idx); err != nil {
 		t.Fatalf("propagateState error: %v", err)
 	}
 
@@ -1502,7 +1502,7 @@ func TestPropagateState_SingleNode(t *testing.T) {
 	writeJSON(t, filepath.Join(d.Store.Dir(), "state.json"), idx)
 
 	// No parent => just updates root index entry
-	if err := d.propagateState("my-node", state.StatusInProgress, idx); err != nil {
+	if err := d.propagateState(d.Logger, "my-node", state.StatusInProgress, idx); err != nil {
 		t.Fatalf("propagateState error: %v", err)
 	}
 	if idx.Nodes["my-node"].State != state.StatusInProgress {

--- a/internal/daemon/deep_coverage_test.go
+++ b/internal/daemon/deep_coverage_test.go
@@ -17,7 +17,7 @@ func TestPropagateState_NodeNotInIndex(t *testing.T) {
 
 	// Node not in index. PropagateState succeeds but does nothing meaningful
 	// since there's nothing to propagate up from
-	err := d.propagateState("nonexistent-node", state.StatusInProgress, idx)
+	err := d.propagateState(d.Logger, "nonexistent-node", state.StatusInProgress, idx)
 	// Should succeed. The function just saves the index
 	if err != nil {
 		t.Logf("propagateState for missing node: %v (may be acceptable)", err)
@@ -42,7 +42,7 @@ func TestPropagateState_ParentLoadError(t *testing.T) {
 
 	// Don't create parent state.json on disk. LoadNode for parent will fail
 	// but propagateState should still succeed or return an error gracefully
-	err := d.propagateState("parent/child", state.StatusInProgress, idx)
+	err := d.propagateState(d.Logger, "parent/child", state.StatusInProgress, idx)
 	// This exercises the loadNode error path inside state.Propagate
 	_ = err
 }
@@ -88,7 +88,7 @@ func TestPropagateState_FourLevelHierarchy(t *testing.T) {
 	leafNS.State = state.StatusComplete
 	writeJSON(t, filepath.Join(projDir, "l1", "l2", "l3", "leaf", "state.json"), leafNS)
 
-	if err := d.propagateState("l1/l2/l3/leaf", state.StatusComplete, idx); err != nil {
+	if err := d.propagateState(d.Logger, "l1/l2/l3/leaf", state.StatusComplete, idx); err != nil {
 		t.Fatalf("propagateState error: %v", err)
 	}
 

--- a/internal/daemon/edge_cases_test.go
+++ b/internal/daemon/edge_cases_test.go
@@ -219,7 +219,7 @@ func TestInvokeWithRetry_UnlimitedRetriesRespectsContextCancel(t *testing.T) {
 	defer cancel()
 
 	model := config.ModelDef{Command: "/nonexistent/binary/xyz", Args: []string{}}
-	_, err := d.invokeWithRetry(ctx, model, "prompt", d.RepoDir, nil, "test")
+	_, err := d.invokeWithRetry(ctx, d.Logger, model, "prompt", d.RepoDir, nil, "test")
 	if err == nil {
 		t.Fatal("expected error when context times out during unlimited retries")
 	}
@@ -238,7 +238,7 @@ func TestInvokeWithRetry_ZeroMaxRetries_NoRetry(t *testing.T) {
 
 	model := config.ModelDef{Command: "/nonexistent/binary/xyz", Args: []string{}}
 	start := time.Now()
-	_, err := d.invokeWithRetry(context.Background(), model, "", d.RepoDir, nil, "test")
+	_, err := d.invokeWithRetry(context.Background(), d.Logger, model, "", d.RepoDir, nil, "test")
 	elapsed := time.Since(start)
 
 	if err == nil {
@@ -282,7 +282,7 @@ echo "Let me know if you have questions."`},
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "chatty-node", TaskID: "task-0001", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	if err != nil {
 		t.Fatalf("runIteration should succeed (no fatal error): %v", err)
 	}
@@ -334,7 +334,7 @@ func TestRunIteration_NonzeroExitCode_NoMarker(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "exitcode-node", TaskID: "task-0001", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	if err != nil {
 		t.Logf("runIteration returned error (may be acceptable): %v", err)
 	}
@@ -384,7 +384,7 @@ echo "WOLFCASTLE_COMPLETE"`},
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "warn-node", TaskID: "task-0001", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	if err != nil {
 		t.Fatalf("runIteration error: %v", err)
 	}
@@ -558,7 +558,7 @@ func TestRunIteration_ContextCancelledDuringExecution(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "cancel-node", TaskID: "task-0001", Found: true}
-	err := d.runIteration(ctx, nav, idx)
+	err := d.runIteration(ctx, d.Logger, nav, idx)
 	// When context is cancelled, the model process is killed. Depending on
 	// timing, this may return an error (context cancelled) or succeed with
 	// no marker (incrementing failure count). Both outcomes are correct.
@@ -624,7 +624,7 @@ func TestRunIteration_PartialMarkerOutput(t *testing.T) {
 
 			idx, _ := d.Store.ReadIndex()
 			nav := &state.NavigationResult{NodeAddress: "partial-node", TaskID: "task-0001", Found: true}
-			_ = d.runIteration(context.Background(), nav, idx)
+			_ = d.runIteration(context.Background(), d.Logger, nav, idx)
 
 			ns, _ := d.Store.ReadNode("partial-node")
 			for _, task := range ns.Tasks {
@@ -674,7 +674,7 @@ echo 'random text at the end'`},
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "garbage-node", TaskID: "task-0001", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	if err != nil {
 		t.Fatalf("runIteration should handle garbage gracefully: %v", err)
 	}
@@ -719,7 +719,7 @@ func TestRunIteration_EmptyOutput(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "silent-node", TaskID: "task-0001", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	if err != nil {
 		t.Fatalf("runIteration should handle empty output: %v", err)
 	}
@@ -757,7 +757,7 @@ func TestRunIteration_PromptAssemblyError(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "prompt-err-node", TaskID: "task-0001", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	if err == nil {
 		t.Fatal("expected error for missing prompt file")
 	}
@@ -830,7 +830,7 @@ func TestRunIteration_NoGitProgress_RejectsComplete(t *testing.T) {
 
 	idx2, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "unchanged-node", TaskID: "task-0001", Found: true}
-	_ = d.runIteration(context.Background(), nav, idx2)
+	_ = d.runIteration(context.Background(), d.Logger, nav, idx2)
 
 	// Task should NOT be complete since git shows no changes
 	reloaded, _ := d.Store.ReadNode("unchanged-node")
@@ -1001,7 +1001,7 @@ func TestRunIteration_MultipleStages_CustomStagesRun(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "multi-stage-node", TaskID: "task-0001", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	if err != nil {
 		t.Fatalf("runIteration error: %v", err)
 	}

--- a/internal/daemon/iteration.go
+++ b/internal/daemon/iteration.go
@@ -30,7 +30,14 @@ const yieldSuffixScopeConflict = "scope_conflict"
 // runIteration executes a single daemon iteration: claims the task, runs each
 // enabled pipeline stage in order, reloads state from disk (to pick up CLI
 // mutations), handles terminal markers, and manages failure escalation.
-func (d *Daemon) runIteration(ctx context.Context, nav *state.NavigationResult, idx *state.RootIndex) error {
+//
+// lg is the logger that receives every record produced during this
+// iteration. The sequential path passes d.Logger (which already has an
+// "exec" file open); parallel workers pass their own child logger so
+// their output doesn't collide with other concurrent workers. This must
+// never be nil — the guard in logging.Logger.Log would silently drop
+// every record, which is exactly the bug this plumbing fixes.
+func (d *Daemon) runIteration(ctx context.Context, lg *logging.Logger, nav *state.NavigationResult, idx *state.RootIndex) error {
 	// Claim the task
 	addr, err := tree.ParseAddress(nav.NodeAddress)
 	if err != nil {
@@ -102,7 +109,7 @@ func (d *Daemon) runIteration(ctx context.Context, nav *state.NavigationResult, 
 		}
 
 		stageStartTime := time.Now()
-		_ = d.Logger.Log(map[string]any{
+		_ = lg.Log(map[string]any{
 			"type":  "stage_start",
 			"stage": stageName,
 			"model": stage.Model,
@@ -115,19 +122,19 @@ func (d *Daemon) runIteration(ctx context.Context, nav *state.NavigationResult, 
 		beforeHEAD := d.Git.HEAD()
 		preInvocationNS := ns
 
-		result, err := d.invokeWithRetry(invokeCtx, model, prompt, d.RepoDir, d.Logger.AssistantWriter(), stageName)
+		result, err := d.invokeWithRetry(invokeCtx, lg, model, prompt, d.RepoDir, lg.AssistantWriter(), stageName)
 		if cancel != nil {
 			cancel()
 		}
 
 		// Restore terminal to cooked mode in case the child left it in raw mode.
 		if err != nil {
-			_ = d.Logger.Log(map[string]any{"type": "stage_error", "stage": stageName, "error": err.Error()})
+			_ = lg.Log(map[string]any{"type": "stage_error", "stage": stageName, "error": err.Error()})
 			return err
 		}
 
 		stageDuration := time.Since(stageStartTime)
-		_ = d.Logger.Log(map[string]any{
+		_ = lg.Log(map[string]any{
 			"type":        "stage_complete",
 			"stage":       stageName,
 			"exit_code":   result.ExitCode,
@@ -139,7 +146,7 @@ func (d *Daemon) runIteration(ctx context.Context, nav *state.NavigationResult, 
 		// have mutated state.json during execution (breadcrumbs, gaps, scope, etc.)
 		ns, err = d.Store.ReadNode(nav.NodeAddress)
 		if err != nil {
-			_ = d.Logger.Log(map[string]any{"type": "reload_error", "error": err.Error()})
+			_ = lg.Log(map[string]any{"type": "reload_error", "error": err.Error()})
 		}
 
 		// Check for terminal markers and transition task state.
@@ -153,20 +160,20 @@ func (d *Daemon) runIteration(ctx context.Context, nav *state.NavigationResult, 
 			invoke.MarkerStringBlocked, invoke.MarkerStringYield,
 		)
 		if marker == invoke.MarkerStringYield {
-			return d.handleYieldMarker(nav, result, preInvocationNS)
+			return d.handleYieldMarker(lg, nav, result, preInvocationNS)
 		}
 		if marker == invoke.MarkerStringBlocked {
-			return d.handleBlockedMarker(nav, idx)
+			return d.handleBlockedMarker(lg, nav, idx)
 		}
 		if marker == invoke.MarkerStringSkip {
-			_ = d.Logger.Log(map[string]any{"type": "terminal_marker", "marker": invoke.MarkerStringSkip, "task": nav.TaskID})
+			_ = lg.Log(map[string]any{"type": "terminal_marker", "marker": invoke.MarkerStringSkip, "task": nav.TaskID})
 			if err := d.Store.MutateNode(nav.NodeAddress, func(ns *state.NodeState) error {
 				return state.TaskComplete(ns, nav.TaskID)
 			}); err != nil {
-				_ = d.Logger.Log(map[string]any{"type": "complete_error", "task": nav.TaskID, "error": err.Error()})
+				_ = lg.Log(map[string]any{"type": "complete_error", "task": nav.TaskID, "error": err.Error()})
 			}
 			if !d.Config.Pipeline.Planning.Enabled {
-				d.autoCompleteDecomposedParents(nav.NodeAddress)
+				d.autoCompleteDecomposedParents(lg, nav.NodeAddress)
 			}
 			// Check replanning triggers before propagation (see COMPLETE path).
 			d.checkReplanningTriggers(nav.NodeAddress, nav.TaskID, idx)
@@ -175,21 +182,21 @@ func (d *Daemon) runIteration(ctx context.Context, nav *state.NavigationResult, 
 			// internally, but re-propagating here updates the in-memory idx
 			// and guards against silent propagation failures in the store.
 			if updatedNS, readErr := d.Store.ReadNode(nav.NodeAddress); readErr == nil {
-				if err := d.propagateState(nav.NodeAddress, updatedNS.State, idx); err != nil {
-					_ = d.Logger.Log(map[string]any{"type": "propagate_error", "error": err.Error()})
+				if err := d.propagateState(lg, nav.NodeAddress, updatedNS.State, idx); err != nil {
+					_ = lg.Log(map[string]any{"type": "propagate_error", "error": err.Error()})
 				}
 			}
 			return nil
 		}
 		if marker == invoke.MarkerStringComplete {
-			if d.handleCompleteMarker(nav, ns, idx, beforeHEAD) {
+			if d.handleCompleteMarker(lg, nav, ns, idx, beforeHEAD) {
 				return nil
 			}
 			// Fell through: COMPLETE was cleared by no-progress check.
 			// Fall through to failure path.
 		}
 
-		d.handleFailure(nav, ns, result, marker)
+		d.handleFailure(lg, nav, ns, result, marker)
 	}
 
 	return nil
@@ -198,14 +205,14 @@ func (d *Daemon) runIteration(ctx context.Context, nav *state.NavigationResult, 
 // handleYieldMarker processes a WOLFCASTLE_YIELD terminal marker: checks for
 // scope-conflict suffixes, detects newly created subtasks, and handles legacy
 // block-parent decomposition when planning is disabled.
-func (d *Daemon) handleYieldMarker(nav *state.NavigationResult, result *invoke.Result, preInvocationNS *state.NodeState) error {
-	_ = d.Logger.Log(map[string]any{"type": "terminal_marker", "marker": invoke.MarkerStringYield})
+func (d *Daemon) handleYieldMarker(lg *logging.Logger, nav *state.NavigationResult, result *invoke.Result, preInvocationNS *state.NodeState) error {
+	_ = lg.Log(map[string]any{"type": "terminal_marker", "marker": invoke.MarkerStringYield})
 
 	// Check for a scope-conflict suffix. When present, return a
 	// typed error so the parallel dispatcher can record the
 	// conflict and avoid immediately re-dispatching into it.
 	if kind, conflictAddr := scanYieldSuffix(result.Stdout); kind == yieldSuffixScopeConflict {
-		_ = d.Logger.Log(map[string]any{
+		_ = lg.Log(map[string]any{
 			"type":    "yield_scope_conflict",
 			"task":    nav.TaskID,
 			"blocker": conflictAddr,
@@ -231,7 +238,7 @@ func (d *Daemon) handleYieldMarker(nav *state.NavigationResult, result *invoke.R
 				_ = d.Store.MutateNode(nav.NodeAddress, func(ns2 *state.NodeState) error {
 					return state.TaskBlock(ns2, nav.TaskID, reason)
 				})
-				_ = d.Logger.Log(map[string]any{
+				_ = lg.Log(map[string]any{
 					"type":      "yield_decomposition",
 					"task":      nav.TaskID,
 					"new_tasks": newTasks,
@@ -244,7 +251,7 @@ func (d *Daemon) handleYieldMarker(nav *state.NavigationResult, result *invoke.R
 		if updatedNS, readErr := d.Store.ReadNode(nav.NodeAddress); readErr == nil {
 			newTasks := findNewTasks(preInvocationNS, updatedNS)
 			if len(newTasks) > 0 {
-				_ = d.Logger.Log(map[string]any{
+				_ = lg.Log(map[string]any{
 					"type":      "yield_decomposition",
 					"task":      nav.TaskID,
 					"new_tasks": newTasks,
@@ -258,19 +265,19 @@ func (d *Daemon) handleYieldMarker(nav *state.NavigationResult, result *invoke.R
 // handleBlockedMarker processes a WOLFCASTLE_BLOCKED terminal marker: checks
 // for superseded tasks, creates remediation subtasks for audit gaps, handles
 // spec review feedback, and propagates blocked state up the tree.
-func (d *Daemon) handleBlockedMarker(nav *state.NavigationResult, idx *state.RootIndex) error {
-	_ = d.Logger.Log(map[string]any{"type": "terminal_marker", "marker": invoke.MarkerStringBlocked, "task": nav.TaskID})
+func (d *Daemon) handleBlockedMarker(lg *logging.Logger, nav *state.NavigationResult, idx *state.RootIndex) error {
+	_ = lg.Log(map[string]any{"type": "terminal_marker", "marker": invoke.MarkerStringBlocked, "task": nav.TaskID})
 
 	// Check if the model blocked a task that's actually
 	// superseded. Superseded work should be SKIP, not BLOCKED.
 	// Treat it as complete so it doesn't poison node state.
 	if d.isSupersededBlock(nav.NodeAddress, nav.TaskID) {
-		_ = d.Logger.Log(map[string]any{"type": "superseded_to_skip", "task": nav.TaskID})
+		_ = lg.Log(map[string]any{"type": "superseded_to_skip", "task": nav.TaskID})
 		d.log(map[string]any{"type": "task_event", "action": "superseded", "task": nav.TaskID, "text": "Superseded (treating as skip)."})
 		if err := d.Store.MutateNode(nav.NodeAddress, func(ns *state.NodeState) error {
 			return state.TaskComplete(ns, nav.TaskID)
 		}); err != nil {
-			_ = d.Logger.Log(map[string]any{"type": "save_error", "error": err.Error()})
+			_ = lg.Log(map[string]any{"type": "save_error", "error": err.Error()})
 		}
 		return nil
 	}
@@ -279,8 +286,8 @@ func (d *Daemon) handleBlockedMarker(nav *state.NavigationResult, idx *state.Roo
 	// instead of blocking. The subtasks fix each gap, and when
 	// they all complete, DeriveParentStatus resets the audit to
 	// not_started so it re-runs to verify the fixes.
-	if created := d.createRemediationSubtasks(nav.NodeAddress, nav.TaskID); created > 0 {
-		_ = d.Logger.Log(map[string]any{"type": "audit_remediation", "task": nav.TaskID, "subtasks": created})
+	if created := d.createRemediationSubtasks(lg, nav.NodeAddress, nav.TaskID); created > 0 {
+		_ = lg.Log(map[string]any{"type": "audit_remediation", "task": nav.TaskID, "subtasks": created})
 		d.log(map[string]any{"type": "task_event", "action": "audit_remediation", "task": nav.TaskID, "text": fmt.Sprintf("Audit: %d gap(s), remediating.", created)})
 		return nil
 	}
@@ -295,14 +302,14 @@ func (d *Daemon) handleBlockedMarker(nav *state.NavigationResult, idx *state.Roo
 	if err := d.Store.MutateNode(nav.NodeAddress, func(ns *state.NodeState) error {
 		return state.TaskBlock(ns, nav.TaskID, "blocked by model")
 	}); err != nil {
-		_ = d.Logger.Log(map[string]any{"type": "save_error", "error": err.Error()})
+		_ = lg.Log(map[string]any{"type": "save_error", "error": err.Error()})
 	}
 	// Check replanning triggers before propagation (see COMPLETE path).
 	d.checkReplanningTriggers(nav.NodeAddress, nav.TaskID, idx)
 	// Propagate blocked state so parent orchestrators can detect
 	// the block and trigger remediation planning.
-	if err := d.propagateState(nav.NodeAddress, state.StatusBlocked, idx); err != nil {
-		_ = d.Logger.Log(map[string]any{"type": "propagate_error", "error": err.Error()})
+	if err := d.propagateState(lg, nav.NodeAddress, state.StatusBlocked, idx); err != nil {
+		_ = lg.Log(map[string]any{"type": "propagate_error", "error": err.Error()})
 	}
 	return nil
 }
@@ -313,7 +320,7 @@ func (d *Daemon) handleBlockedMarker(nav *state.NavigationResult, idx *state.Roo
 // propagates completion state. Returns true if the task was actually
 // completed, false if COMPLETE was cleared (no git progress) and the
 // caller should fall through to the failure path.
-func (d *Daemon) handleCompleteMarker(nav *state.NavigationResult, ns *state.NodeState, idx *state.RootIndex, beforeHEAD string) (completed bool) {
+func (d *Daemon) handleCompleteMarker(lg *logging.Logger, nav *state.NavigationResult, ns *state.NodeState, idx *state.RootIndex, beforeHEAD string) (completed bool) {
 	// Re-read state from disk since the model may have added
 	// deliverables via CLI during execution.
 	if updated, readErr := d.Store.ReadNode(nav.NodeAddress); readErr == nil {
@@ -324,7 +331,7 @@ func (d *Daemon) handleCompleteMarker(nav *state.NavigationResult, ns *state.Nod
 	// not a completion failure. Git progress is the hard gate.
 	missing := checkDeliverables(d.RepoDir, ns, nav.TaskID)
 	if len(missing) > 0 {
-		_ = d.Logger.Log(map[string]any{
+		_ = lg.Log(map[string]any{
 			"type":    "deliverable_warning",
 			"task":    nav.TaskID,
 			"missing": missing,
@@ -347,25 +354,25 @@ func (d *Daemon) handleCompleteMarker(nav *state.NavigationResult, ns *state.Nod
 		// iteration (committed by the failure-path commit). Trust the
 		// agent's COMPLETE marker in that case.
 		if len(missing) > 0 || !hasDeliverables(ns, nav.TaskID) {
-			_ = d.Logger.Log(map[string]any{
+			_ = lg.Log(map[string]any{
 				"type": "no_progress",
 				"task": nav.TaskID,
 			})
 			d.log(map[string]any{"type": "task_event", "action": "no_progress", "task": nav.TaskID, "text": "No changes detected. Failing task."})
 			return false
 		}
-		_ = d.Logger.Log(map[string]any{
+		_ = lg.Log(map[string]any{
 			"type": "no_progress_but_deliverables_exist",
 			"task": nav.TaskID,
 			"text": "No new git changes, but all deliverables present. Accepting COMPLETE.",
 		})
 	}
 
-	_ = d.Logger.Log(map[string]any{"type": "terminal_marker", "marker": invoke.MarkerStringComplete})
+	_ = lg.Log(map[string]any{"type": "terminal_marker", "marker": invoke.MarkerStringComplete})
 	if err := d.Store.MutateNode(nav.NodeAddress, func(ns *state.NodeState) error {
 		return state.TaskComplete(ns, nav.TaskID)
 	}); err != nil {
-		_ = d.Logger.Log(map[string]any{"type": "complete_error", "task": nav.TaskID, "error": err.Error()})
+		_ = lg.Log(map[string]any{"type": "complete_error", "task": nav.TaskID, "error": err.Error()})
 	}
 
 	// Guard: audit tasks must not complete while open gaps remain.
@@ -400,9 +407,9 @@ func (d *Daemon) handleCompleteMarker(nav *state.NavigationResult, ns *state.Nod
 					return nil
 				})
 
-				created := d.createRemediationSubtasks(nav.NodeAddress, nav.TaskID)
+				created := d.createRemediationSubtasks(lg, nav.NodeAddress, nav.TaskID)
 				if created > 0 {
-					_ = d.Logger.Log(map[string]any{
+					_ = lg.Log(map[string]any{
 						"type":     "audit_complete_with_gaps",
 						"task":     nav.TaskID,
 						"subtasks": created,
@@ -414,7 +421,7 @@ func (d *Daemon) handleCompleteMarker(nav *state.NavigationResult, ns *state.Nod
 					_ = d.Store.MutateNode(nav.NodeAddress, func(ns2 *state.NodeState) error {
 						return state.TaskBlock(ns2, nav.TaskID, "open gaps remain")
 					})
-					_ = d.Logger.Log(map[string]any{
+					_ = lg.Log(map[string]any{
 						"type": "audit_blocked_open_gaps",
 						"task": nav.TaskID,
 					})
@@ -427,7 +434,7 @@ func (d *Daemon) handleCompleteMarker(nav *state.NavigationResult, ns *state.Nod
 				// under gitMu with scoped file lists.
 				if d.dispatcher == nil {
 					auditMeta := extractTaskCommitMeta(ns, nav.TaskID)
-					commitAfterIteration(d.RepoDir, d.Logger, nav.TaskID, "success", 0, d.Config.Git, auditMeta, nil)
+					commitAfterIteration(d.RepoDir, lg, nav.TaskID, "success", 0, d.Config.Git, auditMeta, nil)
 				}
 				return true
 			}
@@ -435,10 +442,10 @@ func (d *Daemon) handleCompleteMarker(nav *state.NavigationResult, ns *state.Nod
 	}
 
 	// Generate audit report when an audit task completes.
-	d.maybeWriteAuditReport(nav.NodeAddress, nav.TaskID)
+	d.maybeWriteAuditReport(lg, nav.NodeAddress, nav.TaskID)
 
 	if !d.Config.Pipeline.Planning.Enabled {
-		d.autoCompleteDecomposedParents(nav.NodeAddress)
+		d.autoCompleteDecomposedParents(lg, nav.NodeAddress)
 	}
 	// Refresh the in-memory index entry for the completed leaf so
 	// checkReplanningTriggers sees the current state. Without this,
@@ -461,15 +468,15 @@ func (d *Daemon) handleCompleteMarker(nav *state.NavigationResult, ns *state.Nod
 	// internally, but re-propagating here updates the in-memory idx
 	// and guards against silent propagation failures in the store.
 	if updatedNS, readErr := d.Store.ReadNode(nav.NodeAddress); readErr == nil {
-		if err := d.propagateState(nav.NodeAddress, updatedNS.State, idx); err != nil {
-			_ = d.Logger.Log(map[string]any{"type": "propagate_error", "error": err.Error()})
+		if err := d.propagateState(lg, nav.NodeAddress, updatedNS.State, idx); err != nil {
+			_ = lg.Log(map[string]any{"type": "propagate_error", "error": err.Error()})
 		}
 	}
 
 	// Commit after successful completion. In parallel mode,
 	// drainCompleted commits under gitMu with scoped file lists.
 	if d.dispatcher == nil {
-		commitAfterIteration(d.RepoDir, d.Logger, nav.TaskID, "success", 0, d.Config.Git, extractTaskCommitMeta(ns, nav.TaskID), nil)
+		commitAfterIteration(d.RepoDir, lg, nav.TaskID, "success", 0, d.Config.Git, extractTaskCommitMeta(ns, nav.TaskID), nil)
 	}
 
 	return true
@@ -479,7 +486,7 @@ func (d *Daemon) handleCompleteMarker(nav *state.NavigationResult, ns *state.Nod
 // found (or COMPLETE was cleared by the no-progress check). It records the
 // failure type, increments the failure counter, triggers decomposition or
 // auto-blocking at thresholds, and commits the result.
-func (d *Daemon) handleFailure(nav *state.NavigationResult, ns *state.NodeState, result *invoke.Result, marker string) {
+func (d *Daemon) handleFailure(lg *logging.Logger, nav *state.NavigationResult, ns *state.NodeState, result *invoke.Result, marker string) {
 	// Determine failure type for context injection on retry
 	failureType := "no_terminal_marker"
 	if scanTerminalMarker(result.Stdout) != "" {
@@ -487,7 +494,7 @@ func (d *Daemon) handleFailure(nav *state.NavigationResult, ns *state.NodeState,
 		failureType = "no_progress"
 	}
 
-	_ = d.Logger.Log(map[string]any{
+	_ = lg.Log(map[string]any{
 		"type":  failureType,
 		"empty": result.Stdout == "",
 		"task":  nav.TaskID,
@@ -511,29 +518,29 @@ func (d *Daemon) handleFailure(nav *state.NavigationResult, ns *state.NodeState,
 
 		if failCount >= d.Config.Failure.DecompositionThreshold && d.Config.Failure.DecompositionThreshold > 0 {
 			if ns.DecompositionDepth < d.Config.Failure.MaxDecompositionDepth {
-				_ = d.Logger.Log(map[string]any{"type": "decomposition_threshold", "task": nav.TaskID, "depth": ns.DecompositionDepth})
+				_ = lg.Log(map[string]any{"type": "decomposition_threshold", "task": nav.TaskID, "depth": ns.DecompositionDepth})
 				state.SetNeedsDecomposition(ns, nav.TaskID, true)
 			} else {
-				_ = d.Logger.Log(map[string]any{"type": "auto_block", "task": nav.TaskID, "reason": "max_decomposition_depth"})
+				_ = lg.Log(map[string]any{"type": "auto_block", "task": nav.TaskID, "reason": "max_decomposition_depth"})
 				if blockErr := state.TaskBlock(ns, nav.TaskID, "auto-blocked: decomposition threshold reached at max depth"); blockErr != nil {
-					_ = d.Logger.Log(map[string]any{"type": "auto_block_error", "task": nav.TaskID, "error": blockErr.Error()})
+					_ = lg.Log(map[string]any{"type": "auto_block_error", "task": nav.TaskID, "error": blockErr.Error()})
 				}
 			}
 		}
 
 		if failCount >= d.Config.Failure.HardCap && d.Config.Failure.HardCap > 0 {
-			_ = d.Logger.Log(map[string]any{"type": "auto_block", "task": nav.TaskID, "reason": "hard_cap", "count": failCount})
+			_ = lg.Log(map[string]any{"type": "auto_block", "task": nav.TaskID, "reason": "hard_cap", "count": failCount})
 			if blockErr := state.TaskBlock(ns, nav.TaskID, fmt.Sprintf("auto-blocked: failure hard cap reached (%d)", failCount)); blockErr != nil {
-				_ = d.Logger.Log(map[string]any{"type": "auto_block_error", "task": nav.TaskID, "error": blockErr.Error()})
+				_ = lg.Log(map[string]any{"type": "auto_block_error", "task": nav.TaskID, "error": blockErr.Error()})
 			}
 		}
 
 		return nil
 	})
 	if mutErr != nil {
-		_ = d.Logger.Log(map[string]any{"type": "failure_increment_error", "error": mutErr.Error()})
+		_ = lg.Log(map[string]any{"type": "failure_increment_error", "error": mutErr.Error()})
 	} else {
-		_ = d.Logger.Log(map[string]any{"type": "failure_increment", "task": nav.TaskID, "count": failCount})
+		_ = lg.Log(map[string]any{"type": "failure_increment", "task": nav.TaskID, "count": failCount})
 	}
 
 	// Commit code + state after all failure mutations are applied.
@@ -542,7 +549,7 @@ func (d *Daemon) handleFailure(nav *state.NavigationResult, ns *state.NodeState,
 	if d.dispatcher == nil {
 		failMeta := extractTaskCommitMeta(ns, nav.TaskID)
 		failMeta.FailureType = failureType
-		commitAfterIteration(d.RepoDir, d.Logger, nav.TaskID, "failure", failCount, d.Config.Git, failMeta, nil)
+		commitAfterIteration(d.RepoDir, lg, nav.TaskID, "failure", failCount, d.Config.Git, failMeta, nil)
 	}
 }
 
@@ -963,7 +970,7 @@ func commitDirect(repoDir string, gitCfg config.GitConfig, commitArgs []string, 
 	return nil
 }
 
-func (d *Daemon) autoCompleteDecomposedParents(nodeAddr string) {
+func (d *Daemon) autoCompleteDecomposedParents(lg *logging.Logger, nodeAddr string) {
 	ns, err := d.Store.ReadNode(nodeAddr)
 	if err != nil {
 		return
@@ -1011,7 +1018,7 @@ func (d *Daemon) autoCompleteDecomposedParents(nodeAddr string) {
 				}
 				return state.TaskComplete(ns2, taskID)
 			})
-			_ = d.Logger.Log(map[string]any{
+			_ = lg.Log(map[string]any{
 				"type": "auto_complete_parent",
 				"task": taskID,
 			})
@@ -1038,7 +1045,7 @@ func findNewTasks(before, after *state.NodeState) []string {
 // createRemediationSubtasks checks if the given task is an audit with
 // open gaps and, if so, creates a subtask for each gap. Returns the
 // number of subtasks created (0 if the task isn't an audit or has no gaps).
-func (d *Daemon) createRemediationSubtasks(nodeAddr, taskID string) int {
+func (d *Daemon) createRemediationSubtasks(lg *logging.Logger, nodeAddr, taskID string) int {
 	var created int
 	if err := d.Store.MutateNode(nodeAddr, func(ns *state.NodeState) error {
 		// Find the audit task
@@ -1117,7 +1124,7 @@ func (d *Daemon) createRemediationSubtasks(nodeAddr, taskID string) int {
 
 		return nil
 	}); err != nil {
-		_ = d.Logger.Log(map[string]any{
+		_ = lg.Log(map[string]any{
 			"type":  "remediation_subtask_error",
 			"node":  nodeAddr,
 			"task":  taskID,
@@ -1130,7 +1137,7 @@ func (d *Daemon) createRemediationSubtasks(nodeAddr, taskID string) int {
 // maybeWriteAuditReport checks if the completed task is an audit and, if so,
 // writes a markdown report to the node's directory. This is a best-effort
 // operation; failures are logged but do not block task completion.
-func (d *Daemon) maybeWriteAuditReport(nodeAddr, taskID string) {
+func (d *Daemon) maybeWriteAuditReport(lg *logging.Logger, nodeAddr, taskID string) {
 	ns, err := d.Store.ReadNode(nodeAddr)
 	if err != nil {
 		return
@@ -1150,7 +1157,7 @@ func (d *Daemon) maybeWriteAuditReport(nodeAddr, taskID string) {
 	now := d.Clock.Now()
 	reportPath, err := state.WriteAuditReport(d.Store.Dir(), nodeAddr, ns.Audit, ns.Name, now)
 	if err != nil {
-		_ = d.Logger.Log(map[string]any{
+		_ = lg.Log(map[string]any{
 			"type":  "audit_report_error",
 			"node":  nodeAddr,
 			"error": err.Error(),
@@ -1158,7 +1165,7 @@ func (d *Daemon) maybeWriteAuditReport(nodeAddr, taskID string) {
 		return
 	}
 
-	_ = d.Logger.Log(map[string]any{
+	_ = lg.Log(map[string]any{
 		"type": "audit_report_written",
 		"node": nodeAddr,
 		"path": reportPath,

--- a/internal/daemon/iteration_coverage_test.go
+++ b/internal/daemon/iteration_coverage_test.go
@@ -35,7 +35,7 @@ func TestRunIteration_AlreadyInProgress_SkipsClaim(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "skip-claim", TaskID: "task-0001", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	if err != nil {
 		t.Fatalf("runIteration error: %v", err)
 	}
@@ -87,7 +87,7 @@ with open('%s','w') as f: json.dump(data, f)
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "yield-decomp", TaskID: "task-0001", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	if err != nil {
 		t.Fatalf("runIteration error: %v", err)
 	}
@@ -146,7 +146,7 @@ with open('%s','w') as f: json.dump(data, f)
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "yield-plan", TaskID: "task-0001", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	if err != nil {
 		t.Fatalf("runIteration error: %v", err)
 	}
@@ -187,7 +187,7 @@ func TestRunIteration_YieldNoNewTasks(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "yield-no-new", TaskID: "task-0001", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	if err != nil {
 		t.Fatalf("runIteration error: %v", err)
 	}
@@ -227,7 +227,7 @@ func TestRunIteration_BlockedSuperseded_TreatedAsSkip(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "superseded-node", TaskID: "task-0001", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	if err != nil {
 		t.Fatalf("runIteration error: %v", err)
 	}
@@ -279,7 +279,7 @@ func TestRunIteration_BlockedAudit_CreatesRemediationSubtasks(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "audit-remediation", TaskID: "audit", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	if err != nil {
 		t.Fatalf("runIteration error: %v", err)
 	}
@@ -332,7 +332,7 @@ func TestRunIteration_RemediationSubtasks_InheritClass(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "class-inherit", TaskID: "audit", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	if err != nil {
 		t.Fatalf("runIteration error: %v", err)
 	}
@@ -370,7 +370,7 @@ func TestRunIteration_BlockedNormal_BlocksAndPropagates(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "blocked-normal", TaskID: "task-0001", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	if err != nil {
 		t.Fatalf("runIteration error: %v", err)
 	}
@@ -408,7 +408,7 @@ func TestRunIteration_Complete_MissingDeliverables(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "deliv-warn", TaskID: "task-0001", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	if err != nil {
 		t.Fatalf("runIteration error: %v", err)
 	}
@@ -445,7 +445,7 @@ func TestRunIteration_CompleteAudit_SkipsGitCheck(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "audit-complete", TaskID: "audit", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	if err != nil {
 		t.Fatalf("runIteration error: %v", err)
 	}
@@ -488,7 +488,7 @@ func TestRunIteration_CompleteNoGitProgress_FailsTask(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "no-progress", TaskID: "task-0001", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	if err != nil {
 		t.Fatalf("runIteration error: %v", err)
 	}
@@ -539,7 +539,7 @@ func TestRunIteration_Skip_AutoCompleteDecomposedParent(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "skip-auto", TaskID: "task-0003", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	if err != nil {
 		t.Fatalf("runIteration error: %v", err)
 	}
@@ -970,7 +970,7 @@ func TestAutoCompleteDecomposedParents_MissingSubtask(t *testing.T) {
 		{ID: "task-0002", Description: "child 1", State: state.StatusComplete},
 	})
 
-	d.autoCompleteDecomposedParents("auto-missing")
+	d.autoCompleteDecomposedParents(d.Logger, "auto-missing")
 
 	ns, _ := d.Store.ReadNode("auto-missing")
 	for _, task := range ns.Tasks {
@@ -992,7 +992,7 @@ func TestAutoCompleteDecomposedParents_NotDecomposed(t *testing.T) {
 			BlockedReason: "some other reason"},
 	})
 
-	d.autoCompleteDecomposedParents("auto-notdecomp")
+	d.autoCompleteDecomposedParents(d.Logger, "auto-notdecomp")
 
 	ns, _ := d.Store.ReadNode("auto-notdecomp")
 	for _, task := range ns.Tasks {
@@ -1008,7 +1008,7 @@ func TestAutoCompleteDecomposedParents_NotDecomposed(t *testing.T) {
 func TestAutoCompleteDecomposedParents_ReadError(t *testing.T) {
 	t.Parallel()
 	d := testDaemon(t)
-	d.autoCompleteDecomposedParents("nonexistent-node")
+	d.autoCompleteDecomposedParents(d.Logger, "nonexistent-node")
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1114,7 +1114,7 @@ func TestRunIteration_NoProgress_FailureType(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "fp-node", TaskID: "task-0001", Found: true}
-	_ = d.runIteration(context.Background(), nav, idx)
+	_ = d.runIteration(context.Background(), d.Logger, nav, idx)
 
 	ns, _ := d.Store.ReadNode("fp-node")
 	for _, task := range ns.Tasks {
@@ -1149,7 +1149,7 @@ func TestRunIteration_NoMarker_FailureType(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "ftm-node", TaskID: "task-0001", Found: true}
-	_ = d.runIteration(context.Background(), nav, idx)
+	_ = d.runIteration(context.Background(), d.Logger, nav, idx)
 
 	ns, _ := d.Store.ReadNode("ftm-node")
 	for _, task := range ns.Tasks {

--- a/internal/daemon/iteration_test.go
+++ b/internal/daemon/iteration_test.go
@@ -404,7 +404,7 @@ func TestRunIteration_SuccessCommit_CreatesCommit(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "success-commit", TaskID: "task-0001", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	if err != nil {
 		t.Fatalf("runIteration error: %v", err)
 	}
@@ -460,7 +460,7 @@ func TestRunIteration_SuccessCommit_SkippedWhenDisabled(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "no-success-commit", TaskID: "task-0001", Found: true}
-	_ = d.runIteration(context.Background(), nav, idx)
+	_ = d.runIteration(context.Background(), d.Logger, nav, idx)
 
 	afterLog := gitLog(t, repoDir)
 	if strings.Contains(afterLog, "task-0001 complete") {
@@ -508,7 +508,7 @@ func TestRunIteration_SuccessCommit_SkippedWhenAutoCommitDisabled(t *testing.T) 
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "no-auto-commit", TaskID: "task-0001", Found: true}
-	_ = d.runIteration(context.Background(), nav, idx)
+	_ = d.runIteration(context.Background(), d.Logger, nav, idx)
 
 	afterLog := gitLog(t, repoDir)
 	if strings.Count(afterLog, "\n") != strings.Count(beforeLog, "\n") {
@@ -556,7 +556,7 @@ func TestRunIteration_FailureCommit_CreatesCommit(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "fail-commit", TaskID: "task-0001", Found: true}
-	_ = d.runIteration(context.Background(), nav, idx)
+	_ = d.runIteration(context.Background(), d.Logger, nav, idx)
 
 	log := gitLog(t, repoDir)
 	if !strings.Contains(log, "task-0001 partial (attempt 1)") {
@@ -602,7 +602,7 @@ func TestRunIteration_FailureCommit_SkippedWhenDisabled(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "no-fail-commit", TaskID: "task-0001", Found: true}
-	_ = d.runIteration(context.Background(), nav, idx)
+	_ = d.runIteration(context.Background(), d.Logger, nav, idx)
 
 	afterLog := gitLog(t, repoDir)
 	if strings.Contains(afterLog, "partial (attempt") {
@@ -650,7 +650,7 @@ func TestRunIteration_SuccessCleanTree_NoEmptyCommit(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "clean-tree", TaskID: "task-0001", Found: true}
-	_ = d.runIteration(context.Background(), nav, idx)
+	_ = d.runIteration(context.Background(), d.Logger, nav, idx)
 
 	afterLog := gitLog(t, repoDir)
 	if strings.Contains(afterLog, "wolfcastle:") && !strings.Contains(beforeLog, "wolfcastle:") {
@@ -1077,7 +1077,7 @@ func TestRunIteration_StageComplete_HasDurationMs(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "duration-test", TaskID: "task-0001", Found: true}
-	_ = d.runIteration(context.Background(), nav, idx)
+	_ = d.runIteration(context.Background(), d.Logger, nav, idx)
 	d.Logger.Close()
 
 	records := readLogRecords(t, logDir)

--- a/internal/daemon/parallel.go
+++ b/internal/daemon/parallel.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime/debug"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -84,7 +85,15 @@ func (pd *ParallelDispatcher) runWorker(ctx context.Context, nav *state.Navigati
 	taskAddr := nav.NodeAddress + "/" + nav.TaskID
 	workerCtx, cancel := context.WithCancel(ctx)
 
-	logger := pd.daemon.Logger.Child(fmt.Sprintf("worker-%s", nav.TaskID))
+	// Include the slugified node address in the prefix so workers on
+	// different nodes with the same task ID (e.g., "task-0001") don't
+	// collide on the same filename. The Child logger's iteration
+	// counter starts at zero per instance, so without the node slug
+	// every worker with the same TaskID would produce the identical
+	// "0001-worker-{TaskID}-{ts}.jsonl" path, stomping each other's
+	// writes.
+	nodeSlug := strings.ReplaceAll(nav.NodeAddress, "/", "-")
+	logger := pd.daemon.Logger.Child(fmt.Sprintf("worker-%s-%s", nodeSlug, nav.TaskID))
 
 	pd.mu.Lock()
 	pd.active[taskAddr] = &WorkerSlot{
@@ -121,9 +130,22 @@ func (pd *ParallelDispatcher) runWorker(ctx context.Context, nav *state.Navigati
 		}()
 
 		_ = logger.StartIteration()
+		// StartIteration stamps the full slugified prefix onto TraceID,
+		// which makes each record carry a 100+ character trace field
+		// (the same string we use for the filename to guarantee unique
+		// paths across workers). Override to a compact form — the last
+		// segment of the node address plus the task ID — so the log
+		// view's [trace] column stays readable. Collisions in the
+		// compact form are fine; records already carry the full node
+		// address for disambiguation.
+		shortNode := nav.NodeAddress
+		if idx := strings.LastIndex(shortNode, "/"); idx >= 0 {
+			shortNode = shortNode[idx+1:]
+		}
+		logger.TraceID = fmt.Sprintf("worker-%s-%s-%04d", shortNode, nav.TaskID, logger.Iteration)
 		_ = logger.LogIterationStart("execute", nav.NodeAddress)
 
-		err := pd.daemon.runIteration(workerCtx, nav, idx)
+		err := pd.daemon.runIteration(workerCtx, logger, nav, idx)
 		logger.Close()
 
 		wr := WorkerResult{
@@ -289,7 +311,13 @@ done:
 				if updated, err := d.Store.ReadNode(wr.Node); err == nil {
 					idx, idxErr := d.Store.ReadIndex()
 					if idxErr == nil {
-						_ = d.propagateState(wr.Node, updated.State, idx)
+						// The worker's logger is already closed at this
+						// point; drainCompleted runs back in the main
+						// loop. The fallback-diagnostic record in
+						// propagateState only fires if the index can't
+						// be re-read, so dropping it to d.Logger is a
+						// small regression if no parent file is open.
+						_ = d.propagateState(d.Logger, wr.Node, updated.State, idx)
 					}
 				}
 			}

--- a/internal/daemon/planning.go
+++ b/internal/daemon/planning.go
@@ -217,7 +217,7 @@ func (d *Daemon) runPlanningPass(ctx context.Context, nodeAddr string, ns *state
 	})
 
 	// Invoke the model
-	result, err := d.invokeWithRetry(ctx, model, prompt, d.RepoDir, d.Logger.AssistantWriter(), "plan")
+	result, err := d.invokeWithRetry(ctx, d.Logger, model, prompt, d.RepoDir, d.Logger.AssistantWriter(), "plan")
 	if err != nil {
 		_ = d.Logger.Log(map[string]any{"type": "planning_error", "error": err.Error()})
 		d.Logger.Close()
@@ -282,7 +282,7 @@ func (d *Daemon) runPlanningPass(ctx context.Context, nodeAddr string, ns *state
 		if freshNS, readErr := d.Store.ReadNode(nodeAddr); readErr == nil {
 			derivedState = freshNS.State
 		}
-		if err := d.propagateState(nodeAddr, derivedState, idx); err != nil {
+		if err := d.propagateState(d.Logger, nodeAddr, derivedState, idx); err != nil {
 			_ = d.Logger.Log(map[string]any{"type": "propagate_error", "error": err.Error()})
 		}
 

--- a/internal/daemon/propagate.go
+++ b/internal/daemon/propagate.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"fmt"
 
+	"github.com/dorkusprime/wolfcastle/internal/logging"
 	"github.com/dorkusprime/wolfcastle/internal/state"
 )
 
@@ -12,13 +13,17 @@ import (
 // that CLI commands (called by the intake model) added during iteration.
 // All reads and writes happen inside a single lock hold, so the
 // load/save callbacks use raw I/O (no nested locking).
-func (d *Daemon) propagateState(nodeAddr string, nodeState state.NodeStatus, idx *state.RootIndex) error {
+//
+// lg is the logger for the fallback-diagnostic record emitted when the
+// index can't be re-read. Callers pass the worker's child logger in
+// parallel mode and d.Logger in the sequential path.
+func (d *Daemon) propagateState(lg *logging.Logger, nodeAddr string, nodeState state.NodeStatus, idx *state.RootIndex) error {
 	return d.Store.WithLock(func() error {
 		// Re-read the index from disk to pick up concurrent modifications.
 		freshIdx, err := state.LoadRootIndex(d.Store.IndexPath())
 		if err != nil {
 			// Fall back to the in-memory copy if the file can't be read.
-			_ = d.Logger.Log(map[string]any{
+			_ = lg.Log(map[string]any{
 				"type":  "propagate_index_read_fallback",
 				"node":  nodeAddr,
 				"error": err.Error(),

--- a/internal/daemon/regression_test.go
+++ b/internal/daemon/regression_test.go
@@ -60,7 +60,7 @@ func TestPropagateState_PreservesNewNodesAddedDuringIteration(t *testing.T) {
 
 	// Now propagate using the daemon's stale in-memory idx (which
 	// knows nothing about node-b).
-	if err := d.propagateState("node-a", state.StatusComplete, idx); err != nil {
+	if err := d.propagateState(d.Logger, "node-a", state.StatusComplete, idx); err != nil {
 		t.Fatalf("propagateState error: %v", err)
 	}
 
@@ -112,7 +112,7 @@ func TestPropagateState_FallsBackToInMemoryOnDiskError(t *testing.T) {
 	// behavior is that it doesn't panic or return a load error.
 	// The save may or may not succeed depending on the fallback path;
 	// we only verify no panic and that the in-memory idx gets the update.
-	_ = d.propagateState("node-a", state.StatusComplete, idx)
+	_ = d.propagateState(d.Logger, "node-a", state.StatusComplete, idx)
 
 	if idx.Nodes["node-a"].State != state.StatusComplete {
 		t.Errorf("expected in-memory state to be complete, got %s", idx.Nodes["node-a"].State)

--- a/internal/daemon/remediation_test.go
+++ b/internal/daemon/remediation_test.go
@@ -40,7 +40,7 @@ func TestRunIteration_SkipBypassesProgressCheck(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "skip-node", TaskID: "task-0001", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	if err != nil {
 		t.Fatalf("runIteration error: %v", err)
 	}
@@ -91,7 +91,7 @@ func TestRunIteration_AuditSkipsProgressCheck(t *testing.T) {
 
 	idx, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "audit-node", TaskID: "audit-0001", Found: true}
-	err := d.runIteration(context.Background(), nav, idx)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx)
 	if err != nil {
 		t.Fatalf("runIteration error: %v", err)
 	}
@@ -151,7 +151,7 @@ func TestRunIteration_MissingDeliverables_WarnsButCompletes(t *testing.T) {
 
 	idx2, _ := d.Store.ReadIndex()
 	nav := &state.NavigationResult{NodeAddress: "deliv-node", TaskID: "task-0001", Found: true}
-	err := d.runIteration(context.Background(), nav, idx2)
+	err := d.runIteration(context.Background(), d.Logger, nav, idx2)
 	if err != nil {
 		t.Fatalf("runIteration error: %v", err)
 	}
@@ -258,7 +258,7 @@ func TestAutoCompleteDecomposedParents(t *testing.T) {
 		},
 	})
 
-	d.autoCompleteDecomposedParents("decomp-node")
+	d.autoCompleteDecomposedParents(d.Logger, "decomp-node")
 
 	ns, _ := d.Store.ReadNode("decomp-node")
 	for _, task := range ns.Tasks {
@@ -297,7 +297,7 @@ func TestAutoCompleteDecomposedParents_IncompleteSubtask(t *testing.T) {
 		},
 	})
 
-	d.autoCompleteDecomposedParents("partial-node")
+	d.autoCompleteDecomposedParents(d.Logger, "partial-node")
 
 	ns, _ := d.Store.ReadNode("partial-node")
 	for _, task := range ns.Tasks {

--- a/internal/daemon/retry.go
+++ b/internal/daemon/retry.go
@@ -10,13 +10,20 @@ import (
 	"github.com/dorkusprime/wolfcastle/internal/config"
 	werrors "github.com/dorkusprime/wolfcastle/internal/errors"
 	"github.com/dorkusprime/wolfcastle/internal/invoke"
+	"github.com/dorkusprime/wolfcastle/internal/logging"
 )
 
 // invokeWithRetry wraps ProcessInvoker.Invoke with exponential backoff
 // governed by the config's retries settings. Only invocation errors (non-nil
 // error returns) are retried. A successful process exit (even with a
 // non-zero exit code captured in Result) is not retried here.
-func (d *Daemon) invokeWithRetry(ctx context.Context, model config.ModelDef, prompt string, workDir string, logWriter io.Writer, stageName string) (*invoke.Result, error) {
+//
+// lg is the logger that receives retry/exhaustion records. In parallel
+// mode each worker passes its own child logger; the sequential path
+// passes d.Logger. Callers must never pass nil — the records would be
+// dropped on the floor just like they were before parallel mode's
+// logger plumbing was fixed.
+func (d *Daemon) invokeWithRetry(ctx context.Context, lg *logging.Logger, model config.ModelDef, prompt string, workDir string, logWriter io.Writer, stageName string) (*invoke.Result, error) {
 	rc := d.Config.Retries
 	delay := time.Duration(rc.InitialDelaySeconds) * time.Second
 	maxDelay := time.Duration(rc.MaxDelaySeconds) * time.Second
@@ -39,7 +46,7 @@ func (d *Daemon) invokeWithRetry(ctx context.Context, model config.ModelDef, pro
 
 		// Check whether we've exhausted our retry budget (-1 = unlimited).
 		if rc.MaxRetries >= 0 && attempt >= rc.MaxRetries {
-			_ = d.Logger.Log(map[string]any{
+			_ = lg.Log(map[string]any{
 				"type":     "retry_exhausted",
 				"stage":    stageName,
 				"attempts": attempt + 1,
@@ -48,7 +55,7 @@ func (d *Daemon) invokeWithRetry(ctx context.Context, model config.ModelDef, pro
 			return result, werrors.Invocation(err)
 		}
 
-		_ = d.Logger.Log(map[string]any{
+		_ = lg.Log(map[string]any{
 			"type":    "retry",
 			"stage":   stageName,
 			"attempt": attempt + 1,

--- a/internal/daemon/stages.go
+++ b/internal/daemon/stages.go
@@ -227,7 +227,7 @@ func (d *Daemon) runIntakeStage(ctx context.Context, stage config.PipelineStage)
 		}
 
 		itemStart := time.Now()
-		result, err := d.invokeWithRetry(invokeCtx, model, prompt, d.RepoDir, d.InboxLogger.AssistantWriter(), "intake")
+		result, err := d.invokeWithRetry(invokeCtx, d.InboxLogger, model, prompt, d.RepoDir, d.InboxLogger.AssistantWriter(), "intake")
 		if invokeCancel != nil {
 			invokeCancel()
 		}

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
@@ -156,6 +157,15 @@ func (l *Logger) LogIterationStart(stageType, nodeAddr string) error {
 // LevelInfo (backward compatible per ADR-046).
 func (l *Logger) Log(record map[string]any, levels ...Level) error {
 	if l.file == nil {
+		// Silent-drop canary. Parallel mode introduced a class of
+		// bugs where worker content was logged to a Logger whose
+		// file had never been opened, and every call site's `_ =`
+		// swallowed the "no active iteration" error. The next time
+		// that regression ships, this line makes it visible in the
+		// daemon.log tail instead of hiding behind empty log files.
+		fmt.Fprintf(os.Stderr, "wolfcastle: log record dropped (no active iteration): type=%v trace=%q\n",
+			record["type"], l.TraceID)
+		droppedRecords.Add(1)
 		return fmt.Errorf("no active iteration")
 	}
 
@@ -338,74 +348,108 @@ func IsLogFile(name string) bool {
 // EnforceRetention deletes old log files based on max count and age,
 // then optionally compresses remaining files if compress is true.
 func EnforceRetention(logDir string, maxFiles int, maxAgeDays int, opts ...RetentionOption) error {
-	ro := retentionOpts{compress: false}
+	ro := retentionOpts{compress: false, quietWindow: compressionQuietWindow}
 	for _, o := range opts {
 		o(&ro)
 	}
 
-	entries, err := os.ReadDir(logDir)
-	if err != nil {
-		return fmt.Errorf("reading log directory for retention: %w", err)
-	}
-	var logs []os.DirEntry
-	for _, e := range entries {
-		if !e.IsDir() && IsLogFile(e.Name()) {
-			logs = append(logs, e)
-		}
-	}
+	now := nowFunc()
+	quietCutoff := now.Add(-ro.quietWindow)
 
-	// Sort by name (which sorts by iteration number + timestamp)
-	sort.Slice(logs, func(i, j int) bool {
-		return logs[i].Name() < logs[j].Name()
-	})
-
-	cutoff := nowFunc().AddDate(0, 0, -maxAgeDays)
-
-	// Delete by age
-	for _, l := range logs {
-		info, err := l.Info()
+	// collect captures every log file along with its mtime. Sorting by
+	// mtime — rather than filename — is what keeps parallel workers
+	// safe: a worker logger's filename starts with "0001-..." because
+	// its child iteration counter is fresh, so an alphabetical sort
+	// treats brand-new worker files as the oldest in the directory
+	// and retention would happily delete or compress them first.
+	collect := func() []logFileInfo {
+		entries, err := os.ReadDir(logDir)
 		if err != nil {
+			return nil
+		}
+		out := make([]logFileInfo, 0, len(entries))
+		for _, e := range entries {
+			if e.IsDir() || !IsLogFile(e.Name()) {
+				continue
+			}
+			info, err := e.Info()
+			if err != nil {
+				continue
+			}
+			out = append(out, logFileInfo{name: e.Name(), modTime: info.ModTime()})
+		}
+		sort.Slice(out, func(i, j int) bool {
+			return out[i].modTime.Before(out[j].modTime)
+		})
+		return out
+	}
+
+	logs := collect()
+	if logs == nil {
+		return fmt.Errorf("reading log directory for retention: unreadable")
+	}
+
+	ageCutoff := now.AddDate(0, 0, -maxAgeDays)
+
+	// Delete by age. Files still in the quiet window are skipped so an
+	// active worker's file can never be removed out from under it.
+	for _, l := range logs {
+		if l.modTime.After(quietCutoff) {
 			continue
 		}
-		if info.ModTime().Before(cutoff) {
-			_ = os.Remove(filepath.Join(logDir, l.Name()))
+		if l.modTime.Before(ageCutoff) {
+			_ = os.Remove(filepath.Join(logDir, l.name))
 		}
 	}
 
-	// Re-read and delete by count
-	entries, _ = os.ReadDir(logDir)
-	logs = nil
-	for _, e := range entries {
-		if !e.IsDir() && IsLogFile(e.Name()) {
-			logs = append(logs, e)
-		}
-	}
+	// Re-read and delete by count (oldest mtime first, skipping any
+	// file still in the quiet window).
+	logs = collect()
 	if len(logs) > maxFiles {
-		sort.Slice(logs, func(i, j int) bool {
-			return logs[i].Name() < logs[j].Name()
-		})
-		for _, l := range logs[:len(logs)-maxFiles] {
-			_ = os.Remove(filepath.Join(logDir, l.Name()))
+		stale := make([]logFileInfo, 0, len(logs))
+		for _, l := range logs {
+			if l.modTime.After(quietCutoff) {
+				continue
+			}
+			stale = append(stale, l)
+		}
+		// Delete from the oldest stale files until either the budget
+		// is met or we run out of stale candidates. Fresh files are
+		// never removed even if that leaves the dir temporarily
+		// over budget — retention will catch up on the next tick.
+		overBy := len(logs) - maxFiles
+		if overBy > len(stale) {
+			overBy = len(stale)
+		}
+		for _, l := range stale[:overBy] {
+			_ = os.Remove(filepath.Join(logDir, l.name))
 		}
 	}
 
-	// Compress surviving uncompressed files (excluding the newest, which
-	// may still be actively written to).
+	// Compress surviving uncompressed files, skipping any file whose
+	// mtime is within compressionQuietWindow. In parallel mode several
+	// workers write concurrently, and compressing a file still held
+	// open by another worker unlinks it mid-write and silently loses
+	// the content. We also keep the single mtime-newest stale file
+	// uncompressed so the sequential daemon's tail stays readable on
+	// disk without a gzip round-trip.
 	if ro.compress {
-		entries, _ = os.ReadDir(logDir)
-		var uncompressed []os.DirEntry
-		for _, e := range entries {
-			if !e.IsDir() && strings.HasSuffix(e.Name(), ".jsonl") {
-				uncompressed = append(uncompressed, e)
+		logs = collect()
+		var stale []logFileInfo
+		for _, l := range logs {
+			if !strings.HasSuffix(l.name, ".jsonl") {
+				continue
 			}
+			if l.modTime.After(quietCutoff) {
+				continue
+			}
+			stale = append(stale, l)
 		}
-		// Keep the newest uncompressed file open. Compress only older ones.
-		if len(uncompressed) > 1 {
-			sort.Slice(uncompressed, func(i, j int) bool {
-				return uncompressed[i].Name() < uncompressed[j].Name()
-			})
-			for _, e := range uncompressed[:len(uncompressed)-1] {
-				src := filepath.Join(logDir, e.Name())
+		if len(stale) > 1 {
+			// collect() sorted by mtime ascending, so the mtime-newest
+			// stale file is at the end — skip it.
+			for _, l := range stale[:len(stale)-1] {
+				src := filepath.Join(logDir, l.name)
 				if err := compressFile(src); err != nil {
 					// Non-fatal: the file simply stays uncompressed.
 					continue
@@ -417,17 +461,58 @@ func EnforceRetention(logDir string, maxFiles int, maxAgeDays int, opts ...Reten
 	return nil
 }
 
+// logFileInfo is the minimal view of a log file used by retention: we
+// only need the basename (to open/delete it) and the mtime (to sort and
+// gate against the compression quiet window).
+type logFileInfo struct {
+	name    string
+	modTime time.Time
+}
+
+// compressionQuietWindow is the duration a log file must be idle (no
+// writes) before retention is allowed to compress or delete it. In
+// parallel mode, compressing or unlinking a file still held open by a
+// worker orphans the content, so retention backs off until the file
+// has been quiescent.
+const compressionQuietWindow = 30 * time.Second
+
+// droppedRecords counts records dropped because Logger.Log was called
+// without an active iteration file. Exposed via DroppedRecords for
+// daemon health checks and test assertions; incremented atomically
+// because workers hold independent Logger instances.
+var droppedRecords atomic.Uint64
+
+// DroppedRecords returns the total number of log records silently
+// dropped because no iteration file was open when Log was invoked.
+// A healthy daemon should return 0 at all times; any non-zero value
+// means a code path is calling Log on an uninitialized Logger.
+func DroppedRecords() uint64 {
+	return droppedRecords.Load()
+}
+
 // RetentionOption configures optional retention behaviour.
 type RetentionOption func(*retentionOpts)
 
 type retentionOpts struct {
-	compress bool
+	compress    bool
+	quietWindow time.Duration
 }
 
 // WithCompression enables gzip compression of old log files.
 func WithCompression() RetentionOption {
 	return func(o *retentionOpts) {
 		o.compress = true
+	}
+}
+
+// WithQuietWindow overrides the default quiet window that retention
+// uses to decide when a file is safe to compress or delete. The daemon
+// relies on the default (see compressionQuietWindow) so active workers
+// never have their open files removed; tests that want retention to
+// operate on fresh fixtures can pass WithQuietWindow(0).
+func WithQuietWindow(d time.Duration) RetentionOption {
+	return func(o *retentionOpts) {
+		o.quietWindow = d
 	}
 }
 

--- a/internal/logging/logger_coverage_test.go
+++ b/internal/logging/logger_coverage_test.go
@@ -92,7 +92,7 @@ func TestEnforceRetention_AgeCutoff_WithFrozenClock(t *testing.T) {
 	newFile := filepath.Join(dir, "0002-20260314T00-00Z.jsonl")
 	_ = os.WriteFile(newFile, []byte("{}"), 0644)
 
-	if err := EnforceRetention(dir, 100, 30); err != nil {
+	if err := EnforceRetention(dir, 100, 30, WithQuietWindow(0)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -109,12 +109,14 @@ func TestEnforceRetention_CompressionWithMultipleFiles(t *testing.T) {
 	dir := t.TempDir()
 
 	content := `{"level":"info"}` + "\n"
+	backdate := time.Now().Add(-2 * time.Minute)
 	for i := 1; i <= 5; i++ {
 		name := filepath.Join(dir, fmt.Sprintf("%04d-20260101T00-00Z.jsonl", i))
 		_ = os.WriteFile(name, []byte(content), 0644)
+		_ = os.Chtimes(name, backdate, backdate)
 	}
 
-	if err := EnforceRetention(dir, 100, 365, WithCompression()); err != nil {
+	if err := EnforceRetention(dir, 100, 365, WithCompression(), WithQuietWindow(0)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -145,8 +147,12 @@ func TestEnforceRetention_MixedGzAndPlain(t *testing.T) {
 	_ = os.WriteFile(filepath.Join(dir, "0001-20260101T00-00Z.jsonl.gz"), []byte("compressed"), 0644)
 	_ = os.WriteFile(filepath.Join(dir, "0002-20260102T00-00Z.jsonl"), []byte("{}"), 0644)
 	_ = os.WriteFile(filepath.Join(dir, "0003-20260103T00-00Z.jsonl"), []byte("{}"), 0644)
+	// Back-date the plain files so compression is eligible immediately.
+	backdate := time.Now().Add(-2 * time.Minute)
+	_ = os.Chtimes(filepath.Join(dir, "0002-20260102T00-00Z.jsonl"), backdate, backdate)
+	_ = os.Chtimes(filepath.Join(dir, "0003-20260103T00-00Z.jsonl"), backdate, backdate)
 
-	if err := EnforceRetention(dir, 100, 365, WithCompression()); err != nil {
+	if err := EnforceRetention(dir, 100, 365, WithCompression(), WithQuietWindow(0)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -168,7 +174,7 @@ func TestEnforceRetention_CountDeletesOldestFirst(t *testing.T) {
 		_ = os.WriteFile(name, []byte("{}"), 0644)
 	}
 
-	if err := EnforceRetention(dir, 3, 365); err != nil {
+	if err := EnforceRetention(dir, 3, 365, WithQuietWindow(0)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -268,7 +274,7 @@ func TestEnforceRetention_CompressionErrorNonFatal(t *testing.T) {
 	defer func() { _ = os.Chmod(filepath.Join(dir, "0001-20260101T00-00Z.jsonl"), 0644) }()
 
 	// Should not error. Compression failures are non-fatal
-	if err := EnforceRetention(dir, 100, 365, WithCompression()); err != nil {
+	if err := EnforceRetention(dir, 100, 365, WithCompression(), WithQuietWindow(0)); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -341,7 +347,7 @@ func TestEnforceRetention_OnlyGzFiles_NoCompression(t *testing.T) {
 	}
 
 	// No uncompressed files. Compression pass should be a no-op
-	if err := EnforceRetention(dir, 100, 365, WithCompression()); err != nil {
+	if err := EnforceRetention(dir, 100, 365, WithCompression(), WithQuietWindow(0)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -395,7 +401,7 @@ func TestEnforceRetention_NoUncompressedFiles_SkipsCompression(t *testing.T) {
 	_ = os.WriteFile(filepath.Join(dir, "0001-20260101T00-00Z.jsonl.gz"), []byte("gz1"), 0644)
 	_ = os.WriteFile(filepath.Join(dir, "0002-20260102T00-00Z.jsonl.gz"), []byte("gz2"), 0644)
 
-	if err := EnforceRetention(dir, 100, 365, WithCompression()); err != nil {
+	if err := EnforceRetention(dir, 100, 365, WithCompression(), WithQuietWindow(0)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -412,7 +418,7 @@ func TestEnforceRetention_SingleUncompressed_NotCompressed(t *testing.T) {
 	// Single uncompressed file should NOT be compressed (might be active)
 	_ = os.WriteFile(filepath.Join(dir, "0001-20260101T00-00Z.jsonl"), []byte("{}"), 0644)
 
-	if err := EnforceRetention(dir, 100, 365, WithCompression()); err != nil {
+	if err := EnforceRetention(dir, 100, 365, WithCompression(), WithQuietWindow(0)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -440,7 +446,7 @@ func TestEnforceRetention_AgeAndCountCombined(t *testing.T) {
 	}
 
 	// maxFiles=10 (won't trigger), maxAgeDays=30 (removes 2 old)
-	if err := EnforceRetention(dir, 10, 30); err != nil {
+	if err := EnforceRetention(dir, 10, 30, WithQuietWindow(0)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -498,7 +504,7 @@ func TestEnforceRetention_SymlinkInfoError(t *testing.T) {
 	_ = os.Symlink(brokenTarget, brokenLink)
 
 	// EnforceRetention should handle Info() errors gracefully
-	if err := EnforceRetention(dir, 100, 1); err != nil {
+	if err := EnforceRetention(dir, 100, 1, WithQuietWindow(0)); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/logging/logger_deep_coverage_test.go
+++ b/internal/logging/logger_deep_coverage_test.go
@@ -234,7 +234,7 @@ func TestClose_Idempotent(t *testing.T) {
 
 func TestEnforceRetention_UnreadableDirectory(t *testing.T) {
 	t.Parallel()
-	err := EnforceRetention("/nonexistent/dir/xyz", 10, 30)
+	err := EnforceRetention("/nonexistent/dir/xyz", 10, 30, WithQuietWindow(0))
 	if err == nil {
 		t.Error("expected error for nonexistent directory")
 	}

--- a/internal/logging/logger_errorpath_test.go
+++ b/internal/logging/logger_errorpath_test.go
@@ -71,7 +71,7 @@ func TestEnforceRetention_CompressUnreadableFile(t *testing.T) {
 	_ = os.Chmod(filepath.Join(dir, "0001-20260101T00-00Z.jsonl"), 0000)
 	defer func() { _ = os.Chmod(filepath.Join(dir, "0001-20260101T00-00Z.jsonl"), 0644) }()
 
-	err := EnforceRetention(dir, 100, 30, WithCompression())
+	err := EnforceRetention(dir, 100, 30, WithCompression(), WithQuietWindow(0))
 	if err != nil {
 		t.Fatalf("EnforceRetention should succeed even when compression of one file fails: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestEnforceRetention_CompressWithReadOnlyDestDir(t *testing.T) {
 	_ = os.Chmod(dir, 0555)
 	defer func() { _ = os.Chmod(dir, 0755) }()
 
-	err := EnforceRetention(dir, 100, 30, WithCompression())
+	err := EnforceRetention(dir, 100, 30, WithCompression(), WithQuietWindow(0))
 	if err != nil {
 		t.Fatalf("EnforceRetention should succeed even when .gz creation fails: %v", err)
 	}
@@ -122,7 +122,7 @@ func TestEnforceRetention_DeletesByCount(t *testing.T) {
 	}
 
 	// Keep only 2 newest
-	err := EnforceRetention(dir, 2, 30)
+	err := EnforceRetention(dir, 2, 30, WithQuietWindow(0))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -561,7 +561,7 @@ func TestEnforceRetention_DeletesOldFilesByCount(t *testing.T) {
 		_ = os.WriteFile(name, []byte("{}"), 0644)
 	}
 
-	if err := EnforceRetention(dir, 2, 365); err != nil {
+	if err := EnforceRetention(dir, 2, 365, WithQuietWindow(0)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -583,7 +583,7 @@ func TestEnforceRetention_DeletesOldFilesByAge(t *testing.T) {
 	newFile := filepath.Join(dir, "0002-20260301T00-00Z.jsonl")
 	_ = os.WriteFile(newFile, []byte("{}"), 0644)
 
-	if err := EnforceRetention(dir, 100, 30); err != nil {
+	if err := EnforceRetention(dir, 100, 30, WithQuietWindow(0)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -601,7 +601,7 @@ func TestEnforceRetention_MaxFilesZero_DeletesAll(t *testing.T) {
 		_ = os.WriteFile(filepath.Join(dir, fmt.Sprintf("%04d-20260101T00-00Z.jsonl", i)), []byte("{}"), 0644)
 	}
 
-	if err := EnforceRetention(dir, 0, 365); err != nil {
+	if err := EnforceRetention(dir, 0, 365, WithQuietWindow(0)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -621,7 +621,7 @@ func TestEnforceRetention_MaxAgeDaysZero_DeletesAllByAge(t *testing.T) {
 		_ = os.Chtimes(name, old, old)
 	}
 
-	if err := EnforceRetention(dir, 100, 0); err != nil {
+	if err := EnforceRetention(dir, 100, 0, WithQuietWindow(0)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -637,7 +637,7 @@ func TestEnforceRetention_IgnoresDirectories(t *testing.T) {
 	_ = os.WriteFile(filepath.Join(dir, "0001-20260101T00-00Z.jsonl"), []byte("{}"), 0644)
 	_ = os.MkdirAll(filepath.Join(dir, "subdir"), 0755)
 
-	if err := EnforceRetention(dir, 100, 365); err != nil {
+	if err := EnforceRetention(dir, 100, 365, WithQuietWindow(0)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -659,7 +659,7 @@ func TestEnforceRetention_CountsGzFiles(t *testing.T) {
 		_ = os.WriteFile(filepath.Join(dir, fmt.Sprintf("%04d-20260101T00-00Z%s", i, suffix)), []byte("{}"), 0644)
 	}
 
-	if err := EnforceRetention(dir, 3, 365); err != nil {
+	if err := EnforceRetention(dir, 3, 365, WithQuietWindow(0)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -670,7 +670,7 @@ func TestEnforceRetention_CountsGzFiles(t *testing.T) {
 
 func TestEnforceRetention_ErrorOnMissingDir(t *testing.T) {
 	t.Parallel()
-	err := EnforceRetention(filepath.Join(t.TempDir(), "nonexistent"), 10, 30)
+	err := EnforceRetention(filepath.Join(t.TempDir(), "nonexistent"), 10, 30, WithQuietWindow(0))
 	if err == nil {
 		t.Error("expected error for missing directory")
 	}
@@ -687,7 +687,16 @@ func TestEnforceRetention_WithCompression(t *testing.T) {
 	_ = os.WriteFile(filepath.Join(dir, "0002-20260102T00-00Z.jsonl"), []byte(content), 0644)
 	_ = os.WriteFile(filepath.Join(dir, "0003-20260103T00-00Z.jsonl"), []byte(content), 0644)
 
-	if err := EnforceRetention(dir, 100, 365, WithCompression()); err != nil {
+	// Back-date fixtures past the compression quiet window so they
+	// are eligible for compression immediately. The real daemon
+	// relies on mtime staleness to avoid compressing files that
+	// active workers are still writing to.
+	backdate := time.Now().Add(-2 * time.Minute)
+	for _, name := range []string{"0001-20260101T00-00Z.jsonl", "0002-20260102T00-00Z.jsonl", "0003-20260103T00-00Z.jsonl"} {
+		_ = os.Chtimes(filepath.Join(dir, name), backdate, backdate)
+	}
+
+	if err := EnforceRetention(dir, 100, 365, WithCompression(), WithQuietWindow(0)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -738,7 +747,7 @@ func TestEnforceRetention_WithCompression_SingleFile_NotCompressed(t *testing.T)
 
 	_ = os.WriteFile(filepath.Join(dir, "0001-20260101T00-00Z.jsonl"), []byte("{}"), 0644)
 
-	if err := EnforceRetention(dir, 100, 365, WithCompression()); err != nil {
+	if err := EnforceRetention(dir, 100, 365, WithCompression(), WithQuietWindow(0)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/tui/detail/logview.go
+++ b/internal/tui/detail/logview.go
@@ -552,6 +552,8 @@ func traceCategory(trace string) string {
 	switch {
 	case strings.HasPrefix(trace, "exec"):
 		return "exec"
+	case strings.HasPrefix(trace, "worker"):
+		return "worker"
 	case strings.HasPrefix(trace, "plan"):
 		return "plan"
 	case strings.HasPrefix(trace, "intake"), strings.HasPrefix(trace, "inbox"):
@@ -592,7 +594,7 @@ func (m *LogViewModel) cycleLevelFilter() {
 	m.levelFilter = "all"
 }
 
-var traceCycle = []string{"all", "exec", "plan", "inbox", "system"}
+var traceCycle = []string{"all", "exec", "worker", "plan", "inbox", "system"}
 
 func (m *LogViewModel) cycleTraceFilter() {
 	for i, v := range traceCycle {

--- a/internal/tui/detail/logview_test.go
+++ b/internal/tui/detail/logview_test.go
@@ -200,7 +200,7 @@ func TestKey_T_CycleTraceFilter(t *testing.T) {
 	m := NewLogViewModel()
 	m.SetSize(80, 24)
 
-	expected := []string{"exec", "plan", "inbox", "system", "all"}
+	expected := []string{"exec", "worker", "plan", "inbox", "system", "all"}
 	for _, want := range expected {
 		m, _ = m.Update(keyPress('T'))
 		if m.traceFilter != want {


### PR DESCRIPTION
## Summary

Parallel mode has been silently dropping every log record produced inside \`runIteration\` since parallel execution shipped in v0.3. The dropped records included assistant output, tool calls, stage_complete, terminal markers, and everything else — producing 170-byte stub files containing only an \`iteration_start\` line. The TUI log modal was dark in parallel mode, and downstream symptoms (no activity in the header, stall detector blind to workers, silent auto-commit) were all variations on the same root cause.

## Root cause

\`runIteration\` and its transitive helpers unconditionally called \`d.Logger.Log(...)\`. In the sequential path, \`daemon.go:828\` opens a fresh \`exec\` file on \`d.Logger\` right before invoking \`runIteration\`, so the calls land on disk. In the parallel path, \`parallel.go:87\` creates a *child* logger for each worker, calls \`StartIteration()\` on it, then invokes \`pd.daemon.runIteration(...)\` — which uses \`d.Logger\`, not the child. \`d.Logger\` has no active file in parallel mode, so every Log call hit \`if l.file == nil { return ... }\` and was swallowed by the \`_ =\` prefix on every call site.

Two additional bugs fell out of the fix:
1. Worker log filenames used \`worker-<TaskID>\` as the prefix. Three leaves with the same task name (\`task-0001\`) collided on the same filename; \`os.Create\` truncated the inode repeatedly and workers stomped each other's writes.
2. \`EnforceRetention\` sorted by filename and used count-based delete without any open-file guard. Worker filenames starting with \`0001-\` sorted before parent daemon files (\`0519-heal\`, \`10497-intake\`), so retention treated brand-new worker files as the oldest and deleted them first. Compression also unlinked files while sibling workers still held the inode open.

## Fixes

- \`runIteration\` and seven helpers (\`handleYieldMarker\`, \`handleBlockedMarker\`, \`handleCompleteMarker\`, \`handleFailure\`, \`autoCompleteDecomposedParents\`, \`createRemediationSubtasks\`, \`maybeWriteAuditReport\`) take an explicit \`lg *logging.Logger\` parameter. \`invokeWithRetry\`, \`propagateState\`, and \`commitAfterIteration\` all thread the same logger through.
- Parallel worker at \`parallel.go:126\` passes its child logger to \`runIteration\`; sequential path at \`daemon.go:833\` passes \`d.Logger\`; intake loop at \`stages.go:230\` passes \`d.InboxLogger\`; planning at \`planning.go:220\` passes \`d.Logger\` (planning opens its own \"plan\" file).
- Worker logger prefix now includes the slugified node address: \`worker-<slug(nodeAddr)>-<taskID>\`. Filenames are unique across concurrent workers.
- Worker TraceID is overridden after \`StartIteration\` to a compact form — \`worker-<leaf-basename>-<taskID>-<iter>\` — so the TUI log modal's \`[trace]\` column stays readable. Filename stays long (for uniqueness); trace IDs stamped on records stay short.
- \`EnforceRetention\` sorts by \`ModTime\` instead of filename. The quiet window (default 30s, configurable via \`WithQuietWindow\`) applies to compression, age-delete, and count-delete. Files still held open by workers cannot be removed out from under them.
- \`Logger.Log\` writes a stderr diagnostic and increments a global counter when called without an active iteration file. Exposed as \`logging.DroppedRecords()\`. The silent-drop path is now loud; a non-zero counter in daemon health checks points directly at the next regression of this class.
- TUI \`traceCategory\` recognizes \`worker-*\` as a first-class category; the \`T\` filter cycle becomes \`all → exec → worker → plan → inbox → system → all\`.

## Test plan
- [x] \`go test ./...\` green (full suite, including daemon/logging/tui packages)
- [x] \`go test -tags integration ./test/integration/\` green (105s, \`TestDaemon_ExploratoryReview_CreatesRemediationLeaf\` and all neighbors still pass)
- [x] Live verified on \`/tmp/wc-tui-test\` with \`daemon.parallel.enabled=true, max_workers=3\`: worker log files contain full iteration content (stage_start, assistant text, tool calls, stage_complete, terminal_marker), \`lsof\` shows each worker holding a distinct inode, TUI log modal streams parallel worker output live.
- [x] 17 daemon test files mechanically updated for the new signatures; 5 logging test files updated to pass \`WithQuietWindow(0)\` where they need retention to operate on fresh fixtures.