### PR TITLE
v0.6.7: dirty-tree start modal + --allow-dirty flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.7
+
+### Features
+- **Dirty-tree start now confirms through a TUI modal** instead of silently refusing. `wolfcastle start` gains an `--allow-dirty` flag that skips the interactive y/N prompt and proceeds with a warning. The TUI detects "commit or stash changes first" in daemon-start stderr, pops an `UNCOMMITTED CHANGES` confirmation modal showing which files would be swept into the first commit, and on Enter re-invokes `start -d --allow-dirty`. Previously the TUI's `s` key ran `start -d`, which inherits no TTY and so returned an EOF to `confirmContinue()`, aborting with no visible error — the daemon would just fail to come up and the tab would go cold without explanation.
+
 ## 0.6.6
 
 ### Features

--- a/cmd/daemon/register.go
+++ b/cmd/daemon/register.go
@@ -18,6 +18,7 @@ func Register(app *cmdutil.App, rootCmd *cobra.Command) {
 	startCmd.Flags().BoolP("verbose", "v", false, "Set console log level to debug")
 	startCmd.Flags().Bool("exit-when-done", false, "Exit after all available work is complete")
 	startCmd.Flags().String("instance", "", "Worktree path to target (bypasses CWD-based discovery)")
+	startCmd.Flags().Bool("allow-dirty", false, "Start even if the working tree has uncommitted changes (non-interactive bypass)")
 	_ = startCmd.RegisterFlagCompletionFunc("node", cmdutil.CompleteNodeAddresses(app))
 
 	stopCmd := newStopCmd(app)

--- a/cmd/daemon/start.go
+++ b/cmd/daemon/start.go
@@ -48,6 +48,7 @@ Examples:
 			worktreeBranch, _ := cmd.Flags().GetString("worktree")
 			verbose, _ := cmd.Flags().GetBool("verbose")
 			exitWhenDone, _ := cmd.Flags().GetBool("exit-when-done")
+			allowDirty, _ := cmd.Flags().GetBool("allow-dirty")
 
 			if err := resolveInstance(cmd, app); err != nil {
 				return err
@@ -114,13 +115,21 @@ Examples:
 					output.PrintHuman("The daemon commits code and state together after each task.")
 					output.PrintHuman("These changes will be included in the first commit.")
 					output.PrintHuman("")
-					output.PrintHuman("Options:")
-					output.PrintHuman("  1. Commit or stash your changes, then restart")
-					output.PrintHuman("  2. Disable auto-commit: wolfcastle config set git.auto_commit false")
-					output.PrintHuman("  3. Continue anyway (your changes will be committed with the first task)")
-					output.PrintHuman("")
-					if !confirmContinue() {
-						return fmt.Errorf("aborted: commit or stash changes first")
+					if allowDirty {
+						// Non-interactive bypass. The TUI uses this flag
+						// after confirming through its own modal; the
+						// daemon still prints the warning so background
+						// daemon.log has a record of what was swept in.
+						output.PrintHuman("Continuing anyway (--allow-dirty). Uncommitted changes will be included in the first commit.")
+					} else {
+						output.PrintHuman("Options:")
+						output.PrintHuman("  1. Commit or stash your changes, then restart")
+						output.PrintHuman("  2. Disable auto-commit: wolfcastle config set git.auto_commit false")
+						output.PrintHuman("  3. Continue anyway (your changes will be committed with the first task)")
+						output.PrintHuman("")
+						if !confirmContinue() {
+							return fmt.Errorf("aborted: commit or stash changes first")
+						}
 					}
 				}
 			}

--- a/internal/tui/app/app.go
+++ b/internal/tui/app/app.go
@@ -615,11 +615,28 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.header.SetLoading(false)
 		m.header.SetStatusHint("")
-		raw := strings.TrimSpace(msg.Stderr)
-		if raw == "" && msg.Err != nil {
-			raw = msg.Err.Error()
+		// Keep the raw stderr around for substring probes — the dirty
+		// tree preamble is printed to stdout but we capture both
+		// streams into this field. Sanitization only runs for the
+		// toast path so error detection still sees the uncollapsed text.
+		rawFull := msg.Stderr
+		if rawFull == "" && msg.Err != nil {
+			rawFull = msg.Err.Error()
 		}
-		raw = sanitizeErrorLine(raw)
+		// Dirty-tree path: open a confirmation modal instead of a
+		// toast so the user has an affordance to proceed. The CLI's
+		// dirty-tree warning goes to stdout and ends with the "aborted:
+		// commit or stash changes first" error on stderr; either
+		// signal is enough to route into the modal.
+		if strings.Contains(rawFull, "uncommitted changes") || strings.Contains(rawFull, "commit or stash changes first") {
+			if tab != nil {
+				detail := extractDirtyTreeDetail(rawFull)
+				m.daemonModal.OpenDirty(tab.WorktreeDir, detail)
+				m.activeModal = ModalDaemon
+			}
+			return m, tea.Batch(cmds...)
+		}
+		raw := sanitizeErrorLine(strings.TrimSpace(rawFull))
 		var toastText string
 		switch {
 		case strings.Contains(raw, "already running"), strings.Contains(raw, "lock"):
@@ -628,14 +645,17 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			toastText = "No project found. Run wolfcastle init."
 		case strings.Contains(raw, "identity not configured"):
 			toastText = "Identity not configured. Run wolfcastle init."
-		case strings.Contains(raw, "uncommitted changes"), strings.Contains(raw, "commit or stash"):
-			toastText = "Uncommitted changes. Commit or stash first."
 		case raw == "":
 			toastText = "Daemon failed to start."
 		default:
 			toastText = "Daemon failed to start: " + raw
 		}
 		cmds = append(cmds, m.notify.Push(toastText))
+		return m, tea.Batch(cmds...)
+
+	case tui.DaemonDirtyConfirmedMsg:
+		m.closeModal()
+		cmds = append(cmds, m.startDaemonWithFlags(true))
 		return m, tea.Batch(cmds...)
 
 	case tui.DaemonStoppedMsg:
@@ -1496,6 +1516,35 @@ func (m *TUIModel) appendError(filename, message string) {
 // line so it can't blow up the error bar's height (which is what made
 // the panes collapse on repeated start failures). Trailing context past
 // a reasonable cap is dropped.
+// extractDirtyTreeDetail pulls the git-status summary out of the
+// CLI's dirty-tree warning so the modal can show the user which files
+// would be swept into the first commit. The CLI prints the summary on
+// a line immediately after "The working tree has uncommitted changes:",
+// so we grab everything between that header and the first blank line.
+func extractDirtyTreeDetail(raw string) string {
+	const header = "The working tree has uncommitted changes:"
+	idx := strings.Index(raw, header)
+	if idx < 0 {
+		return ""
+	}
+	tail := raw[idx+len(header):]
+	// Drop the leading newline(s) after the header.
+	tail = strings.TrimLeft(tail, "\r\n")
+	// Stop at the first blank line — the CLI follows the summary with
+	// explanation text and option bullets we don't want to duplicate
+	// in the modal body.
+	if end := strings.Index(tail, "\n\n"); end >= 0 {
+		tail = tail[:end]
+	}
+	detail := strings.TrimSpace(tail)
+	const maxLines = 8
+	lines := strings.Split(detail, "\n")
+	if len(lines) > maxLines {
+		lines = append(lines[:maxLines], fmt.Sprintf("… and %d more", len(lines)-maxLines))
+	}
+	return strings.Join(lines, "\n")
+}
+
 func sanitizeErrorLine(s string) string {
 	s = strings.ReplaceAll(s, "\r\n", " ")
 	s = strings.ReplaceAll(s, "\n", " ")
@@ -1651,6 +1700,15 @@ func (m *TUIModel) handleToggleDaemon() tea.Cmd {
 }
 
 func (m *TUIModel) startDaemon() tea.Cmd {
+	return m.startDaemonWithFlags(false)
+}
+
+// startDaemonWithFlags spawns `wolfcastle start -d`, optionally with
+// `--allow-dirty` when the user confirmed the dirty-tree modal. The
+// allowDirty path exists because `start -d` is detached: its parent
+// process can't answer an interactive y/N prompt, so a dirty tree
+// otherwise produces a silent exit and an empty daemon.log tail.
+func (m *TUIModel) startDaemonWithFlags(allowDirty bool) tea.Cmd {
 	tab := m.activeTab()
 	if tab == nil {
 		return nil
@@ -1664,14 +1722,20 @@ func (m *TUIModel) startDaemon() tea.Cmd {
 		if err != nil {
 			exe = "wolfcastle"
 		}
-		cmd := exec.Command(exe, "start", "-d")
+		args := []string{"start", "-d"}
+		if allowDirty {
+			args = append(args, "--allow-dirty")
+		}
+		cmd := exec.Command(exe, args...)
 		cmd.Dir = dir
 		var stderr bytes.Buffer
 		cmd.Stderr = &stderr
+		var stdout bytes.Buffer
+		cmd.Stdout = &stdout
 		if runErr := cmd.Run(); runErr != nil {
 			return tui.DaemonStartFailedMsg{
 				Err:    runErr,
-				Stderr: stderr.String(),
+				Stderr: stderr.String() + stdout.String(),
 			}
 		}
 		instances, _ := instance.List()

--- a/internal/tui/app/app_test.go
+++ b/internal/tui/app/app_test.go
@@ -1260,7 +1260,7 @@ func TestDaemonStartFailedNotFoundError(t *testing.T) {
 	}
 }
 
-func TestDaemonStartFailedPrefersStderr(t *testing.T) {
+func TestDaemonStartFailedDirtyTreeOpensModal(t *testing.T) {
 	m := newColdModel(t)
 	m.activeTab().DaemonStarting = true
 	result, _ := m.Update(tui.DaemonStartFailedMsg{
@@ -1268,15 +1268,53 @@ func TestDaemonStartFailedPrefersStderr(t *testing.T) {
 		Stderr: "Error: aborted: commit or stash changes first\n",
 	})
 	model := toModel(t, result)
-	if !model.notify.HasToasts() {
-		t.Fatal("expected a toast for the failure")
+	// A dirty-tree failure routes into the confirmation modal, not a
+	// toast, so the user has an affordance to proceed with --allow-dirty.
+	if model.notify.HasToasts() {
+		t.Errorf("dirty-tree failure should not surface as a toast, got: %q", model.notify.View())
 	}
-	view := model.notify.View()
-	if !strings.Contains(view, "Uncommitted changes") {
-		t.Errorf("toast should mention uncommitted changes, got: %q", view)
+	if model.activeModal != ModalDaemon {
+		t.Fatalf("expected ModalDaemon to be active, got %v", model.activeModal)
 	}
-	if strings.Contains(view, "exit status 1") {
-		t.Errorf("should not surface bare exit code when stderr is available, got: %q", view)
+	if model.daemonModal.action != "dirty-start" {
+		t.Errorf("expected daemonModal action 'dirty-start', got %q", model.daemonModal.action)
+	}
+}
+
+func TestDaemonStartFailedDirtyTreeConfirmRetriesWithAllowDirty(t *testing.T) {
+	m := newColdModel(t)
+	m.activeTab().DaemonStarting = true
+	result, _ := m.Update(tui.DaemonStartFailedMsg{
+		Err:    fmt.Errorf("exit status 1"),
+		Stderr: "Error: aborted: commit or stash changes first\n",
+	})
+	model := toModel(t, result)
+	if model.activeModal != ModalDaemon || model.daemonModal.action != "dirty-start" {
+		t.Fatalf("expected dirty-start modal after failure, got action=%q activeModal=%v", model.daemonModal.action, model.activeModal)
+	}
+	// Pressing Enter confirms → DaemonDirtyConfirmedMsg → closeModal + startDaemonWithFlags(true).
+	result, cmd := model.Update(keyMsg("enter"))
+	model = toModel(t, result)
+	if cmd == nil {
+		t.Fatal("expected a command from Enter confirmation")
+	}
+	msg := cmd()
+	if _, ok := msg.(tui.DaemonDirtyConfirmedMsg); !ok {
+		t.Fatalf("expected DaemonDirtyConfirmedMsg from modal confirm, got %T", msg)
+	}
+	// Feed the confirm back in; the app should close the modal and
+	// emit the start command with --allow-dirty. We can't exec
+	// a daemon in-process, so we just assert the state transition.
+	result, cmd = model.Update(msg)
+	model = toModel(t, result)
+	if model.activeModal != ModalNone {
+		t.Errorf("modal should be closed after dirty confirm, got %v", model.activeModal)
+	}
+	if !model.activeTab().DaemonStarting {
+		t.Errorf("tab should be marked DaemonStarting after confirm retry")
+	}
+	if cmd == nil {
+		t.Error("expected a command to start the daemon with --allow-dirty")
 	}
 }
 

--- a/internal/tui/app/daemon_modal.go
+++ b/internal/tui/app/daemon_modal.go
@@ -16,12 +16,13 @@ import (
 // draining status) and waits for Enter to confirm or Esc to cancel.
 type DaemonModalModel struct {
 	active     bool
-	action     string // "start" or "stop"
+	action     string // "start", "stop", or "dirty-start"
 	isRunning  bool
 	isDraining bool
 	pid        int
 	branch     string
 	worktree   string
+	dirtyBody  string // populated for the dirty-start variant
 	width      int
 	height     int
 }
@@ -35,6 +36,17 @@ func (m *DaemonModalModel) Open(action string, isRunning, isDraining bool, pid i
 	m.pid = pid
 	m.branch = branch
 	m.worktree = worktree
+	m.dirtyBody = ""
+}
+
+// OpenDirty activates the modal in dirty-tree confirmation mode. The
+// detail string is the git-status summary we want to show the user so
+// they know what's about to be swept into the first commit.
+func (m *DaemonModalModel) OpenDirty(worktree, detail string) {
+	m.active = true
+	m.action = "dirty-start"
+	m.worktree = worktree
+	m.dirtyBody = detail
 }
 
 // Close deactivates the modal.
@@ -65,7 +77,11 @@ func (m DaemonModalModel) Update(msg tea.Msg) (DaemonModalModel, tea.Cmd) {
 	}
 	switch {
 	case key.Matches(kp, confirmKey):
+		action := m.action
 		m.active = false
+		if action == "dirty-start" {
+			return m, func() tea.Msg { return tui.DaemonDirtyConfirmedMsg{} }
+		}
 		return m, func() tea.Msg { return tui.DaemonConfirmedMsg{} }
 	case key.Matches(kp, dismissKey):
 		m.active = false
@@ -94,7 +110,11 @@ func (m DaemonModalModel) View() string {
 		innerW = 1
 	}
 
-	title := tui.ModalTitleStyle.Render(strings.ToUpper(m.action + " DAEMON"))
+	titleText := m.action + " DAEMON"
+	if m.action == "dirty-start" {
+		titleText = "UNCOMMITTED CHANGES"
+	}
+	title := tui.ModalTitleStyle.Render(strings.ToUpper(titleText))
 
 	var body strings.Builder
 	body.WriteString(tui.ModalDimStyle.Render(m.bodyText()))
@@ -132,6 +152,20 @@ func (m DaemonModalModel) bodyText() string {
 			lines = append(lines, "")
 			lines = append(lines, "The daemon is currently draining. Stopping it will interrupt in-flight work.")
 		}
+		return strings.Join(lines, "\n")
+	}
+
+	if m.action == "dirty-start" {
+		lines := []string{
+			fmt.Sprintf("The working tree at %s has uncommitted changes.", m.worktree),
+			"",
+			"The daemon commits code and state together after each task, so these changes would be included in the first commit alongside whatever the first task writes.",
+		}
+		if m.dirtyBody != "" {
+			lines = append(lines, "")
+			lines = append(lines, m.dirtyBody)
+		}
+		lines = append(lines, "", "Continue anyway?")
 		return strings.Join(lines, "\n")
 	}
 

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -172,6 +172,12 @@ type AddInboxItemCmd struct {
 // DaemonConfirmedMsg signals that the user confirmed a daemon action in a modal dialog.
 type DaemonConfirmedMsg struct{}
 
+// DaemonDirtyConfirmedMsg signals that the user confirmed the dirty-tree
+// start prompt in a modal dialog. The app responds by re-invoking
+// startDaemonWithFlags(allowDirty=true) so the detached `start -d`
+// process skips its interactive y/N prompt.
+type DaemonDirtyConfirmedMsg struct{}
+
 // ToastMsg requests that a transient notification toast be displayed.
 type ToastMsg struct {
 	Text string


### PR DESCRIPTION
## Summary

Pressing \`s\` in the TUI on a dirty worktree used to silently refuse: \`start -d\` inherits no stdin, the CLI's \`confirmContinue()\` saw EOF and treated it as \"N\", and the TUI only surfaced the resulting error as a tiny \"Uncommitted changes\" toast with no affordance to proceed. You had to drop out of the TUI, shell out, commit/stash by hand, and come back.

This PR adds a non-interactive bypass (\`--allow-dirty\`) and wires the TUI to detect the dirty-tree failure, pop a confirmation modal showing what would be swept into the first commit, and re-invoke the daemon with the flag on Enter.

## What changes

- **\`wolfcastle start --allow-dirty\`**: skips the interactive y/N prompt when the working tree is dirty and proceeds with a warning. The daemon log gets a \"continuing anyway (--allow-dirty)\" line so there's a record of what the first commit swept in.
- **TUI**: \`startDaemon\` split into \`startDaemon()\` / \`startDaemonWithFlags(allowDirty bool)\`. The flagged form captures both stdout and stderr into the failure buffer because the CLI's dirty-tree preamble is printed on stdout, not stderr.
- **\`DaemonModalModel.OpenDirty(worktree, detail)\`**: new \"dirty-start\" variant alongside the existing start/stop actions. Title reads \`UNCOMMITTED CHANGES\`. Body explains the auto-commit consequences and includes the git-status summary extracted from the CLI output (capped at 8 lines with a tail).
- **\`DaemonDirtyConfirmedMsg\`**: new message the modal emits on Enter in dirty-start mode. The app \`Update\` handler closes the modal and calls \`startDaemonWithFlags(true)\`.
- **\`extractDirtyTreeDetail\` helper**: pulls the file list out of the CLI's \"The working tree has uncommitted changes:\" preamble.

## Test plan
- [x] \`go test ./...\` green
- [x] New tests: \`TestDaemonStartFailedDirtyTreeOpensModal\` (confirms modal opens on dirty failure), \`TestDaemonStartFailedDirtyTreeConfirmRetriesWithAllowDirty\` (confirms Enter → DaemonDirtyConfirmedMsg → retry with allowDirty=true).
- [x] Manual: live-tested against a dirty \`/tmp/wc-tui-test\`. Modal opens, shows the status summary, Enter starts the daemon with \`--allow-dirty\`, daemon comes up normally, TUI transitions to Live state.