### PR TITLE
v0.6.8: parent-loop logger + canary closes remaining silent drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.6.8
+
+### Features
+- **Dedicated `ParentLogger` for daemon-lifetime events.** A third `*logging.Logger` opens at `Run()` entry with a `daemon` prefix and stays open until the daemon exits. Parent-loop events — `drainCompleted` diagnostics, auto-archive decisions, spec-review hooks, knowledge maintenance, instance-registry warnings, shutdown-signal lifecycle — route through this logger instead of reaching for `d.Logger`, which in parallel mode has no active file between planning passes. File name is `2NNNN-daemon-TIMESTAMP.jsonl` (iteration counter offset by 20000 so it can't collide with exec/plan or inbox namespaces).
+- **Nil-safe `Logger.Log` receiver.** Calling `.Log(...)` on a nil `*logging.Logger` now returns an error and increments the dropped-records counter instead of panicking. Tests that construct `Daemon` directly without calling `New()` — and any future caller that holds a nil reference through a free function — no longer need defensive guards.
+
+### Bug Fixes
+- **Canary-caught silent drops closed up across the parent loop.** The v0.6.6 plumbing fixed `runIteration` itself, but several helpers and lifecycle paths were still calling `d.Logger.Log` (or `d.log`) on an iteration-scoped logger that had no active file. This release routes them through the always-live parent logger:
+  - `parallel.go` — every `drainCompleted`, `fillSlots`, `reclaimOrphans` diagnostic, plus the three `commitAfterIteration` invocations (success, failure, scope-conflict) and the `propagateState` fallback diagnostic.
+  - `archive.go` — `auto_archive_failed` and `archived` events fired from `tryAutoArchive` in the main loop.
+  - `spec_review.go` — `review_queued` and `review_failed` events fired from the post-iteration hook.
+  - `knowledge_maintenance.go` — `budget_exceeded` events.
+  - `daemon.go` — the shutdown-signal goroutine, the 2-second force-exit grace message, the instance-registry warning, and the three `task_event` sites (serial planning error, serial iteration error, parallel planning error).
+  - `iteration.go` — six `d.log(task_event ...)` calls inside `handleBlockedMarker` / `handleCompleteMarker` / `handleFailure` that the v0.6.6 sweep missed because they used the nil-safe wrapper instead of `d.Logger.Log` directly. Now route through the `lg` parameter alongside every other logger call in those methods.
+- **Worker trace IDs no longer duplicate the task number.** The previous format stamped `worker-<node>-task-0001-0001` — the trailing `0001` was the Child logger's iteration counter, which is always `0001` because each worker runs exactly one iteration. Dropped the redundant suffix; trace IDs read `worker-cart-and-promo-domain-task-0001` now.
+
+### Quality
+- **`DroppedRecords()` and the silent-drop canary on stderr** are now test-covered. New `internal/logging/dropped_records_test.go` pins the counter behavior: zero on the happy path, one on a nil receiver (no panic), one on a missing iteration, two after a close-then-log sequence.
+
 ## 0.6.7
 
 ### Features

--- a/internal/daemon/archive.go
+++ b/internal/daemon/archive.go
@@ -111,19 +111,19 @@ func (d *Daemon) tryAutoArchive(idx *state.RootIndex) bool {
 	// Archive one node per iteration to keep each cycle bounded.
 	addr := eligible[0]
 	if err := d.archiveNode(addr); err != nil {
-		_ = d.Logger.Log(map[string]any{
+		d.logParent(map[string]any{
 			"type":  "auto_archive_error",
 			"node":  addr,
 			"error": err.Error(),
 		})
-		d.log(map[string]any{"type": "archive_event", "action": "auto_archive_failed", "node": addr, "text": fmt.Sprintf("Auto-archive failed for %s: %v", addr, err), "error": err.Error()})
+		d.logParent(map[string]any{"type": "archive_event", "action": "auto_archive_failed", "node": addr, "text": fmt.Sprintf("Auto-archive failed for %s: %v", addr, err), "error": err.Error()})
 		return false
 	}
 
-	_ = d.Logger.Log(map[string]any{
+	d.logParent(map[string]any{
 		"type": "auto_archive",
 		"node": addr,
 	})
-	d.log(map[string]any{"type": "archive_event", "action": "archived", "node": addr, "text": fmt.Sprintf("Archived completed project: %s", addr)})
+	d.logParent(map[string]any{"type": "archive_event", "action": "archived", "node": addr, "text": fmt.Sprintf("Archived completed project: %s", addr)})
 	return true
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -67,6 +67,7 @@ type Daemon struct {
 	ScopeNode      string
 	Logger         *logging.Logger
 	InboxLogger    *logging.Logger // separate logger for the inbox goroutine
+	ParentLogger   *logging.Logger // always-open daemon-lifecycle file for parent-loop events
 	RepoDir        string
 	Clock          clock.Clock
 	Git            git.Provider
@@ -102,6 +103,16 @@ func (d *Daemon) log(record map[string]any) {
 func (d *Daemon) logInbox(record map[string]any) {
 	if d.InboxLogger != nil {
 		_ = d.InboxLogger.Log(record)
+	}
+}
+
+// logParent is a nil-safe wrapper around d.ParentLogger.Log. Parent-loop
+// events (drain diagnostics, auto-archive decisions, spec review hooks,
+// knowledge maintenance) route through this so tests that construct a
+// Daemon directly — without calling New — don't trip on a nil logger.
+func (d *Daemon) logParent(record map[string]any) {
+	if d.ParentLogger != nil {
+		_ = d.ParentLogger.Log(record)
 	}
 }
 
@@ -142,6 +153,17 @@ func New(cfg *config.Config, wolfcastleDir string, store *state.Store, scopeNode
 	// their iteration numbers never overlap.
 	inboxLogger.Iteration = inboxIterationOffset + logging.IterationFromDir(logDir)
 
+	// A third logger captures events that happen in the daemon's
+	// parent loop — drain diagnostics, auto-archive decisions, spec
+	// review hooks — that don't belong to any single iteration. Its
+	// file stays open for the daemon's lifetime so the silent-drop
+	// canary never fires on these paths.
+	parentLogger, err := logging.NewLogger(logDir)
+	if err != nil {
+		return nil, err
+	}
+	parentLogger.Iteration = 20000 + logging.IterationFromDir(logDir)
+
 	// Build domain repositories for prompt and class resolution, then
 	// assemble a ContextBuilder that replaces the legacy standalone
 	// buildIterationContext functions.
@@ -162,6 +184,7 @@ func New(cfg *config.Config, wolfcastleDir string, store *state.Store, scopeNode
 		ScopeNode:      scopeNode,
 		Logger:         logger,
 		InboxLogger:    inboxLogger,
+		ParentLogger:   parentLogger,
 		RepoDir:        repoDir,
 		Clock:          clock.New(),
 		Git:            git.NewService(repoDir),
@@ -485,12 +508,19 @@ func (d *Daemon) Run(ctx context.Context) error {
 				if !ok {
 					return
 				}
-				d.log(map[string]any{"type": "daemon_lifecycle", "event": "standing_down", "reason": "signal", "text": "Wolfcastle standing down (signal)"})
+				// Route through the parent logger: the signal handler
+				// runs in its own goroutine and d.Logger's state at
+				// that moment depends on whether a planning/exec
+				// iteration is mid-flight. ParentLogger is always
+				// live for the daemon's lifetime, so lifecycle events
+				// land on disk no matter which iteration (if any) is
+				// currently holding the iteration file.
+				d.logParent(map[string]any{"type": "daemon_lifecycle", "event": "standing_down", "reason": "signal", "text": "Wolfcastle standing down (signal)"})
 				cancel()
 				d.shutdownOnce.Do(func() { close(d.shutdown) })
 				go func() {
 					time.Sleep(2 * time.Second)
-					_ = d.Logger.Log(map[string]any{"type": "force_exit", "message": "signal handler force exit after 2s grace period"})
+					d.logParent(map[string]any{"type": "force_exit", "message": "signal handler force exit after 2s grace period"})
 					_ = instance.Deregister(d.RepoDir)
 					d.removeActivityFile()
 					os.Exit(0)
@@ -516,6 +546,19 @@ func (d *Daemon) Run(ctx context.Context) error {
 	d.iteration.Store(0)
 	d.hasWorked = false
 
+	// Open the parent-loop logger file and keep it open for the
+	// daemon's entire lifetime. Parent-loop events (drain diagnostics,
+	// auto-archive, spec review hooks, knowledge maintenance, and any
+	// other housekeeping that isn't scoped to a specific iteration)
+	// write through this logger so they can't silently drop records
+	// when d.Logger has no active iteration file. Tests that build a
+	// Daemon directly without calling New() leave ParentLogger nil;
+	// the logParent helper is the nil-safe call path for those.
+	if d.ParentLogger != nil {
+		_ = d.ParentLogger.StartIterationWithPrefix("daemon")
+		defer d.ParentLogger.Close()
+	}
+
 	// Open a "heal" iteration to capture the startup banner, self-heal
 	// output, and git-check warning in a single structured log file.
 	_ = d.Logger.StartIterationWithPrefix("heal")
@@ -539,9 +582,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 	d.Logger.Close()
 
 	// Register this daemon in the instance registry so CLI commands
-	// can discover it by CWD matching.
+	// can discover it by CWD matching. The heal iteration file just
+	// closed, so route through the parent logger which stays open
+	// for the daemon's entire lifetime.
 	if regErr := instance.Register(d.RepoDir, d.branch); regErr != nil {
-		d.log(map[string]any{"type": "warning", "text": fmt.Sprintf("instance registry: %v", regErr)})
+		d.logParent(map[string]any{"type": "warning", "text": fmt.Sprintf("instance registry: %v", regErr)})
 	}
 	defer func() { _ = instance.Deregister(d.RepoDir) }()
 
@@ -773,7 +818,10 @@ func (d *Daemon) runOnceSerial(ctx context.Context, idx *state.RootIndex) (Itera
 	// its subtree needs work, not before.
 	if planAddr, planNS := d.findPlanningTarget(idx); planAddr != "" {
 		if err := d.runPlanningPass(ctx, planAddr, planNS, idx); err != nil {
-			d.log(map[string]any{"type": "task_event", "action": "planning_error", "text": fmt.Sprintf("Planning error: %v", err), "error": err.Error()})
+			// runPlanningPass Close()s the plan file on error, so
+			// d.Logger has no active file by the time we get here.
+			// Route through the parent logger.
+			d.logParent(map[string]any{"type": "task_event", "action": "planning_error", "text": fmt.Sprintf("Planning error: %v", err), "error": err.Error()})
 			return IterationError, nil
 		}
 		return IterationDidWork, nil
@@ -834,7 +882,10 @@ execute:
 	d.Logger.Close()
 
 	if err != nil {
-		d.log(map[string]any{"type": "task_event", "action": "iteration_error", "text": fmt.Sprintf("Iteration error: %v", err), "error": err.Error()})
+		// d.Logger's exec file was just closed. Route the error
+		// record through the parent logger so it lands on disk
+		// instead of tripping the silent-drop canary.
+		d.logParent(map[string]any{"type": "task_event", "action": "iteration_error", "text": fmt.Sprintf("Iteration error: %v", err), "error": err.Error()})
 
 		// State corruption is fatal: continuing risks further damage.
 		var stateErr *werrors.StateError
@@ -903,7 +954,10 @@ func (d *Daemon) runOnceParallel(ctx context.Context, idx *state.RootIndex) (Ite
 
 	if planAddr, planNS := d.findPlanningTarget(idx); planAddr != "" {
 		if err := d.runPlanningPass(ctx, planAddr, planNS, idx); err != nil {
-			d.log(map[string]any{"type": "task_event", "action": "planning_error", "text": fmt.Sprintf("Planning error: %v", err), "error": err.Error()})
+			// Same rationale as the serial path: plan file is
+			// already closed by runPlanningPass, so route the
+			// error through the parent logger.
+			d.logParent(map[string]any{"type": "task_event", "action": "planning_error", "text": fmt.Sprintf("Planning error: %v", err), "error": err.Error()})
 			return IterationError, nil
 		}
 		return IterationDidWork, nil

--- a/internal/daemon/iteration.go
+++ b/internal/daemon/iteration.go
@@ -273,7 +273,7 @@ func (d *Daemon) handleBlockedMarker(lg *logging.Logger, nav *state.NavigationRe
 	// Treat it as complete so it doesn't poison node state.
 	if d.isSupersededBlock(nav.NodeAddress, nav.TaskID) {
 		_ = lg.Log(map[string]any{"type": "superseded_to_skip", "task": nav.TaskID})
-		d.log(map[string]any{"type": "task_event", "action": "superseded", "task": nav.TaskID, "text": "Superseded (treating as skip)."})
+		_ = lg.Log(map[string]any{"type": "task_event", "action": "superseded", "task": nav.TaskID, "text": "Superseded (treating as skip)."})
 		if err := d.Store.MutateNode(nav.NodeAddress, func(ns *state.NodeState) error {
 			return state.TaskComplete(ns, nav.TaskID)
 		}); err != nil {
@@ -288,7 +288,7 @@ func (d *Daemon) handleBlockedMarker(lg *logging.Logger, nav *state.NavigationRe
 	// not_started so it re-runs to verify the fixes.
 	if created := d.createRemediationSubtasks(lg, nav.NodeAddress, nav.TaskID); created > 0 {
 		_ = lg.Log(map[string]any{"type": "audit_remediation", "task": nav.TaskID, "subtasks": created})
-		d.log(map[string]any{"type": "task_event", "action": "audit_remediation", "task": nav.TaskID, "text": fmt.Sprintf("Audit: %d gap(s), remediating.", created)})
+		_ = lg.Log(map[string]any{"type": "task_event", "action": "audit_remediation", "task": nav.TaskID, "text": fmt.Sprintf("Audit: %d gap(s), remediating.", created)})
 		return nil
 	}
 
@@ -336,7 +336,7 @@ func (d *Daemon) handleCompleteMarker(lg *logging.Logger, nav *state.NavigationR
 			"task":    nav.TaskID,
 			"missing": missing,
 		})
-		d.log(map[string]any{"type": "task_event", "action": "deliverable_warning", "task": nav.TaskID, "text": fmt.Sprintf("Warning: declared deliverables missing: %v", missing)})
+		_ = lg.Log(map[string]any{"type": "task_event", "action": "deliverable_warning", "task": nav.TaskID, "text": fmt.Sprintf("Warning: declared deliverables missing: %v", missing)})
 	}
 
 	// Audit tasks skip the git progress check: their output is
@@ -358,7 +358,7 @@ func (d *Daemon) handleCompleteMarker(lg *logging.Logger, nav *state.NavigationR
 				"type": "no_progress",
 				"task": nav.TaskID,
 			})
-			d.log(map[string]any{"type": "task_event", "action": "no_progress", "task": nav.TaskID, "text": "No changes detected. Failing task."})
+			_ = lg.Log(map[string]any{"type": "task_event", "action": "no_progress", "task": nav.TaskID, "text": "No changes detected. Failing task."})
 			return false
 		}
 		_ = lg.Log(map[string]any{
@@ -414,7 +414,7 @@ func (d *Daemon) handleCompleteMarker(lg *logging.Logger, nav *state.NavigationR
 						"task":     nav.TaskID,
 						"subtasks": created,
 					})
-					d.log(map[string]any{"type": "task_event", "action": "audit_gaps", "task": nav.TaskID, "text": fmt.Sprintf("Audit has %d open gap(s), creating remediation subtasks.", created)})
+					_ = lg.Log(map[string]any{"type": "task_event", "action": "audit_gaps", "task": nav.TaskID, "text": fmt.Sprintf("Audit has %d open gap(s), creating remediation subtasks.", created)})
 				} else {
 					// Edge case: open gaps exist but no subtasks created.
 					// Block the audit to prevent silent completion.
@@ -425,7 +425,7 @@ func (d *Daemon) handleCompleteMarker(lg *logging.Logger, nav *state.NavigationR
 						"type": "audit_blocked_open_gaps",
 						"task": nav.TaskID,
 					})
-					d.log(map[string]any{"type": "task_event", "action": "audit_blocked", "task": nav.TaskID, "text": "Audit blocked: open gaps remain."})
+					_ = lg.Log(map[string]any{"type": "task_event", "action": "audit_blocked", "task": nav.TaskID, "text": "Audit blocked: open gaps remain."})
 				}
 				// Commit the decomposition: audit gaps, remediation
 				// subtasks, and reverted audit state. This gives a

--- a/internal/daemon/knowledge_maintenance.go
+++ b/internal/daemon/knowledge_maintenance.go
@@ -108,13 +108,13 @@ func (d *Daemon) checkKnowledgeBudget(nodeAddr string) bool {
 		return false
 	}
 
-	_ = d.Logger.Log(map[string]any{
+	d.logParent(map[string]any{
 		"type":       "knowledge_maintenance_created",
 		"node":       nodeAddr,
 		"task_id":    taskID,
 		"tokens":     tokens,
 		"max_tokens": maxTokens,
 	})
-	d.log(map[string]any{"type": "knowledge_event", "action": "budget_exceeded", "node": nodeAddr, "text": fmt.Sprintf("Knowledge budget exceeded (%d/%d tokens), maintenance task queued", tokens, maxTokens)})
+	d.logParent(map[string]any{"type": "knowledge_event", "action": "budget_exceeded", "node": nodeAddr, "text": fmt.Sprintf("Knowledge budget exceeded (%d/%d tokens), maintenance task queued", tokens, maxTokens)})
 	return true
 }

--- a/internal/daemon/parallel.go
+++ b/internal/daemon/parallel.go
@@ -135,14 +135,14 @@ func (pd *ParallelDispatcher) runWorker(ctx context.Context, nav *state.Navigati
 		// (the same string we use for the filename to guarantee unique
 		// paths across workers). Override to a compact form — the last
 		// segment of the node address plus the task ID — so the log
-		// view's [trace] column stays readable. Collisions in the
-		// compact form are fine; records already carry the full node
-		// address for disambiguation.
+		// view's [trace] column stays readable. Each worker is a fresh
+		// Child logger and runs exactly one iteration, so the iter
+		// counter would always be "0001" and adds nothing to the ID.
 		shortNode := nav.NodeAddress
 		if idx := strings.LastIndex(shortNode, "/"); idx >= 0 {
 			shortNode = shortNode[idx+1:]
 		}
-		logger.TraceID = fmt.Sprintf("worker-%s-%s-%04d", shortNode, nav.TaskID, logger.Iteration)
+		logger.TraceID = fmt.Sprintf("worker-%s-%s", shortNode, nav.TaskID)
 		_ = logger.LogIterationStart("execute", nav.NodeAddress)
 
 		err := pd.daemon.runIteration(workerCtx, logger, nav, idx)
@@ -202,7 +202,7 @@ done:
 		// callers below must guard against that rather than crashing.
 		ns, nsErr := d.Store.ReadNode(wr.Node)
 		if nsErr != nil {
-			_ = d.Logger.Log(map[string]any{
+			d.logParent(map[string]any{
 				"type":  "read_node_error",
 				"task":  taskAddr,
 				"node":  wr.Node,
@@ -230,7 +230,7 @@ done:
 			entry := pd.blocked[taskAddr]
 			pd.mu.Unlock()
 
-			_ = d.Logger.Log(map[string]any{
+			d.logParent(map[string]any{
 				"type":        "scope_yield_tracking",
 				"task":        taskAddr,
 				"blocker":     wr.Blocker,
@@ -245,7 +245,7 @@ done:
 				if ns != nil {
 					meta = extractTaskCommitMeta(ns, wr.Task)
 				}
-				commitAfterIteration(d.RepoDir, d.Logger, wr.Task, "failure", 0, d.Config.Git, meta, scope)
+				commitAfterIteration(d.RepoDir, d.ParentLogger, wr.Task, "failure", 0, d.Config.Git, meta, scope)
 				d.gitMu.Unlock()
 			}
 
@@ -281,7 +281,7 @@ done:
 				// State write failed: the task remains in_progress permanently
 				// because fillSlots will never rediscover it. Log so operators
 				// can intervene.
-				_ = d.Logger.Log(map[string]any{
+				d.logParent(map[string]any{
 					"type":  "scope_conflict_reset_error",
 					"task":  taskAddr,
 					"node":  wr.Node,
@@ -303,7 +303,7 @@ done:
 			if ns != nil {
 				meta = extractTaskCommitMeta(ns, wr.Task)
 			}
-			commitAfterIteration(d.RepoDir, d.Logger, wr.Task, "success", 0, d.Config.Git, meta, scope)
+			commitAfterIteration(d.RepoDir, d.ParentLogger, wr.Task, "success", 0, d.Config.Git, meta, scope)
 			d.gitMu.Unlock()
 
 			if ns != nil {
@@ -311,13 +311,12 @@ done:
 				if updated, err := d.Store.ReadNode(wr.Node); err == nil {
 					idx, idxErr := d.Store.ReadIndex()
 					if idxErr == nil {
-						// The worker's logger is already closed at this
-						// point; drainCompleted runs back in the main
-						// loop. The fallback-diagnostic record in
-						// propagateState only fires if the index can't
-						// be re-read, so dropping it to d.Logger is a
-						// small regression if no parent file is open.
-						_ = d.propagateState(d.Logger, wr.Node, updated.State, idx)
+						// drainCompleted runs on the main loop after
+						// the worker has closed its child logger.
+						// Route through ParentLogger so propagate's
+						// fallback-diagnostic record lands on disk
+						// instead of tripping the silent-drop canary.
+						_ = d.propagateState(d.ParentLogger, wr.Node, updated.State, idx)
 					}
 				}
 			}
@@ -345,7 +344,7 @@ done:
 				// State write failed: failure count was not incremented, so
 				// the task may retry indefinitely or remain stuck. Log so
 				// operators can intervene.
-				_ = d.Logger.Log(map[string]any{
+				d.logParent(map[string]any{
 					"type":  "failure_increment_error",
 					"task":  taskAddr,
 					"node":  wr.Node,
@@ -358,7 +357,7 @@ done:
 			if ns != nil {
 				failMeta = extractTaskCommitMeta(ns, wr.Task)
 			}
-			commitAfterIteration(d.RepoDir, d.Logger, wr.Task, "failure", failCount, d.Config.Git, failMeta, scope)
+			commitAfterIteration(d.RepoDir, d.ParentLogger, wr.Task, "failure", failCount, d.Config.Git, failMeta, scope)
 			d.gitMu.Unlock()
 
 			// Release scope locks and clean up active/blocked state.
@@ -431,7 +430,7 @@ func (pd *ParallelDispatcher) reclaimOrphans(idx *state.RootIndex) int {
 				continue
 			}
 
-			_ = d.Logger.Log(map[string]any{
+			d.logParent(map[string]any{
 				"type": "reclaim_orphan",
 				"task": taskAddr,
 				"node": addr,
@@ -470,7 +469,7 @@ func (pd *ParallelDispatcher) fillSlots(ctx context.Context, idx *state.RootInde
 
 	tasks, err := state.FindParallelTasks(idx, d.ScopeNode, nodeLoader, available)
 	if err != nil {
-		_ = d.Logger.Log(map[string]any{
+		d.logParent(map[string]any{
 			"type":  "fill_slots_error",
 			"error": err.Error(),
 		})
@@ -499,7 +498,7 @@ func (pd *ParallelDispatcher) fillSlots(ctx context.Context, idx *state.RootInde
 			return state.TaskClaim(ns, nav.TaskID)
 		})
 		if claimErr != nil {
-			_ = d.Logger.Log(map[string]any{
+			d.logParent(map[string]any{
 				"type":  "claim_error",
 				"task":  taskAddr,
 				"error": claimErr.Error(),

--- a/internal/daemon/spec_review.go
+++ b/internal/daemon/spec_review.go
@@ -113,7 +113,7 @@ func (d *Daemon) checkSpecReviewNeeded(nodeAddr, taskID string) bool {
 	})
 
 	if mutErr != nil {
-		_ = d.Logger.Log(map[string]any{
+		d.logParent(map[string]any{
 			"type":  "spec_review_create_error",
 			"node":  nodeAddr,
 			"task":  taskID,
@@ -122,13 +122,13 @@ func (d *Daemon) checkSpecReviewNeeded(nodeAddr, taskID string) bool {
 		return false
 	}
 
-	_ = d.Logger.Log(map[string]any{
+	d.logParent(map[string]any{
 		"type":      "spec_review_created",
 		"node":      nodeAddr,
 		"spec_task": taskID,
 		"review_id": reviewID,
 	})
-	d.log(map[string]any{"type": "spec_event", "action": "review_queued", "node": nodeAddr, "text": fmt.Sprintf("Spec review queued: %s", reviewID)})
+	d.logParent(map[string]any{"type": "spec_event", "action": "review_queued", "node": nodeAddr, "text": fmt.Sprintf("Spec review queued: %s", reviewID)})
 	return true
 }
 
@@ -188,12 +188,12 @@ func (d *Daemon) handleSpecReviewBlocked(nodeAddr, taskID string) bool {
 		return false
 	}
 
-	_ = d.Logger.Log(map[string]any{
+	d.logParent(map[string]any{
 		"type":      "spec_review_feedback",
 		"node":      nodeAddr,
 		"review_id": taskID,
 		"spec_task": specTaskID,
 	})
-	d.log(map[string]any{"type": "spec_event", "action": "review_failed", "node": nodeAddr, "text": fmt.Sprintf("Spec review failed, revision queued for %s", specTaskID)})
+	d.logParent(map[string]any{"type": "spec_event", "action": "review_failed", "node": nodeAddr, "text": fmt.Sprintf("Spec review failed, revision queued for %s", specTaskID)})
 	return true
 }

--- a/internal/logging/dropped_records_test.go
+++ b/internal/logging/dropped_records_test.go
@@ -1,0 +1,99 @@
+package logging
+
+import (
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+)
+
+// resetDroppedRecords is a helper that zeros the package counter so
+// tests can make precise claims about a specific scenario rather than
+// fighting with noise from earlier-running tests.
+func resetDroppedRecords() {
+	droppedRecords.Store(0)
+}
+
+func TestDroppedRecords_ZeroOnHappyPath(t *testing.T) {
+	// Not t.Parallel(): we mutate and read a package-level atomic.
+	resetDroppedRecords()
+
+	dir := t.TempDir()
+	lg, err := NewLogger(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lg.StartIterationWithPrefix("happy"); err != nil {
+		t.Fatal(err)
+	}
+	if err := lg.Log(map[string]any{"type": "hello"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	lg.Close()
+
+	if got := DroppedRecords(); got != 0 {
+		t.Errorf("happy path should drop nothing, got %d", got)
+	}
+}
+
+func TestDroppedRecords_NilReceiverIsCountedNotFatal(t *testing.T) {
+	resetDroppedRecords()
+	// Suppress the stderr canary line so verbose test runs stay quiet.
+	devnull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = devnull.Close() }()
+	oldStderr := os.Stderr
+	os.Stderr = devnull
+	defer func() { os.Stderr = oldStderr }()
+
+	var lg *Logger
+	if err := lg.Log(map[string]any{"type": "nil-receiver"}); err == nil {
+		t.Error("expected an error from a nil-receiver log call")
+	}
+	if got := DroppedRecords(); got != 1 {
+		t.Errorf("expected 1 drop from nil receiver, got %d", got)
+	}
+}
+
+func TestDroppedRecords_NoActiveIterationIsCounted(t *testing.T) {
+	resetDroppedRecords()
+	devnull, _ := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	defer func() { _ = devnull.Close() }()
+	oldStderr := os.Stderr
+	os.Stderr = devnull
+	defer func() { os.Stderr = oldStderr }()
+
+	dir := t.TempDir()
+	lg, err := NewLogger(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Never call StartIteration. Log should drop and count.
+	_ = lg.Log(map[string]any{"type": "no-file"})
+	if got := DroppedRecords(); got != 1 {
+		t.Errorf("expected 1 drop without StartIteration, got %d", got)
+	}
+
+	// Start an iteration, write one record, close, write again: the
+	// post-close write should be dropped and counted.
+	_ = lg.StartIterationWithPrefix("late")
+	if err := lg.Log(map[string]any{"type": "ok"}); err != nil {
+		t.Fatal(err)
+	}
+	lg.Close()
+	_ = lg.Log(map[string]any{"type": "after-close"})
+
+	if got := DroppedRecords(); got != 2 {
+		t.Errorf("expected 2 drops total, got %d", got)
+	}
+
+	// Sanity: the happy record did write a file.
+	entries, _ := os.ReadDir(dir)
+	if len(entries) == 0 {
+		t.Error("expected the one successful log to produce a file")
+	}
+	_ = filepath.Join // keep path/filepath import alive without a matcher
+	_ = atomic.Uint64{}
+}

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -155,16 +155,26 @@ func (l *Logger) LogIterationStart(stageType, nodeAddr string) error {
 // Log writes a structured record to the current iteration's log file.
 // The level parameter is optional: if omitted, the record is logged at
 // LevelInfo (backward compatible per ADR-046).
+//
+// A nil receiver is treated as "no active iteration" so tests that
+// build a Daemon directly without calling New — and any future caller
+// that holds a nil *Logger reference — are safe from panics. The
+// silent-drop canary still counts these and writes to stderr so the
+// nil path isn't invisible.
 func (l *Logger) Log(record map[string]any, levels ...Level) error {
-	if l.file == nil {
+	if l == nil || l.file == nil {
 		// Silent-drop canary. Parallel mode introduced a class of
 		// bugs where worker content was logged to a Logger whose
 		// file had never been opened, and every call site's `_ =`
 		// swallowed the "no active iteration" error. The next time
 		// that regression ships, this line makes it visible in the
 		// daemon.log tail instead of hiding behind empty log files.
+		trace := ""
+		if l != nil {
+			trace = l.TraceID
+		}
 		fmt.Fprintf(os.Stderr, "wolfcastle: log record dropped (no active iteration): type=%v trace=%q\n",
-			record["type"], l.TraceID)
+			record["type"], trace)
 		droppedRecords.Add(1)
 		return fmt.Errorf("no active iteration")
 	}


### PR DESCRIPTION
## Summary

Closes the class of silent-drop bugs that the v0.6.6 parallel-worker plumbing started but didn't finish. v0.6.6 fixed \`runIteration\` itself by threading a \`*logging.Logger\` parameter through it; v0.6.8 introduces a dedicated **ParentLogger** that stays open for the daemon's entire lifetime and catches everything that happens *around* iterations — drain diagnostics, auto-archive, spec review, knowledge maintenance, shutdown signals, error paths in the main loop.

The silent-drop canary (v0.6.6) made this PR possible: run the daemon live, grep \`daemon.log\` for \"log record dropped\", and each match names a specific \`type\` / \`trace\` of a call site that's routing to the wrong logger. Over a handful of bounce cycles I tracked down and closed every remaining site. Final verification: three consecutive clean stop-start cycles with zero new drops.

## Architecture

- **\`d.ParentLogger *logging.Logger\`** — a third logger alongside \`d.Logger\` (iteration-scoped) and \`d.InboxLogger\` (intake stage). Opens at \`Run()\` with \`StartIterationWithPrefix(\"daemon\")\`, closed via \`defer\` on exit. Iteration counter offset by 20000 so the filename \`2NNNN-daemon-TIMESTAMP.jsonl\` can't collide with exec (\`0-9999\`) or inbox (\`10000-19999\`).
- **\`d.logParent(record)\`** — nil-safe wrapper mirroring the existing \`d.log\` and \`d.logInbox\` pattern, so tests that build \`Daemon\` directly without calling \`New()\` don't panic on a nil logger.
- **Nil-safe \`Logger.Log\` receiver** — \`if l == nil || l.file == nil { canary; return err }\`. Free functions holding a nil \`*logging.Logger\` (e.g. \`commitAfterIteration\` called from parallel drain) no longer segfault.

## Sites rerouted

- **\`parallel.go\`** — \`read_node_error\`, \`scope_yield_tracking\`, \`scope_conflict_reset_error\`, \`failure_increment_error\`, \`reclaim_orphan\`, \`fill_slots_error\`, \`claim_error\`; the three \`commitAfterIteration\` calls (success, failure, scope-conflict partial commit); the \`propagateState\` fallback diagnostic.
- **\`archive.go\`** — \`auto_archive_failed\`, \`archived\`.
- **\`spec_review.go\`** — \`review_queued\`, \`review_failed\`.
- **\`knowledge_maintenance.go\`** — \`budget_exceeded\`.
- **\`daemon.go\`** — the shutdown-signal goroutine's \`standing_down signal\` event, the 2-second force-exit grace message, the instance-registry warning, and the three \`task_event\` sites in \`runOnceSerial\` / \`runOnceParallel\` that fire after their iteration or planning file has closed.
- **\`iteration.go\`** — six \`d.log(task_event ...)\` calls inside \`handleBlockedMarker\` / \`handleCompleteMarker\` / \`handleFailure\` that the v0.6.6 sweep missed (it only caught \`d.Logger.Log\`, not the nil-safe \`d.log\` wrapper). Now route through the \`lg\` parameter.

## Quality of life

- **Worker trace IDs shortened**: the previous format stamped \`worker-<node>-task-0001-0001\` — the trailing \`0001\` was the Child logger's iteration counter, which is always \`0001\` because each worker runs exactly one iteration. Dropped the redundant suffix; trace reads \`worker-cart-and-promo-domain-task-0001\` now.
- **Silent-drop canary test coverage**: new \`internal/logging/dropped_records_test.go\` pins the counter behavior — zero on the happy path, one on a nil receiver (no panic), one on no-active-iteration, two after close-then-log.

## Test plan

- [x] \`go test ./...\` green
- [x] \`go test -tags integration ./test/integration/\` green (98s)
- [x] Live test on \`/tmp/wc-tui-test\` with \`daemon.parallel.enabled=true, max_workers=3\`. Three consecutive bounces with zero new canary lines in \`daemon.log\`. Parent logger file \`20NNN-daemon-*.jsonl\` held open by the daemon process across the entire run.
- [x] \`grep -c \"log record dropped\" daemon.log\` stable across bounces.